### PR TITLE
added imap import, improved OCR configuration

### DIFF
--- a/papermerge/config.json
+++ b/papermerge/config.json
@@ -30,12 +30,15 @@
     "storage_dir": "str",
     "import_dir": "str",
     "smbv1": "bool?",
+    "imaphost": "str?",
+    "imapusername": "str?",
+    "imappassword": "str?",
     "CONFIG_LOCATION": "str",
     "TZ": "str?"
   },
   "slug": "papermerge",
   "upstream": "2.0.1",
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "2.0.1-18",
+  "version": "2.0.1-19",
   "webui": "http://[HOST]:[PORT:8000]"
 }

--- a/papermerge/rootfs/etc/cont-init.d/91-OCR.sh
+++ b/papermerge/rootfs/etc/cont-init.d/91-OCR.sh
@@ -3,19 +3,45 @@
 
 # Allow OCR setting
 OCRLANG="$(bashio::config "ocrlang")"
+languageCount=$(echo "$OCRLANG" | tr -cd ',' | wc -c)
+languageCount=$((languageCount+1))
+bashio::log.info "Configuring ${languageCount} languages"
 
 if [ -n "$OCRLANG" ]; then
-  LINE=$(sed -n '/OCR_LANGUAGES/=' /data/config/papermerge.conf.py)
-  bashio::log.info "OCRLANG variable is set, processing the language packages"
-  apt-get update >/dev/null
-  for i in $(echo "$OCRLANG" | tr "," " "); do
-    if apt-cache show tesseract-ocr-"${i}" >/dev/null 2>&1; then
-      echo "installing tesseract-ocr-${i}" >/dev/null
-      apt-get install -yqq tesseract-ocr-"${i}" >/dev/null
-    else
-      echo "package tesseract-ocr-${i} not found in the repository, skipping"
-    fi
-    sed -i "$LINE a   \"${i}\": \"${i}\"," /data/config/papermerge.conf.py
-    bashio::log.info "... ${i} installed"
-  done
+    lineStart=$(sed -n '/OCR_LANGUAGES/=' /data/config/papermerge.conf.py)
+    bashio::log.info "OCRLANG variable is set, processing the language packages"
+    lineEnd=$(sed -n '/}/=' /data/config/papermerge.conf.py)
+    sed -i "${lineStart},${lineEnd}d" /data/config/papermerge.conf.py
+
+    bashio::log.info "Writing new configuration"
+    echo "OCRLANG = {" >> /data/config/papermerge.conf.py
+
+    languages=$(echo "$OCRLANG" | tr "," "\n")
+
+    apt-get update >/dev/null
+
+    i=0
+    for language in $languages; do
+        bashio::log.info "Processing language ${language}"
+        if apt-cache show tesseract-ocr-"${language}" >/dev/null 2>&1; then
+            bashio::log.info "Installing tesseract-ocr-${language}"
+            apt-get install -yqq tesseract-ocr-"${language}" >/dev/null
+            languageFullName=$(apt-cache show tesseract-ocr-"${language}" | grep -E '^(Description|Description-en):' | grep -oE '[^ ]+$')
+            bashio::log.info "${language} identified as ${languageFullName}"
+            i=$((i+1))
+            if [[ $i -eq $languageCount ]]; then
+                echo "  \"$language\" : \"$languageFullName\"" >> /data/config/papermerge.conf.py
+            elif [[ $i -eq 1 ]]; then
+                echo "  \"$language\" : \"$languageFullName\"," >> /data/config/papermerge.conf.py
+                bashio::log.info "Setting default language to ${language}"
+                sed -i "s/^OCR_DEFAULT_LANGUAGE = \"eng\"/OCR_DEFAULT_LANGUAGE = \"${language}\"/g" /data/config/papermerge.conf.py
+            else
+                echo "  \"$language\" : \"$languageFullName\"," >> /data/config/papermerge.conf.py
+            fi
+            bashio::log.info "... ${language} installed"
+        else
+            bashio::log.info "Package tesseract-ocr-${language} not found in the repository, skipping"
+        fi
+    done
+    echo "}" >> /data/config/papermerge.conf.py
 fi

--- a/papermerge/rootfs/etc/cont-init.d/99-configuration.sh
+++ b/papermerge/rootfs/etc/cont-init.d/99-configuration.sh
@@ -42,3 +42,33 @@ if [ ! -d "$IMPORTDIR" ]; then
   mkdir -p "$IMPORTDIR"
 fi
 chown -R abc:abc "$IMPORTDIR"
+
+##################
+# CONFIGURE IMAP #
+##################
+
+IMAPHOST=$(bashio::config 'imaphost')
+IMAPUSERNAME=$(bashio::config 'imapusername')
+IMAPPASSWORD=$(bashio::config 'imappassword')
+
+if [ $IMAPHOST != "null" ]; then
+    printf "\nIMPORT_MAIL_HOST = \"${IMAPHOST}\"" >> /data/config/papermerge.conf.py
+    bashio::log.info "IMPORT_MAIL_HOST set to $IMAPHOST"
+
+    if [ $IMAPUSERNAME != "null" ]; then
+        printf "\nIMPORT_MAIL_USER = \"${IMAPUSERNAME}\"" >> /data/config/papermerge.conf.py
+        bashio::log.info "IMPORT_MAIL_USER set to $IMAPUSERNAME"
+        printf "\n" >> /data/config/papermerge.conf.py
+    else
+        bashio::log.info "! IMAPHOST has been set, but no IMAPUSERNAME. Please check your configuration!"
+    fi
+
+    if [ $IMAPPASSWORD != "null" ]; then
+        printf '%s\n' "IMPORT_MAIL_PASS = \"${IMAPPASSWORD}\"" >> /data/config/papermerge.conf.py
+        IMAPPASSWORDMASKED=$(echo "$IMAPPASSWORD" | sed -r 's/./x/g')
+        bashio::log.info "IMPORT_MAIL_PASS set to $IMAPPASSWORDMASKED"
+    else
+        bashio::log.info "! IMAPHOST has been set, but no IMAPPASSWORD. Please check your configuration!"
+    fi
+
+fi


### PR DESCRIPTION
Papermerge can now be configured to use IMAP for document import.

OCR configuration has been rewritten, first language will be set as Papermerge's default OCR languge