### PR TITLE
Update healthcheck url

### DIFF
--- a/immich/CHANGELOG.md
+++ b/immich/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Fix healthcheck (thanks @red-avtovo)
+
 ## 1.122.1-2 (08-12-2024)
 - Minor bugs fixed
 

--- a/immich/Dockerfile
+++ b/immich/Dockerfile
@@ -119,7 +119,7 @@ LABEL \
 #################
 
 ENV HEALTH_PORT="8080" \
-    HEALTH_URL="/api/server-info/ping"
+    HEALTH_URL="/api/server/ping"
 HEALTHCHECK \
     --interval=5s \
     --retries=5 \

--- a/immich/config.json
+++ b/immich/config.json
@@ -139,6 +139,6 @@
   "slug": "immich",
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "1.122.1-2",
+  "version": "1.122.1-3",
   "webui": "http://[HOST]:[PORT:8080]"
 }


### PR DESCRIPTION
The url was moved to /api/server/* as of this release
https://github.com/immich-app/immich/releases/tag/v1.118.0