### PR TITLE
Corrected version parameter case

### DIFF
--- a/plex/config.json
+++ b/plex/config.json
@@ -115,7 +115,7 @@
   },
   "slug": "plex_nas",
   "url": "https://github.com/alexbelgium/hassio-addons/tree/master/plex",
-  "version": "1.28.2.6106-44a5bbd28-ls129",
+  "version": "1.28.2.6106-44a5bbd28-ls129-2",
   "video": true,
   "webui": "http://[HOST]:[PORT:32400]/web"
 }

--- a/plex/config.json
+++ b/plex/config.json
@@ -53,7 +53,7 @@
   "environment": {
     "PGID": "0",
     "PUID": "0",
-    "version": "docker"
+    "VERSION": "docker"
   },
   "host_network": true,
   "init": false,


### PR DESCRIPTION
lower case version has no effect and produces a warning on startup. upper case produces the correct behavior of skipping the update check and leaving it to docker.