### PR TITLE
[Calibre] Add wireless connection port to config.json

### DIFF
--- a/calibre/CHANGELOG.md
+++ b/calibre/CHANGELOG.md
@@ -1,3 +1,5 @@
+## v6.13.0-ls204 (21-02-2023)
+- Add wireless connection port
 
 ## v6.13.0-ls203 (19-02-2023)
 - Update to latest version from linuxserver/docker-calibre

--- a/calibre/README.md
+++ b/calibre/README.md
@@ -49,7 +49,7 @@ Webui can be found at <http://your-ip:PORT>.
 Configurations can be done through the app webUI, except for the following options.
 Please read the upstream container documentation for further info : https://github.com/linuxserver/docker-calibre/blob/35b5e3ae06ba95f666687150ca5fd632b8db9e87/README.md#application-setup
 
-In particular, the webserver needs to be manually enabled from the desktop app with port 8081 to be able to access it.
+In particular, the webserver and wireless connections needs to be manually enabled from the desktop app to be able to access it, with ports 8081 and 9090 respectively.
 
 ```yaml
 PGID: user

--- a/calibre/README.md
+++ b/calibre/README.md
@@ -49,7 +49,7 @@ Webui can be found at <http://your-ip:PORT>.
 Configurations can be done through the app webUI, except for the following options.
 Please read the upstream container documentation for further info : https://github.com/linuxserver/docker-calibre/blob/35b5e3ae06ba95f666687150ca5fd632b8db9e87/README.md#application-setup
 
-In particular, the webserver and wireless connections needs to be manually enabled from the desktop app to be able to access it, with ports 8081 and 9090 respectively.
+In particular, the webserver and wireless connection needs to be manually enabled from the desktop app to be able to access it, using ports 8081 and 9090 respectively.
 
 ```yaml
 PGID: user

--- a/calibre/config.json
+++ b/calibre/config.json
@@ -66,11 +66,13 @@
   "panel_icon": "mdi:book-multiple",
   "ports": {
     "8080/tcp": 8080,
-    "8081/tcp": 8081
+    "8081/tcp": 8081,
+    "9090/tcp": 9090
   },
   "ports_description": {
     "8080/tcp": "Calibre desktop gui",
-    "8081/tcp": "Calibre webserver gui, to be enabled within the desktop gui"
+    "8081/tcp": "Calibre webserver gui, to be enabled within the desktop gui",
+    "9090/tcp": "Calibre wireless connection port, to be enabled within the desktop gui"
   },
   "privileged": [
     "SYS_ADMIN",
@@ -89,7 +91,7 @@
     "networkdisks": "str?"
   },
   "slug": "calibre",
-  "url": "https://github.com/alexbelgium/hassio-addons/tree/master/calibre",
+  "url": "https://github.com/danbruno/hassio-addons/tree/calibre-wireless-port/calibre",
   "version": "v6.13.0-ls203",
   "video": true
 }

--- a/calibre/config.json
+++ b/calibre/config.json
@@ -91,7 +91,7 @@
     "networkdisks": "str?"
   },
   "slug": "calibre",
-  "url": "https://github.com/danbruno/hassio-addons/tree/calibre-wireless-port/calibre",
+  "url": "https://github.com/alexbelgium/hassio-addons/tree/master/calibre",
   "version": "v6.13.0-ls203",
   "video": true
 }

--- a/calibre/config.json
+++ b/calibre/config.json
@@ -72,7 +72,7 @@
   "ports_description": {
     "8080/tcp": "Calibre desktop gui",
     "8081/tcp": "Calibre webserver gui, to be enabled within the desktop gui",
-    "9090/tcp": "Calibre wireless connection port, to be enabled within the desktop gui"
+    "9090/tcp": "Calibre wireless connection, to be enabled within the desktop gui"
   },
   "privileged": [
     "SYS_ADMIN",

--- a/calibre/config.json
+++ b/calibre/config.json
@@ -92,6 +92,6 @@
   },
   "slug": "calibre",
   "url": "https://github.com/alexbelgium/hassio-addons/tree/master/calibre",
-  "version": "v6.13.0-ls203",
+  "version": "v6.13.0-ls204",
   "video": true
 }

--- a/calibre/config.json
+++ b/calibre/config.json
@@ -92,6 +92,6 @@
   },
   "slug": "calibre",
   "url": "https://github.com/alexbelgium/hassio-addons/tree/master/calibre",
-  "version": "v6.13.0-ls204",
+  "version": "v6.13.0-ls203-2",
   "video": true
 }

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
   "name": "HA Add-ons by alexbelgium",
-  "url": "https://github.com/alexbelgium/hassio-addons",
+  "url": "https://github.com/danbruno/hassio-addons",
   "maintainer": "alexbelgium"
 }

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
   "name": "HA Add-ons by alexbelgium",
-  "url": "https://github.com/danbruno/hassio-addons",
+  "url": "https://github.com/alexbelgium/hassio-addons",
   "maintainer": "alexbelgium"
 }


### PR DESCRIPTION
Tried my best to follow the guidelines given. I've tried this on my local home assistant instance and it works as expected. My Kobo Libra 2 can connect wirelessly to calibre using Kobo-UNCaGED which is really handy when my add-on server is tucked away and the USB ports aren't easily accessible.

The guidelines weren't too descriptive on how to increase the version number so I apologize if I got that incorrect.