### PR TITLE
[Whoogle] Use latest tag

### DIFF
--- a/whoogle/build.json
+++ b/whoogle/build.json
@@ -1,8 +1,8 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/benbusby/whoogle-search:0.8.2",
-    "amd64": "ghcr.io/benbusby/whoogle-search:0.8.2",
-    "armv7": "ghcr.io/benbusby/whoogle-search:0.8.2"
+    "aarch64": "ghcr.io/benbusby/whoogle-search:latest",
+    "amd64": "ghcr.io/benbusby/whoogle-search:latest",
+    "armv7": "ghcr.io/benbusby/whoogle-search:latest"
   },
   "codenotary": {
     "signer": "alexandrep.github@gmail.com"

--- a/whoogle/config.json
+++ b/whoogle/config.json
@@ -111,5 +111,5 @@
   },
   "slug": "whoogle-search",
   "url": "https://github.com/alexbelgium/hassio-addons/tree/master/whoogle",
-  "version": "0.8.3"
+  "version": "0.8.3-2"
 }


### PR DESCRIPTION
It is now pinned to 0.8.2 and when the bot updates to a newer version it does not update the tag so switching to latest will help since it is now on 0.8.2 instead of the mentioned 0.8.3.