### PR TITLE
change to ghcr

### DIFF
--- a/whoogle/build.json
+++ b/whoogle/build.json
@@ -1,7 +1,7 @@
 {
   "build_from": {
-    "armv7": "benbusby/whoogle-search:latest",
-    "aarch64": "benbusby/whoogle-search:latest",
-    "amd64": "benbusby/whoogle-search:latest"
+    "armv7": "ghcr.io/benbusby/whoogle-search:latest",
+    "aarch64": "ghcr.io/benbusby/whoogle-search:latest",
+    "amd64": "ghcr.io/benbusby/whoogle-search:latest"
   }
 }


### PR DESCRIPTION
We all love docker hub but the rate limiting is stupid af. So I think we should be switching to ghcr to make this future proof.

I did not bump the config file since it is not needed atm. Will wait for a new release from whoogle themself.