### PR TITLE
Update 00-smb_mounts.sh

### DIFF
--- a/.templates/00-smb_mounts.sh
+++ b/.templates/00-smb_mounts.sh
@@ -138,6 +138,20 @@ if bashio::config.has_value 'networkdisks'; then
             SMBVERS="$(nmap --script smb-protocols "$server" -p 445 2>1 | awk '/  [0-9]/' | awk '{print $NF}'  | cut -c -3 | sort -V | tail -n 1  || true)"
             # Manage output
             if [ -n "$SMBVERS" ]; then
+                case $SMBVERS in
+                  202)
+                    SMBVERS="2.0"
+                    ;;
+                  21)
+                    SMBVERS="2.1"
+                    ;;
+                  302)
+                    SMBVERS="3.02"
+                    ;;
+                  311)
+                    SMBVERS="3.1.1"
+                    ;;
+                esac
                 echo "... SMB version $SMBVERS detected"
                 SMBVERS=",vers=$SMBVERS"
             elif smbclient -t 2 -L "$server" -m NT1 -N $DOMAINCLIENT &>/dev/null; then


### PR DESCRIPTION
nmap smb-protocol script outputs: 
| smb-protocols:
|   dialects:
|     NT LM 0.12 (SMBv1) [dangerous, but default]
|     202
|     21
|     30
|     302
|_    311
which is incompatible with mount cifs vers:
vers=arg
SMB protocol version. Allowed values are:
1.0 - The classic CIFS/SMBv1 protocol.
2.0 - The SMBv2.002 protocol. This was initially introduced in Windows Vista Service Pack 1, and Windows Server 2008. Note that the initial release version of Windows Vista spoke a slightly different dialect (2.000) that is not supported.
2.1 - The SMBv2.1 protocol that was introduced in Microsoft Windows 7 and Windows Server 2008R2.
3.0 - The SMBv3.0 protocol that was introduced in Microsoft Windows 8 and Windows Server 2012.
3.02 or 3.0.2 - The SMBv3.0.2 protocol that was introduced in Microsoft Windows 8.1 and Windows Server 2012R2.
3.1.1 or 3.11 - The SMBv3.1.1 protocol that was introduced in Microsoft Windows 10 and Windows Server 2016.
3 - The SMBv3.0 protocol version and above.
default - Tries to negotiate the highest SMB2+ version supported by both the client and server.