### PR TITLE
Handle upstream formatting change: spaces not tab

### DIFF
--- a/qbittorrent/Dockerfile
+++ b/qbittorrent/Dockerfile
@@ -46,7 +46,7 @@ RUN \
     \
     # Correct permissions
     && sed -i 's=/config=/config/qBittorrent || true=g' /etc/cont-init.d/10-adduser \
-    && sed -i 's=	/config=/config/qBittorrent || true=g' /etc/cont-init.d/30-config \
+    && sed -i 's=    /config=    /config/qBittorrent || true=g' /etc/cont-init.d/30-config \
     \
     # Set download folder to /share
     && sed -i 's|/downloads/|/share/qBittorrent/|g' /defaults/qBittorrent.conf \


### PR DESCRIPTION
Upstream lsio commit 7c0eb4e6761f5a48d8ce88facd24e2ed4c16f246 in
github.com/linuxserver/docker-qbittorrent changed the formatting of the
line being patched here and broke the sed replacement. Update the sed
command to match as expected.

The result of this failing sed command was actually a hang on my machine since the command in question would remain `chown ... -R /config` instead of `chown ... -R /config/qBittorrent`.