### PR TITLE
Move to CastSponsorSkip

### DIFF
--- a/sponsorblockcast/CHANGELOG.md
+++ b/sponsorblockcast/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Switch to castsponsorskip @bruvv
+
 ## 1.1 (15-05-2023)
 - Updated chromecast-go
 

--- a/sponsorblockcast/build.json
+++ b/sponsorblockcast/build.json
@@ -1,8 +1,8 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/bruvv/sponsorblockcast:latest",
-    "amd64": "ghcr.io/bruvv/sponsorblockcast:latest",
-    "armv7": "ghcr.io/bruvv/sponsorblockcast:latest"
+    "aarch64": "ghcr.io/gabe565/castsponsorskip:latest",
+    "amd64": "ghcr.io/gabe565/castsponsorskip:latest",
+    "armv7": "ghcr.io/gabe565/castsponsorskip:latest"
   },
   "codenotary": {
     "signer": "alexandrep.github@gmail.com"

--- a/sponsorblockcast/config.json
+++ b/sponsorblockcast/config.json
@@ -12,7 +12,7 @@
   "host_network": true,
   "image": "ghcr.io/alexbelgium/sponsorblockcast-{arch}",
   "init": false,
-  "name": "Sponsorblockcast",
+  "name": "Castsponsorskip",
   "options": {
     "SBCCATEGORIES": "sponsor",
     "SBCPOLLINTERVAL": "1",
@@ -26,5 +26,5 @@
   },
   "slug": "sponsorblockcast",
   "url": "https://github.com/alexbelgium/hassio-addons/tree/master/sponsorblockcast",
-  "version": "1.1"
+  "version": "1.2"
 }


### PR DESCRIPTION
sponsorblockcast has been superseded by CastSponsorSkip, written by gabe565. I recommend moving over to it for improved performance and privacy. sponsorblockcast will no longer be maintained.