### PR TITLE
Fix cron problem

### DIFF
--- a/epicgamesfree/rootfs/templates/config.json
+++ b/epicgamesfree/rootfs/templates/config.json
@@ -1,6 +1,6 @@
 {
    "runOnStartup":true,
-   "cronSchedule":"0 0/6 * * *",
+   "cronSchedule":"0 */6 * * *",
    "logLevel":"info",
    "webPortalConfig":{
       "baseUrl":"https://epic.example.com"


### PR DESCRIPTION
The cron scheduler maybe don't implement all cron options and does not work fine with 0/6.

With 0/6 only execute at 0 and at 6, so, you need relogin every day (the token need refresh each 8 hours).

Changing 0/6 to */6 it works fine.