### PR TITLE
Added missing USB device types

### DIFF
--- a/scrutiny/config.json
+++ b/scrutiny/config.json
@@ -105,7 +105,7 @@
     "COLLECTOR_API_ENDPOINT": "str?",
     "COLLECTOR_HOST_ID": "str?",
     "Mode": "list(Collector+WebUI|Collector)?",
-    "SMARTCTL_COMMAND_DEVICE_TYPE": "list(auto|ata|scsi|sat|usbcypress|usbjmicron|usbsunplus|marvell|megaraid|sntasmedia)?",
+    "SMARTCTL_COMMAND_DEVICE_TYPE": "list(auto|ata|scsi|sat|usbcypress|usbjmicron|usbsunplus|sntasmedia|sntjmicron|sntrealtek|marvell|megaraid)?",
     "SMARTCTL_MEGARAID_DISK_NUM": "int?",
     "TZ": "str?",
     "Updates": "list(Hourly|Daily|Weekly)",

--- a/scrutiny/config.json
+++ b/scrutiny/config.json
@@ -114,5 +114,5 @@
   "slug": "scrutiny",
   "udev": true,
   "url": "https://github.com/AnalogJ/scrutiny",
-  "version": "v0.8.1-4"
+  "version": "v0.8.1-5"
 }


### PR DESCRIPTION
There were some smartctl's device types missing. Added the "snt*" types, which I use. Information taken from https://www.smartmontools.org/wiki/USB