### PR TITLE
Deckoz2302 omada host network

### DIFF
--- a/omada/CHANGELOG.md
+++ b/omada/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.5.1-chromium-amd64-2022-08-26 (2022-08-26)
+## 5.5.1-chromium-amd64-2022-08-26 (2022-08-29)
 - run add_on on host network so controller can outgres to physical 
   network properly
 

--- a/omada/CHANGELOG.md
+++ b/omada/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.5.1-chromium-amd64-2022-08-26 (2022-08-26)
+- run add_on on host network so controller can outgres to physical 
+  network properly
 
 ## 5.5-chromium-amd64-2022-08-26 (2022-08-26)
 - Update to latest version from mbentley/omada-controller

--- a/omada/config.json
+++ b/omada/config.json
@@ -45,6 +45,6 @@
   "host_network": true,
   "slug": "omada",
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "5.5-chromium-amd64-2022-08-26",
+  "version": "5.5-chromium-amd64-2022-08-26-2",
   "webui": "[PROTO:ssl]://[HOST]:[PORT:8088]"
 }

--- a/omada/config.json
+++ b/omada/config.json
@@ -42,6 +42,7 @@
     "8088/tcp": "web interface http",
     "8843/tcp": "portal https"
   },
+  "host_network": true,
   "slug": "omada",
   "url": "https://github.com/alexbelgium/hassio-addons",
   "version": "5.5-chromium-amd64-2022-08-26",

--- a/omada/updater.json
+++ b/omada/updater.json
@@ -1,6 +1,6 @@
 {
   "by_date": true,
-  "last_update": "2022-08-26",
+  "last_update": "2022-08-29",
   "repository": "alexbelgium/hassio-addons",
   "slug": "omada",
   "source": "dockerhub",


### PR DESCRIPTION
Run add_on on host network so outgres is possible. Omada controller does not function with only ingres ports. Omada controller needs to run on the same physical network as devices where the gateway provides cidr spanning.  Ie if run with host_network 'false' outgres is only able to see docker network.

With host_network 'true' outgres relies on the gateway for cidr spanning to discover devices. Ie a subnet with 192.168.1.0/24 the gateway 192.168.1.1 would provide address 192.168.1.1-192.168.1.254. or 192.168.0.0/22 would have the gateway of 192.168.0.1 and provide outgres to 192.168.0.0-192.168.3.254