### PR TITLE
Fix: Flaresolverr healthcheck path

### DIFF
--- a/flaresolverr/CHANGELOG.md
+++ b/flaresolverr/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Correct healthcheck endpoint (thanks @override80)
 
 ## 3.3.13 (13-01-2024)
 - Update to latest version from FlareSolverr/FlareSolverr

--- a/flaresolverr/Dockerfile
+++ b/flaresolverr/Dockerfile
@@ -103,7 +103,7 @@ LABEL \
 #################
 
 ENV HEALTH_PORT="8191" \
-    HEALTH_URL="health"
+    HEALTH_URL="/health"
 HEALTHCHECK \
     --interval=5s \
     --retries=5 \

--- a/flaresolverr/Dockerfile
+++ b/flaresolverr/Dockerfile
@@ -103,7 +103,7 @@ LABEL \
 #################
 
 ENV HEALTH_PORT="8191" \
-    HEALTH_URL=""
+    HEALTH_URL="health"
 HEALTHCHECK \
     --interval=5s \
     --retries=5 \

--- a/flaresolverr/config.json
+++ b/flaresolverr/config.json
@@ -76,6 +76,6 @@
   "slug": "flaresolverr",
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "3.3.13",
+  "version": "3.3.13-2",
   "webui": "[PROTO:ssl]://[HOST]:[PORT:8191]"
 }


### PR DESCRIPTION
Since flaresolverr has a specific endpoint for healthchecks (/health) it could make sense to use it insted of the root. Also, this will not flood the log when using INFO LOG_LEVEL (default) with entries like:

`2024-01-15T17:49:56.962520+01:00 hassio addon_db21ed7f_flaresolverr[816]: 2024-01-15 17:49:56 INFO     127.0.0.1 GET http://127.0.0.1:8191/ 200 OK`