### PR TITLE
feat: add sntasmedia smartctl device type

### DIFF
--- a/scrutiny/config.json
+++ b/scrutiny/config.json
@@ -104,7 +104,7 @@
     "COLLECTOR_API_ENDPOINT": "str?",
     "COLLECTOR_HOST_ID": "str?",
     "Mode": "list(Collector+WebUI|Collector)?",
-    "SMARTCTL_COMMAND_DEVICE_TYPE": "list(auto|ata|scsi|sat|usbcypress|usbjmicron|usbsunplus|marvell|megaraid)?",
+    "SMARTCTL_COMMAND_DEVICE_TYPE": "list(auto|ata|scsi|sat|usbcypress|usbjmicron|usbsunplus|marvell|megaraid|sntasmedia)?",
     "SMARTCTL_MEGARAID_DISK_NUM": "int?",
     "TZ": "str?",
     "Updates": "list(Hourly|Daily|Weekly)",
@@ -113,5 +113,5 @@
   "slug": "scrutiny",
   "udev": true,
   "url": "https://github.com/AnalogJ/scrutiny",
-  "version": "v0.8.1-2"
+  "version": "v0.8.1-3"
 }

--- a/scrutiny_fa/config.json
+++ b/scrutiny_fa/config.json
@@ -39,7 +39,7 @@
     "COLLECTOR_API_ENDPOINT": "str?",
     "COLLECTOR_HOST_ID": "str?",
     "Mode": "list(Collector+WebUI|Collector)?",
-    "SMARTCTL_COMMAND_DEVICE_TYPE": "list(auto|ata|scsi|sat|usbcypress|usbjmicron|usbsunplus|marvell|megaraid)?",
+    "SMARTCTL_COMMAND_DEVICE_TYPE": "list(auto|ata|scsi|sat|usbcypress|usbjmicron|usbsunplus|marvell|megaraid|sntasmedia)?",
     "SMARTCTL_MEGARAID_DISK_NUM": "int?",
     "TZ": "str?",
     "Updates": "list(Hourly|Daily|Weekly)",

--- a/scrutiny_fa/config.json
+++ b/scrutiny_fa/config.json
@@ -48,5 +48,5 @@
   "slug": "scrutiny_fa",
   "udev": true,
   "url": "https://github.com/AnalogJ/scrutiny",
-  "version": "v0.8.1-2"
+  "version": "v0.8.1-3"
 }


### PR DESCRIPTION
Looked up using `docker run -it ghcr.io/analogj/scrutiny:latest /bin/bash` and ran `smartctl --help` to see supported device types. `sntasmedia` is listed there.