### PR TITLE
feat: add media mount for portainer

### DIFF
--- a/portainer/config.json
+++ b/portainer/config.json
@@ -19,6 +19,7 @@
   "init": false,
   "map": [
     "share:rw",
+    "media:rw",
     "ssl"
   ],
   "name": "Portainer",


### PR DESCRIPTION
I use portainer to run Channels DVR, which requires access to my mounted media folders. 