### PR TITLE
Update docker hub from omni-nightly to latest nightly

### DIFF
--- a/mealie/build.json
+++ b/mealie/build.json
@@ -1,7 +1,7 @@
 {
   "build_from": {
-    "aarch64": "hkotel/mealie:omni-nightly",
-    "amd64": "hkotel/mealie:omni-nightly"
+    "aarch64": "hkotel/mealie:nightly",
+    "amd64": "hkotel/mealie:nightly"
   },
   "codenotary": {
     "signer": "alexandrep.github@gmail.com"


### PR DESCRIPTION
Mealie is now stable. Latest docker hub is just nightly