### PR TITLE
Use utf-8 as default charset encoding in CIFS mounts

### DIFF
--- a/.templates/92-smb_mounts.sh
+++ b/.templates/92-smb_mounts.sh
@@ -67,17 +67,28 @@ if bashio::config.has_value 'networkdisks'; then
 
         # if Fail test different smb and sec versions
         if [ "$MOUNTED" = false ]; then
-            for SMBVERS in ",vers=3" ",vers=1.0" ",vers=2.1" ",vers=3.0" ",nodfs" ",uid=0,gid=0,forceuid,forcegid" ",noforceuid,noforcegid" ",domain=${DOMAIN:-WORKGROUP}" ",noserverino"; do
-                mount -t cifs -o "iocharset=utf8,rw,file_mode=0775,dir_mode=0775,username=$CIFS_USERNAME,password=${CIFS_PASSWORD}$SMBVERS$PUID$PGID" "$disk" /mnt/"$diskname" 2>/dev/null && MOUNTED=true && break || MOUNTED=false
-                for SECVERS in ",sec=ntlmv2" ",sec=ntlmv2i" ",sec=ntlmssp" ",sec=ntlmsspi" ",sec=krb5i" ",sec=krb5" ",iocharset=utf8" ",noserverino"; do
-                    mount -t cifs -o "iocharset=utf8,rw,file_mode=0775,dir_mode=0775,username=$CIFS_USERNAME,password=${CIFS_PASSWORD}$SMBVERS$SECVERS$PUID$PGID" "$disk" /mnt/"$diskname" 2>/dev/null && MOUNTED=true && break 2 && break || MOUNTED=false
+        
+            # Test with PUIDPGID, remove otherwise
+            ######################################
+            for PUIDPGID in "$PUID$PGID" ""; do
+            
+                # Test with iocharset utf8, remove otherwise
+                ############################################
+                for CHARSET in ",iocharset=utf8" ""; do
+                
+                    # Test with different SMB versions
+                    ##################################
+                    for SMBVERS in ",vers=3" ",vers=1.0" ",vers=2.1" ",vers=3.0" ",nodfs" ",uid=0,gid=0,forceuid,forcegid" ",noforceuid,noforcegid" ",domain=${DOMAIN:-WORKGROUP}"; do
+                        mount -t cifs -o "rw,file_mode=0775,dir_mode=0775,username=$CIFS_USERNAME,password=${CIFS_PASSWORD}$CHARSET$SMBVERS$PUIDPGID" "$disk" /mnt/"$diskname" 2>/dev/null && MOUNTED=true && break || MOUNTED=false
+                        
+                        # Test with different security versions
+                        #######################################
+                        for SECVERS in ",sec=ntlmv2" ",sec=ntlmv2i" ",sec=ntlmssp" ",sec=ntlmsspi" ",sec=krb5i" ",sec=krb5"; do
+                            mount -t cifs -o "rw,file_mode=0775,dir_mode=0775,username=$CIFS_USERNAME,password=${CIFS_PASSWORD}$CHARSET$SMBVERS$SECVERS$PUIDPGID$CHARSET" "$disk" /mnt/"$diskname" 2>/dev/null && MOUNTED=true && break 2 && break || MOUNTED=false
+                        done
+                    done
                 done
             done
-        fi
-
-        # if Fail test without PUID and PGID
-        if [ "$MOUNTED" = false ]; then
-            mount -t cifs -o iocharset=utf8,rw,username="$CIFS_USERNAME",password="${CIFS_PASSWORD}" "$disk" /mnt/"$diskname" && MOUNTED=true || MOUNTED=false
         fi
 
         # Messages

--- a/.templates/92-smb_mounts.sh
+++ b/.templates/92-smb_mounts.sh
@@ -63,21 +63,21 @@ if bashio::config.has_value 'networkdisks'; then
 
         # Tries to mount with default options
         # shellcheck disable=SC2140
