### PR TITLE
Tor http proxy

### DIFF
--- a/tor/CHANGELOG.md
+++ b/tor/CHANGELOG.md
@@ -22,3 +22,7 @@
 
 - Fix snowflake build
 - Lint issues
+
+## 5.0.2-3 (13-02-2025)
+
+- Fix network for http tunel

--- a/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
+++ b/tor/rootfs/etc/s6-overlay/s6-rc.d/init-tor/run
@@ -91,7 +91,7 @@ fi
 
 # Configure Http tunnel port
 if bashio::config.true 'http_tunnel'; then
-    echo 'HTTPTunnelPort 9080' >> "${torrc}"
+    echo 'HTTPTunnelPort 0.0.0.0:9080' >> "${torrc}"
 fi
 
 # Configure hidden services


### PR DESCRIPTION
```
Feb 13 21:39:00.832 [notice] Opening HTTP tunnel listener on 127.0.0.1:9080
Feb 13 21:39:00.832 [notice] Opened HTTP tunnel listener connection (ready) on 127.0.0.1:9080
```
It is open in 127.0.0.1  network  by default which is not reachable inside container only. Let's expose port to 0.0.0.0 instead.