### PR TITLE
[fireflyiii] Move upload folder to a persistent storage

### DIFF
--- a/fireflyiii/CHANGELOG.md
+++ b/fireflyiii/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 5.7.14-2 (29-10-2022)
+- Fix bug #530
 
 ## 5.7.14 (20-10-2022)
 - Update to latest version from firefly-iii/firefly-iii

--- a/fireflyiii/Dockerfile
+++ b/fireflyiii/Dockerfile
@@ -40,6 +40,9 @@ RUN \
     #################
     if [ "$BUILD_UPSTREAM" = "5.7.14" ] ; then \
     sed -i "s|, \$transaction\[\x27amount\x27\] ?? \x270\x27);|, (string)(\$transaction\[\x27amount\x27\] ?? \x270\x27));|g" /var/www/html/app/Helpers/Collector/GroupCollector.php; else echo "not 5.7.5"; fi
+RUN \
+    # Change upload folder to "ha_upload" since the default one is binded to a volume (see base image)
+    sed -i "s/'root'   => storage_path('upload'),/'root'   => storage_path('ha_upload'),/g" /var/www/html/config/filesystems.php
 
 ##################
 # 3 Install apps #

--- a/fireflyiii/config.json
+++ b/fireflyiii/config.json
@@ -46,6 +46,6 @@
   "slug": "fireflyiii",
   "startup": "services",
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "5.7.14",
+  "version": "5.7.14-2",
   "webui": "[PROTO:ssl]://[HOST]:[PORT:8080]"
 }

--- a/fireflyiii/rootfs/etc/cont-init.d/99-run.sh
+++ b/fireflyiii/rootfs/etc/cont-init.d/99-run.sh
@@ -121,6 +121,24 @@ case $(bashio::config 'DB_CONNECTION') in
 
 esac
 
+########################
+# Define upload folder #
+########################
+
+bashio::log.info "Defining upload folder"
+
+# Creating folder
+if [ ! -d /config/addons_config/fireflyiii/upload ]; then
+    mkdir -p /config/addons_config/fireflyiii/upload
+    chown -R www-data:www-data /config/addons_config/fireflyiii/upload
+fi
+
+# Creating symlink
+if [ -d /var/www/html/storage/ha_upload ]; then
+    rm -r /var/www/html/storage/ha_upload
+fi
+ln -s /config/addons_config/fireflyiii/upload /var/www/html/storage/ha_upload
+
 ################
 # CRON OPTIONS #
 ################


### PR DESCRIPTION
This is suppose to fix #530.
The idea is to move the upload folder to a persistent storage by using the same approch used for the sqlite database.
The main issue is that the default upload folder `/var/www/html/storage/upload` is binded to a volume ([see layer 34 of base docker image fireflyiii/core:latest](https://hub.docker.com/layers/fireflyiii/core/latest/images/sha256-b00209abbc10bcf8277a49a169216dc4eb354d86e4ec41e0abc967d78738f91b?context=explore)) and cannot be removed and replaced with a symbolic link. 
For such reason the default upload folder has been changed to `/var/www/html/storage/ha_upload` by using the `sed` command since there is no easy way (e.g. env variable) to do it.