### PR TITLE
fix(inadyn): go modules management

### DIFF
--- a/inadyn/Dockerfile
+++ b/inadyn/Dockerfile
@@ -82,6 +82,7 @@ RUN apk add --no-cache \
     build-base\
     git\
     go &&\
+    go env -w GO111MODULE=off &&\
     go get -u github.com/quantumew/mustache-cli &&\
     cp "$GOPATH"/bin/* /usr/bin/ && \
     rm -rf "$GOPATH" /var/cache/apk/* /tmp/src &&\

--- a/inadyn/config.json
+++ b/inadyn/config.json
@@ -54,5 +54,5 @@
   },
   "slug": "inadyn",
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "2.9.1-6"
+  "version": "2.9.1-7"
 }


### PR DESCRIPTION
Related to https://github.com/alexbelgium/hassio-addons/issues/491

`mustache-cli` isn't installed due to Go 11 modules management.
