### PR TITLE
Mailer security changed

### DIFF
--- a/joplin/CHANGELOG.md
+++ b/joplin/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Breaking change: MAILER_SECURE replaced by MAILER_SECURITY
 - WARNING : update to supervisor 2022.11 before installing
 - Add access to systime
 

--- a/joplin/README.md
+++ b/joplin/README.md
@@ -66,7 +66,7 @@ To use email service, set the follow variables in the config:
 1 = true, 0 = false
 MAILER_HOST=mail.example.com
 MAILER_PORT=995
-MAILER_SECURE=1
+MAILER_SECURITY=none, tls, starttls
 MAILER_AUTH_USER=info@example.com
 MAILER_AUTH_PASSWORD=your_password
 MAILER_NOREPLY_NAME=from_name

--- a/joplin/config.json
+++ b/joplin/config.json
@@ -48,6 +48,6 @@
   },
   "slug": "joplin",
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "2.9.7-3",
+  "version": "2.9.7-4",
   "webui": "[PROTO:ssl]://[HOST]:[PORT:22300]"
 }

--- a/joplin/config.json
+++ b/joplin/config.json
@@ -38,7 +38,7 @@
     "MAILER_NOREPLY_EMAIL": "str?",
     "MAILER_NOREPLY_NAME": "str?",
     "MAILER_PORT": "int?",
-    "MAILER_SECURITY": "str?",
+    "MAILER_SECURITY": "list(none|tls|starttls)?",
     "POSTGRES_DATABASE": "str?",
     "POSTGRES_HOST": "str?",
     "POSTGRES_PASSWORD": "str?",

--- a/joplin/config.json
+++ b/joplin/config.json
@@ -38,7 +38,7 @@
     "MAILER_NOREPLY_EMAIL": "str?",
     "MAILER_NOREPLY_NAME": "str?",
     "MAILER_PORT": "int?",
-    "MAILER_SECURE": "int?",
+    "MAILER_SECURITY": "str?",
     "POSTGRES_DATABASE": "str?",
     "POSTGRES_HOST": "str?",
     "POSTGRES_PASSWORD": "str?",

--- a/joplin/rootfs/etc/cont-init.d/99-run.sh
+++ b/joplin/rootfs/etc/cont-init.d/99-run.sh
@@ -53,7 +53,7 @@ fi
 # Configure app
 bashio::config.has_value 'MAILER_HOST' && export MAILER_HOST=$(bashio::config 'MAILER_HOST') && bashio::log.info 'Mailer Host set'
 bashio::config.has_value 'MAILER_PORT' && export MAILER_PORT=$(bashio::config 'MAILER_PORT') && bashio::log.info 'Mailer Port set'
-bashio::config.has_value 'MAILER_SECURE' && export MAILER_SECURE=$(bashio::config 'MAILER_SECURE') && bashio::log.info 'Mailer Secure set'
+bashio::config.has_value 'MAILER_SECURITY' && export MAILER_SECURITY=$(bashio::config 'MAILER_SECURITY') && bashio::log.info 'Mailer Security set'
 bashio::config.has_value 'MAILER_AUTH_USER' && export MAILER_AUTH_USER=$(bashio::config 'MAILER_AUTH_USER') && bashio::log.info 'Mailer User set'
 bashio::config.has_value 'MAILER_AUTH_PASSWORD' && export MAILER_AUTH_PASSWORD=$(bashio::config 'MAILER_AUTH_PASSWORD') && bashio::log.info 'Mailer Password set'
 bashio::config.has_value 'MAILER_NOREPLY_NAME' && export MAILER_NOREPLY_NAME=$(bashio::config 'MAILER_NOREPLY_NAME') && bashio::log.info 'Mailer Noreply Name set'


### PR DESCRIPTION
Hi Alex,

with version 2.7 the variable was changed from MAILER_SECURE to MAILER_SECURITY and now it accepts a string with either tls, starttls, or none.

I hope I found it everywhere :-)