### PR TITLE
Add Ingress autologin to Calibre-web

### DIFF
--- a/calibre_web/CHANGELOG.md
+++ b/calibre_web/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Feat : ingress autologin (thanks @met67)
 
 ## 0.6.18-ls164 (09-06-2022)
 - Update to latest version from linuxserver/docker-calibre-web

--- a/calibre_web/Dockerfile
+++ b/calibre_web/Dockerfile
@@ -62,6 +62,10 @@ RUN if ! command -v bash >/dev/null 2>/dev/null; then (apt-get update && apt-get
     && eval /./automatic_packages.sh "${PACKAGES:-}" \
     && rm /automatic_packages.sh || printf '%s\n' "${PACKAGES:-}" > /ENVFILE
 
+# Install sqlite3 & set defaults
+RUN if ! command -v sqlite3 >/dev/null 2>/dev/null; then (apt-get update && apt-get install -yqq --no-install-recommends sqlite3 || apk add --no-cache sqlite3) >/dev/null; fi \
+    && sqlite3 /defaults/app.db 'update settings set config_reverse_proxy_login_header_name="X-WebAuth-User",config_allow_reverse_proxy_header_login=1'
+
 ################
 # 4 Entrypoint #
 ################

--- a/calibre_web/config.json
+++ b/calibre_web/config.json
@@ -62,10 +62,10 @@
   },
   "panel_icon": "mdi:library",
   "ports": {
-    "8083/tcp": 8083
+    "8083/tcp": null
   },
   "ports_description": {
-    "8083/tcp": "calibre-web webui"
+    "8083/tcp": "Calibre-web webui (Not required for Ingress)"
   },
   "privileged": [
     "SYS_ADMIN",
@@ -81,10 +81,11 @@
     "cifspassword": "str?",
     "cifsusername": "str?",
     "localdisks": "str?",
-    "networkdisks": "str?"
+    "networkdisks": "str?",
+    "ingress_user": "str?"
   },
   "slug": "calibre-web",
   "url": "https://github.com/alexbelgium/hassio-addons/tree/master/calibre-web",
-  "version": "0.6.18-ls164",
+  "version": "0.6.18-ls164-test5",
   "video": true
 }

--- a/calibre_web/rootfs/etc/cont-init.d/32-nginx.sh
+++ b/calibre_web/rootfs/etc/cont-init.d/32-nginx.sh
@@ -4,45 +4,52 @@
 #################
 # NGINX SETTING #
 #################
-declare port
-declare certfile
+#declare port
+#declare certfile
+declare ingress_user
 declare ingress_interface
 declare ingress_port
-declare keyfile
+#declare keyfile
 
-port=$(bashio::addon.port 80)
-if bashio::var.has_value "${port}"; then
-    bashio::config.require.ssl
+#port=$(bashio::addon.port 80)
+#if bashio::var.has_value "${port}"; then
+#    bashio::config.require.ssl
+#
+#    if bashio::config.true 'ssl'; then
+#        certfile=$(bashio::config 'certfile')
+#        keyfile=$(bashio::config 'keyfile')
+#
+#        mv /etc/nginx/servers/direct-ssl.disabled /etc/nginx/servers/direct.conf
+#        sed -i "s/%%certfile%%/${certfile}/g" /etc/nginx/servers/direct.conf
+#        sed -i "s/%%keyfile%%/${keyfile}/g" /etc/nginx/servers/direct.conf
+#
+#    else
+#        mv /etc/nginx/servers/direct.disabled /etc/nginx/servers/direct.conf
+#    fi
+#fi
 
-    if bashio::config.true 'ssl'; then
-        certfile=$(bashio::config 'certfile')
-        keyfile=$(bashio::config 'keyfile')
+## Force scheme
+#if bashio::config.true 'force_scheme_https'; then
+#    # shellcheck disable=SC2016
+#    sed -i 's|$scheme|https|g' /etc/nginx/servers/ingress.conf
+#fi
 
-        mv /etc/nginx/servers/direct-ssl.disabled /etc/nginx/servers/direct.conf
-        sed -i "s/%%certfile%%/${certfile}/g" /etc/nginx/servers/direct.conf
-        sed -i "s/%%keyfile%%/${keyfile}/g" /etc/nginx/servers/direct.conf
+## Force external port
+#if bashio::config.has_value 'force_external_port'; then
+#    sed -i "s|%%haport%%|$(bashio::config 'force_external_port')|g" /etc/nginx/servers/ingress.conf
+#fi
 
