### PR TITLE
Update README.md - APP_KEY description Fixed Typo

### DIFF
--- a/fireflyiii/README.md
+++ b/fireflyiii/README.md
@@ -34,7 +34,7 @@ Options can be configured through two ways :
 ```yaml
 "CONFIG_LOCATION": location of the config.yaml # Sets the location of the config.yaml (see below)
 "DB_CONNECTION": "list(sqlite_internal|mariadb_addon|mysql|pgsql)" # Defines the type of database to use : sqlite (default, embedded in the addon) ; MariaDB (auto-detection if the MariaDB addon is installed and runs), and external databases that requires that the other DB_ fields are set (mysql and pgsql)
-"APP_KEY": 12 characters # This is your encryption key, don't lose it!
+"APP_KEY": 32 characters # This is your encryption key, don't lose it!
 "DB_HOST": "CHANGEME" # only needed if using a remote database
 "DB_PORT": "CHANGEME" # only needed if using a remote database
 "DB_DATABASE": "CHANGEME" # only needed if using a remote database


### PR DESCRIPTION
Fixed typo: `"APP_KEY": 12 characters # This is your encryption key, don't lose it!` to `"APP_KEY": 32 characters # This is your encryption key, don't lose it!`