### PR TITLE
[Castsponserblock] Added CSS_MUTE_ADS config option

### DIFF
--- a/sponsorblockcast/CHANGELOG.md
+++ b/sponsorblockcast/CHANGELOG.md
@@ -1,22 +1,18 @@
-
+### 0.4.0-1 (02-09-2023)
+- Added CSS_MUTE_ADS config added, mutes ADS. Bool, default to true
 ## 0.4.0 (02-09-2023)
 - Update to latest version from gabe565/CastSponsorSkip
 ### 1.3-4 (27-08-2023)
 - Chromecast check fixed @bruvv
 - Readme updated to reflect the changes @bruvv
-
 ### 1.3-3 (25-08-2023)
 - Start up fixed @bruvv
-
 ### 1.3-2 (22-08-2023)
 - Minor bugs fixed
 - Switch to castsponsorskip @bruvv
-
 ## 1.1 (15-05-2023)
 - Updated chromecast-go
-
 ### 1.00 (14-03-2023)
 - Minor bugs fixed
 ## 1.0
-
 - Initial build

--- a/sponsorblockcast/config.json
+++ b/sponsorblockcast/config.json
@@ -18,14 +18,16 @@
     "CSS_DISCOVER_INTERVAL": "5m",
     "CSS_PAUSED_INTERVAL": "1m",
     "CSS_PLAYING_INTERVAL": "1s",
-    "CSS_YOUTUBE_API_KEY": " "
+    "CSS_YOUTUBE_API_KEY": "",
+    "CSS_MUTE_ADS": "true"
   },
   "schema": {
     "CSS_CATEGORIES": "str",
     "CSS_DISCOVER_INTERVAL": "str",
     "CSS_PAUSED_INTERVAL": "str",
     "CSS_PLAYING_INTERVAL": "str",
-    "CSS_YOUTUBE_API_KEY": "str"
+    "CSS_YOUTUBE_API_KEY": "str",
+    "CSS_MUTE_ADS": "bool"
   },
   "slug": "sponsorblockcast",
   "url": "https://github.com/alexbelgium/hassio-addons/tree/master/sponsorblockcast",

--- a/sponsorblockcast/config.json
+++ b/sponsorblockcast/config.json
@@ -31,5 +31,5 @@
   },
   "slug": "sponsorblockcast",
   "url": "https://github.com/alexbelgium/hassio-addons/tree/master/sponsorblockcast",
-  "version": "0.4.0"
+  "version": "0.4.0-1"
 }

--- a/sponsorblockcast/rootfs/etc/cont-init.d/99-run.sh
+++ b/sponsorblockcast/rootfs/etc/cont-init.d/99-run.sh
@@ -6,7 +6,7 @@
 mkdir -p /tmp/castsponsorskip
 
 # Export options as env variables
-for var in CSS_CATEGORIES CSS_DISCOVER_INTERVAL CSS_PAUSED_INTERVAL CSS_PLAYING_INTERVAL CSS_YOUTUBE_API_KEY; do
+for var in CSS_CATEGORIES CSS_DISCOVER_INTERVAL CSS_PAUSED_INTERVAL CSS_PLAYING_INTERVAL CSS_YOUTUBE_API_KEY CSS_MUTE_ADS; do
     if bashio::config.has_value "$var"; then
         export "$var"="$(bashio::config "$var")"
     fi


### PR DESCRIPTION
New upstream version v0.4.0 of castsponserblock added an option to mute ads. This defaults to true but can be set to false, added that option.