### PR TITLE
Display Birdnet-go to non-admin

### DIFF
--- a/birdnet-go/config.json
+++ b/birdnet-go/config.json
@@ -80,6 +80,7 @@
     "COMMAND": "realtime"
   },
   "panel_icon": "mdi:bird",
+  "panel_admin": false,
   "ports": {
     "8080/tcp": 8080
   },


### PR DESCRIPTION
Hey,

would love to allow my non-admin users to see Birdnet-go panel, so I made this PR.
I think this is the kind of soft that is to be shared with non-admins.

Ideally, I would like to give the choice to the end user by creating an schema `allowNonAdmin: "bool"` and use it to define `panel_admin` config but I don't think it's possible ?

Thx 🙏 