### PR TITLE
Add an appropriate Icon for Ingress

### DIFF
--- a/radarr/config.json
+++ b/radarr/config.json
@@ -84,5 +84,5 @@
   },
   "slug": "radarr_nas",
   "url": "https://github.com/alexbelgium/hassio-addons/tree/master/radarr",
-  "version": "4.3.2.6857-19"
+  "version": "4.3.2.6857-20"
 }

--- a/radarr/config.json
+++ b/radarr/config.json
@@ -60,7 +60,7 @@
     "PGID": 0,
     "PUID": 0
   },
-  "panel_icon": "mdi:download-circle",
+  "panel_icon": "mdi:movie-outline",
   "ports": {
     "7878/tcp": 7878
   },

--- a/sonarr/config.json
+++ b/sonarr/config.json
@@ -84,5 +84,5 @@
   },
   "slug": "sonarr_nas",
   "url": "https://github.com/alexbelgium/hassio-addons/tree/master/sonarr",
-  "version": "3.0.9.1549-10"
+  "version": "3.0.9.1549-11"
 }

--- a/sonarr/config.json
+++ b/sonarr/config.json
@@ -60,7 +60,7 @@
     "PGID": 0,
     "PUID": 0
   },
-  "panel_icon": "mdi:download-circle-outline",
+  "panel_icon": "mdi:television-classic",
   "ports": {
     "8989/tcp": 8989
   },


### PR DESCRIPTION
Radarr and Sonarr both have the same Ingress icon, just a download circle.

Proposing a Movie Icon(Radarr), and a TV icon(Sonarr) for ingress, to easily determine the application on HA sidebar when collapsed

Current:
![image](https://user-images.githubusercontent.com/8958480/219719881-38e211a2-8459-49c5-b17c-33cef73bfb07.png)

Proposed:
![image](https://user-images.githubusercontent.com/8958480/219719930-19376cc5-84ee-4622-9d62-ebdf3d76382a.png)
 