### PR TITLE
[TOR] http tunnel capability

### DIFF
--- a/tor/CHANGELOG.md
+++ b/tor/CHANGELOG.md
@@ -13,3 +13,7 @@
 ## 5.0.1-4 (14-08-2024)
 
 - Add execution permission for permission for /etc/s6-overlay/s6-overlay/s6-rc.d/init-tor/run file
+
+## 5.0.2-1 (13-02-2025)
+
+- HTTP tunneling

--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:16.2.0
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:17.1.3
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -11,22 +11,22 @@ COPY rootfs /
 # Setup base
 RUN \
     apk add --no-cache \
-        coreutils=9.5-r1 \
-        openssl=3.3.1-r3 \
-        tor=0.4.8.12-r0 \
-        go=1.22.6-r0 \
-        git=2.45.2-r0 \
-        ca-certificates=20240705-r0 \
-        libcap=2.70-r0
+    coreutils=9.5-r2 \
+    openssl=3.3.2-r6 \
+    tor=0.4.8.14-r1 \
+    go=1.23.6-r0 \
+    git=2.47.2-r0 \
+    ca-certificates=20241121-r1 \
+    libcap=2.71-r0
 
 # Download pluggable-transports sources
 WORKDIR /go
 ARG OBFS_VERSION=obfs4proxy-0.0.14
-ARG SNOWFLAKE_VERSION=v2.9.2
-ARG WEBTUNNEL_VERSION=e64b1b3562f3ab50d06141ecd513a21ec74fe8c6
+ARG SNOWFLAKE_VERSION=v2.10.1
+ARG WEBTUNNEL_VERSION=v0.0.2
 RUN git clone -b ${OBFS_VERSION} --single-branch --depth 1 https://github.com/Yawning/obfs4.git \
     && git clone -b ${SNOWFLAKE_VERSION} --single-branch --depth 1 https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake.git \
-    && git clone --single-branch --depth 1 https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/webtunnel.git
+    && git clone -b ${WEBTUNNEL_VERSION} --single-branch --depth 1 https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/webtunnel.git
 
 # Build obfs4proxy
 WORKDIR /go/obfs4
@@ -56,11 +56,11 @@ HEALTHCHECK \
     --interval=60s \
     --timeout=30s \
     CMD curl \
-        --silent \
-        --location \
-        --socks5-hostname localhost:9050 \
-        https://check.torproject.org/?lang=en_US \
-        | grep -qm1 Congratulations
+    --silent \
+    --location \
+    --socks5-hostname localhost:9050 \
+    https://check.torproject.org/?lang=en_US \
+    | grep -qm1 Congratulations
 
 # Build arguments
 ARG BUILD_ARCH

--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:17.1.3
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:17.1.4
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -13,11 +13,11 @@ RUN \
     apk add --no-cache \
     coreutils=9.5-r2 \
     openssl=3.3.3-r0 \
-    tor=0.4.8.14-r0 \
-    go=1.22.10-r0 \
-    git=2.45.3-r0 \
+    tor=0.4.8.14-r1 \
+    go=1.23.6-r0 \
+    git=2.47.2-r0 \
     ca-certificates=20241121-r1 \
-    libcap=2.70-r0
+    libcap=2.71-r0
 
 # Download pluggable-transports sources
 WORKDIR /go

--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:17.1.4
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:15.0.8
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -11,13 +11,13 @@ COPY rootfs /
 # Setup base
 RUN \
     apk add --no-cache \
-    coreutils=9.5-r2 \
-    openssl=3.3.3-r0 \
-    tor=0.4.8.14-r1 \
-    go=1.23.6-r0 \
-    git=2.47.2-r0 \
+    coreutils=9.4-r2 \
+    openssl=3.1.8-r0 \
+    tor=0.4.8.14-r0 \
+    go=1.21.10-r0 \
+    git=2.43.6-r0 \
     ca-certificates=20241121-r1 \
-    libcap=2.71-r0
+    libcap=2.69-r1
 
 # Download pluggable-transports sources
 WORKDIR /go

--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -12,12 +12,12 @@ COPY rootfs /
 RUN \
     apk add --no-cache \
     coreutils=9.5-r2 \
-    openssl=3.3.2-r6 \
-    tor=0.4.8.14-r1 \
-    go=1.23.6-r0 \
-    git=2.47.2-r0 \
+    openssl=3.3.3-r0 \
+    tor=0.4.8.14-r0 \
+    go=1.22.10-r0 \
+    git=2.45.3-r0 \
     ca-certificates=20241121-r1 \
-    libcap=2.71-r0
+    libcap=2.70-r0
 
 # Download pluggable-transports sources
 WORKDIR /go

--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:15.0.8
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:17.1.4
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -11,13 +11,13 @@ COPY rootfs /
 # Setup base
 RUN \
     apk add --no-cache \
