### PR TITLE
fix: resolve config.env directory issue in free_games_claimer add-on (#1655)

### DIFF
--- a/free_games_claimer/config.json
+++ b/free_games_claimer/config.json
@@ -93,6 +93,6 @@
   "slug": "free_games_claimer",
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "1.6-5",
+  "version": "1.6-6",
   "webui": "[PROTO:ssl]://[HOST]:[PORT:6080]"
 }


### PR DESCRIPTION
Steps taken:
1. Added a check to detect if config.env is a directory instead of a file.  
2. Removed the invalid directory if found and replaced it with a valid config.env file.  
3. Set proper permissions for the config.env file.  
4. Improved logging for debugging and status updates.  
