### PR TITLE
Add discovery to Mealie config

### DIFF
--- a/mealie/config.json
+++ b/mealie/config.json
@@ -113,5 +113,5 @@
   "slug": "mealie",
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "v2.3.0"
+  "version": "v2.3.0-test"
 }


### PR DESCRIPTION
Integrations can support discovery of add-ons if the add-on supports it.

Adding discovery for Mealie so that the integration can detect the add-on and suggest a setup.  Note this is not in place within the integration at the moment as needs the discovery tag into the add-on to detect this, I am not an add-on dev so have been unable to work out where to add this into my own config to test.

See adguard example of where this has been added.
https://github.com/hassio-addons/addon-adguard-home/blob/f7d3615c616d942ef150e7bc0afc5a1c9e4060bc/adguard/config.yaml#L25