### PR TITLE
Add scrutiny host ID details

### DIFF
--- a/scrutiny/config.json
+++ b/scrutiny/config.json
@@ -44,7 +44,8 @@
     "/dev/nvme2"
   ],
   "environment": {
-    "COLLECTOR_API_ENDPOINT": "http://localhost:8080"
+    "COLLECTOR_API_ENDPOINT": "http://localhost:8080",
+    "COLLECTOR_HOST_ID": "home_assistant"
   },
   "ingress": true,
   "init": false,
@@ -71,6 +72,7 @@
   ],
   "schema": {
     "COLLECTOR_API_ENDPOINT": "str?",
+    "COLLECTOR_HOST_ID": "str?",
     "expose_config": "bool?",
     "Mode": "list(Collector+WebUI|Collector)?",
     "TZ": "str?",

--- a/scrutiny_fa/config.json
+++ b/scrutiny_fa/config.json
@@ -7,7 +7,8 @@
   "codenotary": "alexandrep.github@gmail.com",
   "description": "Scrutiny WebUI for smartd S.M.A.R.T monitoring (Full Access)",
   "environment": {
-    "COLLECTOR_API_ENDPOINT": "http://localhost:8080"
+    "COLLECTOR_API_ENDPOINT": "http://localhost:8080",
+    "COLLECTOR_HOST_ID": "home_assistant"
   },
   "full_access": true,
   "image": "ghcr.io/alexbelgium/scrutiny-fa-{arch}",
@@ -36,6 +37,7 @@
   ],
   "schema": {
     "COLLECTOR_API_ENDPOINT": "str?",
+    "COLLECTOR_HOST_ID": "str?",
     "Mode": "list(Collector+WebUI|Collector)?",
     "TZ": "str?",
     "Updates": "list(Hourly|Daily|Weekly)",
@@ -45,5 +47,5 @@
   "slug": "scrutiny_fa",
   "udev": true,
   "url": "https://github.com/AnalogJ/scrutiny",
-  "version": "v0.5.0-5"
+  "version": "v0.5.0-6"
 }


### PR DESCRIPTION
Fixes #571 

When running Scrutiny in a hub/spoke model (multiple collectors feeding data back to a single "controller" that runs the UI), the hostname is not currently sent with the data.

This PR aims to fix that by creating [a new environment variable](https://github.com/AnalogJ/scrutiny/blob/master/docs/TROUBLESHOOTING_DEVICE_COLLECTOR.md#hub--spoke-model-with-multiple-hosts) that matches the value in the Scrutiny documentation, and sets it by default to home_assistant.

NOTE: This is currently **UNTESTED** as I cannot get a local dev environment working.