-        mount -t cifs -o rw,username="$CIFS_USERNAME",password="$CIFS_PASSWORD$DOMAIN$PUID$PGID" "$disk" /mnt/"$diskname" 2>ERRORCODE && MOUNTED=true || MOUNTED=false
+        mount -t cifs -o iocharset=utf8,rw,username="$CIFS_USERNAME",password="$CIFS_PASSWORD$DOMAIN$PUID$PGID" "$disk" /mnt/"$diskname" 2>ERRORCODE && MOUNTED=true || MOUNTED=false
 
         # if Fail test different smb and sec versions
         if [ "$MOUNTED" = false ]; then
             for SMBVERS in ",vers=3" ",vers=1.0" ",vers=2.1" ",vers=3.0" ",nodfs" ",uid=0,gid=0,forceuid,forcegid" ",noforceuid,noforcegid" ",domain=${DOMAIN:-WORKGROUP}" ",noserverino"; do
-                mount -t cifs -o "rw,file_mode=0775,dir_mode=0775,username=$CIFS_USERNAME,password=${CIFS_PASSWORD}$SMBVERS$PUID$PGID" "$disk" /mnt/"$diskname" 2>/dev/null && MOUNTED=true && break || MOUNTED=false
+                mount -t cifs -o "iocharset=utf8,rw,file_mode=0775,dir_mode=0775,username=$CIFS_USERNAME,password=${CIFS_PASSWORD}$SMBVERS$PUID$PGID" "$disk" /mnt/"$diskname" 2>/dev/null && MOUNTED=true && break || MOUNTED=false
                 for SECVERS in ",sec=ntlmv2" ",sec=ntlmv2i" ",sec=ntlmssp" ",sec=ntlmsspi" ",sec=krb5i" ",sec=krb5" ",iocharset=utf8" ",noserverino"; do
-                    mount -t cifs -o "rw,file_mode=0775,dir_mode=0775,username=$CIFS_USERNAME,password=${CIFS_PASSWORD}$SMBVERS$SECVERS$PUID$PGID" "$disk" /mnt/"$diskname" 2>/dev/null && MOUNTED=true && break 2 && break || MOUNTED=false
+                    mount -t cifs -o "iocharset=utf8,rw,file_mode=0775,dir_mode=0775,username=$CIFS_USERNAME,password=${CIFS_PASSWORD}$SMBVERS$SECVERS$PUID$PGID" "$disk" /mnt/"$diskname" 2>/dev/null && MOUNTED=true && break 2 && break || MOUNTED=false
                 done
             done
         fi
 
         # if Fail test without PUID and PGID
         if [ "$MOUNTED" = false ]; then
-            mount -t cifs -o rw,username="$CIFS_USERNAME",password="${CIFS_PASSWORD}" "$disk" /mnt/"$diskname" && MOUNTED=true || MOUNTED=false
+            mount -t cifs -o iocharset=utf8,rw,username="$CIFS_USERNAME",password="${CIFS_PASSWORD}" "$disk" /mnt/"$diskname" && MOUNTED=true || MOUNTED=false
         fi
 
         # Messages
@@ -91,7 +91,7 @@ if bashio::config.has_value 'networkdisks'; then
             # Test for serverino
             # shellcheck disable=SC2015
             touch "/mnt/$diskname/testaze" && mv "/mnt/$diskname/testaze" "/mnt/$diskname/testaze2" && rm "/mnt/$diskname/testaze2" ||
-            (umount "/mnt/$diskname" && mount -t cifs -o "rw,file_mode=0775,dir_mode=0775,username=$CIFS_USERNAME,password=${CIFS_PASSWORD}$SMBVERS$SECVERS,noserverino" "$disk" /mnt/"$diskname" && bashio::log.warning "noserverino option used")
+            (umount "/mnt/$diskname" && mount -t cifs -o "iocharset=utf8,rw,file_mode=0775,dir_mode=0775,username=$CIFS_USERNAME,password=${CIFS_PASSWORD}$SMBVERS$SECVERS,noserverino" "$disk" /mnt/"$diskname" && bashio::log.warning "noserverino option used")
 
         else
             # Mounting failed messages


### PR DESCRIPTION
Hi, I'm having issues with accents in filenames using the cifs mounting options in your addons, this is mostly annoying with qBittorrent as I have a lot of music torrents with lots of files and lots of accents and I can't seed them correctly or download new files with proper names.

Please do not merge this without proper review / testing, I think using the `iocharset=utf8` option in the mount command might be all that's needed to fix the issue, but I wasn't able to test it myself as I am proficient enough in docker stuff to properly setup my own functional repo.

I tried messing directly with the containers on my install but haven't had any success so far, do you have a suggestion on how I could easily test it ?