### PR TITLE
Fix user/pass (if defined) to healthcheck

### DIFF
--- a/transmission/Dockerfile
+++ b/transmission/Dockerfile
@@ -141,8 +141,8 @@ RUN \
 ENV HEALTH_PORT="9091" \
     HEALTH_URL=""
 HEALTHCHECK \
-    --interval=5s \
+    --interval=1m \
     --retries=5 \
     --start-period=30s \
     --timeout=25s \
-    CMD curl -A "HealthCheck: Docker/1.0" -s -f $([ -n "${user}" ] && [ -n "${pass}" ] && echo "-u ${user}:${pass}") "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f $(source ~/.bashrc && [ -n "${user}" ] && [ -n "${pass}" ] && echo "-u ${user}:${pass}") "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/transmission/config.json
+++ b/transmission/config.json
@@ -131,5 +131,5 @@
   "slug": "transmission_ls",
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "4.0.6-r0-ls272-3"
+  "version": "4.0.6-r0-ls272-4"
 }


### PR DESCRIPTION
Healthcheck curl doesn't have access to user and pass env variables without source ~/.bashrc.
I also think that more reasonable to change healthcheck interval from 5s to 1m.

Thanks for your great job!

PS: I test all cases locally and can confirm that this time everything works as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Refined system health monitoring by extending the check interval and updating the initialization process to better account for environment settings, enhancing overall stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->