### PR TITLE
Remove comment in example to enable the folder configuration itself.

### DIFF
--- a/unpackerr/README.md
+++ b/unpackerr/README.md
@@ -51,7 +51,7 @@ In /config/unpackerr.conf you can set all variables according to this list of en
 
 Folders must be custimozed in the conf file with the lines :
 ```
-#[[folder]]
+[[folder]]
 ## Windows paths must use two backslashes: "C:\\Some\\Folder\\To\\Watch"
 path = "/share/downloads_packed"
 ## Path to extract files to. The default (leaving this blank) is the same as `path` (above).


### PR DESCRIPTION
Remove comment in example to enable the folder configuration itself.

Related: #502 