### PR TITLE
Official Portainer Add-On Deprecated

### DIFF
--- a/portainer/config.json
+++ b/portainer/config.json
@@ -42,7 +42,7 @@
   "slug": "portainer",
   "startup": "services",
   "upstream": "2.9.2",
-  "url": "https://github.com/hassio-addons/addon-portainer",
+  "url": "https://github.com/alexbelgium/hassio-addons",
   "version": "2.9.2",
   "webui": "[PROTO:ssl]://[HOST]:[PORT:9099]"
 }


### PR DESCRIPTION
The official Portainer Add-On has been deprecated by Franck, the URL should in general be changed to this add-on page instead for ease of access.