-    coreutils=9.4-r2 \
-    openssl=3.1.8-r0 \
-    tor=0.4.8.14-r0 \
-    go=1.21.10-r0 \
-    git=2.43.6-r0 \
+    coreutils=9.5-r2 \
+    openssl=3.3.3-r0 \
+    tor=0.4.8.14-r1 \
+    go=1.23.6-r0 \
+    git=2.47.2-r0 \
     ca-certificates=20241121-r1 \
-    libcap=2.69-r1
+    libcap=2.71-r0
 
 # Download pluggable-transports sources
 WORKDIR /go

--- a/tor/README.md
+++ b/tor/README.md
@@ -42,6 +42,10 @@ The installation of this add-on is pretty straightforward and not different in c
 
 You should follow to the initial guide for configuring base addon options. Here will described only extra options in comparisons with base:
 
+### Option: `http_tunnel`
+
+Setting this option to true opens port 9080 to listen for connections from HTTP-speaking applications. Enabling this feature allows you to use other applications on your network to use the Tor network via http proxy.
+
 ### Option: `bridges`
 
 > Ensure the option value is clear to avoid unintended use of transport plugins and bridges.

--- a/tor/build.json
+++ b/tor/build.json
@@ -1,8 +1,8 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/hassio-addons/base:16.2.0",
-    "amd64": "ghcr.io/hassio-addons/base:16.2.0",
-    "armv7": "ghcr.io/hassio-addons/base:16.2.0"
+    "aarch64": "ghcr.io/hassio-addons/base:17.1.4",
+    "amd64": "ghcr.io/hassio-addons/base:17.1.4",
+    "armv7": "ghcr.io/hassio-addons/base:17.1.4"
   },
   "codenotary": {
     "base_image": "codenotary@frenck.dev",

--- a/tor/config.json
+++ b/tor/config.json
@@ -21,13 +21,16 @@
       "8123:80"
     ],
     "socks": false,
+    "http_tunnel": false,
     "stealth": false
   },
   "ports": {
-    "9050/tcp": 9050
+    "9050/tcp": 9050,
+    "9080/tcp": 9080
   },
   "ports_description": {
-    "9050/tcp": "Tor SOCKS proxy port"
+    "9050/tcp": "Tor SOCKS proxy port",
+    "9080/tcp": "Tor HTTP tunnel port"
   },
   "schema": {
     "bridges": [
@@ -42,10 +45,11 @@
       "match(^(.*:)?(?:[0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])?$)"
     ],
     "socks": "bool",
+    "http_tunnel": "bool",
     "stealth": "bool"
   },
   "slug": "tor",
   "startup": "services",
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "5.0.1-4"
+  "version": "5.0.2-1"
 }

--- a/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
+++ b/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
@@ -89,10 +89,15 @@ else
     echo 'SOCKSPort 127.0.0.1:9050' >> "${torrc}"
 fi
 
+# Configure Http tunnel port
+if bashio::config.true 'http_tunnel'; then
+    echo 'HTTPTunnelPort 9080' >> "${torrc}"
+fi
+
 # Configure hidden services
 if bashio::config.true 'hidden_services'; then
     echo "HiddenServiceDir ${hidden_service_dir}" >> "${torrc}"
-    
+
     for port in $(bashio::config 'ports'); do
         count=$(echo "${port}" | sed 's/[^:]//g'| awk '{ print length }')
         if [[ "${count}" == 0 ]]; then
@@ -134,13 +139,13 @@ then
 
     # Add client for OBFS transport
     echo "ClientTransportPlugin obfs2,obfs3,obfs4,scramblesuit exec /usr/local/bin/obfs4proxy managed" >> "${torrc}"
-    
+
     # Add client for Snowflake transport
     echo "ClientTransportPlugin snowflake exec /usr/local/bin/snowflake" >> "${torrc}"
 
     # Add client for WebTunnel transport
     echo "ClientTransportPlugin webtunnel exec /usr/local/bin/webtunnel" >> "${torrc}"
-    
+
     # Add bridges
     while read -r bridge; do
         bashio::log.info "Bridge ${bridge}"
@@ -178,7 +183,7 @@ then
     while read -r clientname; do
         # Generate key is they do not exist yet
         if ! bashio::fs.file_exists "${authorized_clients_dir}/${clientname}.auth"
-        then 
+        then
             key=$(openssl genpkey -algorithm x25519)
 
             private_key=$(
@@ -226,7 +231,7 @@ then
             bashio::log.red "Private key:"
             bashio::log.red "${private_key}"
             bashio::log.red
-            bashio::log.red 
+            bashio::log.red
         else
             bashio::log.info "Keys for ${clientname} already exists; skipping..."
         fi


### PR DESCRIPTION
I like to use tor as a  local proxy for application to bypass some restrictions, but not all of them support SOCKS protocol via 9050 port. Let's open 9080 port to use the HTTP tunnel capability, which is build in to the tor to achieve that.