### PR TITLE
Fix Mealie repo url

### DIFF
--- a/mealie/updater.json
+++ b/mealie/updater.json
@@ -6,6 +6,6 @@
   "repository": "alexbelgium/hassio-addons",
   "slug": "mealie",
   "source": "github",
-  "upstream_repo": "hay-kot/mealie",
+  "upstream_repo": "mealie-recipes/mealie",
   "upstream_version": "v2.2.0"
 }


### PR DESCRIPTION
The repo has been moved to its own organisation. Even though you get redirected to it, it's a nice change to have