### PR TITLE
Bump version to v0.6.1

### DIFF
--- a/sponsorblockcast/CHANGELOG.md
+++ b/sponsorblockcast/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.6.1 (11-24-2023)
+- Update to latest version from gabe565/CastSponsorSkip
 
 ## 0.6.0 (11-11-2023)
 - Update to latest version from gabe565/CastSponsorSkip

--- a/sponsorblockcast/config.json
+++ b/sponsorblockcast/config.json
@@ -25,5 +25,5 @@
   "slug": "sponsorblockcast",
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons/tree/master/sponsorblockcast",
-  "version": "0.6.0"
+  "version": "0.6.1"
 }

--- a/sponsorblockcast/updater.json
+++ b/sponsorblockcast/updater.json
@@ -4,5 +4,5 @@
   "slug": "sponsorblockcast",
   "source": "github",
   "upstream_repo": "gabe565/CastSponsorSkip",
-  "upstream_version": "0.6.0"
+  "upstream_version": "0.6.1"
 }


### PR DESCRIPTION
This PR bumps CastSponsorSkip version to v0.6.1, which contains a pretty important bugfix to improve reconnection when a Cast device is rebooted.