### PR TITLE
Update pgvecto-rs to fix Immich support

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Update pgvector to 0.2.0
+
 ### 15.5-6 (03-02-2024)
 - Fix : use custom postgres username
 

--- a/postgres/build.json
+++ b/postgres/build.json
@@ -1,7 +1,7 @@
 {
   "build_from": {
-    "aarch64": "tensorchord/pgvecto-rs:pg15-v0.1.11",
-    "amd64": "tensorchord/pgvecto-rs:pg15-v0.1.11",
+    "aarch64": "tensorchord/pgvecto-rs:pg15-v0.2.0",
+    "amd64": "tensorchord/pgvecto-rs:pg15-v0.2.0",
     "armv7": "postgres:15-alpine"
   },
   "codenotary": {

--- a/postgres/config.json
+++ b/postgres/config.json
@@ -37,5 +37,5 @@
   "slug": "postgres",
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "15.5-6"
+  "version": "15.5-7"
 }


### PR DESCRIPTION
The latest Immich update changed the requirement from v0.1.11 to v0.2.0