### PR TITLE
Change the type of forced-update

### DIFF
--- a/inadyn/README.md
+++ b/inadyn/README.md
@@ -50,7 +50,7 @@ The available configuration options are as follows (this is filled in with some 
   "iface": "eth0",
   "iterations": 0,
   "period": 300,
-  "forced_update": false,
+  "forced_update": 300,
   "secure_ssl": true,
   "providers": [
     {

--- a/inadyn/config.json
+++ b/inadyn/config.json
@@ -22,7 +22,7 @@
     "iface": "str?",
     "iterations": "int?",
     "period": "int?",
-    "forced_update": "bool?",
+    "forced_update": "int?",
     "secure_ssl": "bool?",
     "providers": [
       {


### PR DESCRIPTION
From the documentation, forced-update should be an integer representing the time in seconds where Inadyn should update:

https://manpages.ubuntu.com/manpages/bionic/man8/inadyn.8.html

#241 