### PR TITLE
Add user/pass (if defined) to healthcheck

### DIFF
--- a/transmission/Dockerfile
+++ b/transmission/Dockerfile
@@ -145,4 +145,4 @@ HEALTHCHECK \
     --retries=5 \
     --start-period=30s \
     --timeout=25s \
-    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f $([ -n "${user}" ] && [ -n "${pass}" ] && echo "-u ${user}:${pass}") "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/transmission/config.json
+++ b/transmission/config.json
@@ -131,5 +131,5 @@
   "slug": "transmission_ls",
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "4.0.6-r0-ls272-2"
+  "version": "4.0.6-r0-ls272-3"
 }


### PR DESCRIPTION
Configuration example:
```yaml
DNS_server: 192.168.1.1
PGID: 0
PUID: 0
customUI: transmission-web-control
user: admin
pass: secret
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the service’s health monitoring to support secure authentication, improving overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->