-    else
-        mv /etc/nginx/servers/direct.disabled /etc/nginx/servers/direct.conf
-    fi
-fi
-
-# Force scheme
-if bashio::config.true 'force_scheme_https'; then
-    # shellcheck disable=SC2016
-    sed -i 's|$scheme|https|g' /etc/nginx/servers/ingress.conf
-fi
-
-# Force external port
-if bashio::config.has_value 'force_external_port'; then
-    sed -i "s|%%haport%%|$(bashio::config 'force_external_port')|g" /etc/nginx/servers/ingress.conf
+ingress_user='admin'
+if bashio::config.has_value 'ingress_user'; then
+    ingress_user=$(bashio::config 'ingress_user')
 fi
 
 ingress_port=$(bashio::addon.ingress_port)
 ingress_interface=$(bashio::addon.ip_address)
-ha_port=$(bashio::core.port)
+#ha_port=$(bashio::core.port)
 
+sed -i "s/%%ingress_user%%/${ingress_user}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
-sed -i "s/%%haport%%/${ha_port}/g" /etc/nginx/servers/ingress.conf
+#sed -i "s/%%haport%%/${ha_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%UIPATH%%|$(bashio::addon.ingress_entry)|g" /etc/nginx/servers/ingress.conf

--- a/calibre_web/rootfs/etc/cont-init.d/80-configuration.sh
+++ b/calibre_web/rootfs/etc/cont-init.d/80-configuration.sh
@@ -9,9 +9,7 @@ if bashio::config.has_value 'TZ'; then
     ln -snf /usr/share/zoneinfo/"$TIMEZONE" /etc/localtime && echo "$TIMEZONE" >/etc/timezone
 fi
 
-# Disable session protection 
-# https://forums.unraid.net/topic/71927-support-linuxserverio-calibre-web/page/5/#comment-1015352
-#echo "**** patching calibre-web - removing session protection ****"
-#sed -i "/lm.session_protection = 'strong'/d" /app/calibre-web/cps/__init__.py || true
+# Set Ingress login
+sqlite3 /config/addons_config/calibre-web/app.db 'update settings set config_reverse_proxy_login_header_name="X-WebAuth-User",config_allow_reverse_proxy_header_login=1'
 
 bashio::log.info "Default username:password is admin:admin123"

--- a/calibre_web/rootfs/etc/nginx/includes/upstream.conf
+++ b/calibre_web/rootfs/etc/nginx/includes/upstream.conf
@@ -1,3 +1,3 @@
 upstream backend {
-    server 127.0.0.1:8080;
+    server 127.0.0.1:8083;
 }

--- a/calibre_web/rootfs/etc/nginx/servers/ingress.conf
+++ b/calibre_web/rootfs/etc/nginx/servers/ingress.conf
@@ -5,7 +5,10 @@ server {
     client_max_body_size 0;
 
     location / {
-        
+       allow   172.30.32.2;
+       deny    all;
+       proxy_set_header X-WebAuth-User %%ingress_user%%;
+
        # Base from https://github.com/janeczku/calibre-web/wiki/Setup-Reverse-Proxy#nginx
        proxy_bind              $server_addr;
        proxy_pass              http://127.0.0.1:8083;
@@ -14,7 +17,7 @@ server {
        proxy_set_header        Host                    $http_host;
        proxy_set_header        X-Forwarded-For         $proxy_add_x_forwarded_for;
        proxy_set_header        X-Script-Name           %%UIPATH%%;  # IMPORTANT: path has NO trailing slash
-  
+
        # Optimisation
        proxy_buffering         off;
        proxy_read_timeout      30;


### PR DESCRIPTION
As discussed in the previous days, this PR adds Ingress autologin through the `Reverse Proxy Header Name` feature of Calibre-Web.
Since now Ingress is fully functional, direct exposure of Calibre-web on port 8083 is disabled.
The user used to autologin defaults to `admin` but can be customized.
Also cleaned up some remains from previous tests...