### PR TITLE
Update link to lidarr/README.md

### DIFF
--- a/lidarr/config.json
+++ b/lidarr/config.json
@@ -104,7 +104,7 @@
   },
   "slug": "lidarr_nas",
   "udev": true,
-  "url": "https://github.com/alexbelgium/hassio-addons/blob/master/lidarr/Readme.md",
+  "url": "https://github.com/alexbelgium/hassio-addons/blob/master/lidarr/README.md",
   "version": "2.5.3.4341",
   "webui": "[PROTO:ssl]://[HOST]:[PORT:8686]"
 }


### PR DESCRIPTION
# PR Summary
Commit ac319251a5520d631430970815515def905226da renamed `lidarr/Readme.md` to be `lidarr/README.md`. This PR adjusts sources to changes.