### PR TITLE
MAILER_SECURE changed to MAILER_SECURITY

### DIFF
--- a/joplin/config.json
+++ b/joplin/config.json
@@ -38,7 +38,7 @@
     "MAILER_NOREPLY_EMAIL": "str?",
     "MAILER_NOREPLY_NAME": "str?",
     "MAILER_PORT": "int?",
-    "MAILER_SECURE": "int?",
+    "MAILER_SECURITY": "str?",
     "POSTGRES_DATABASE": "str?",
     "POSTGRES_HOST": "str?",
     "POSTGRES_PASSWORD": "str?",


### PR DESCRIPTION
Version 2.7.4 had a breaking change, MAILER_SECURE was renamed to MAILER_SECURITY and contains a string now with possible values: none, tls, or starttls

https://joplinapp.org/changelog_server/#server-v2-7-4-https-github-com-laurent22-joplin-releases-tag-server-v2-7-4-2022-02-02t19-23-34z https://discourse.joplinapp.org/t/breaking-change-on-mailer-configuration-in-joplin-server-2-7/23464