### PR TITLE
Fix librespeed ingress port

### DIFF
--- a/librespeed/CHANGELOG.md
+++ b/librespeed/CHANGELOG.md
@@ -1,8 +1,12 @@
+## 5.4.1b (03-04-2025)
+
+- Fix PGID issue
+
 ## 5.4.1a (03-04-2025)
 
-- Fixed ingress
-- Added config for IPINFO_APIKEY
-- Added descriptions for configs
+- Fix ingress
+- Add config for IPINFO_APIKEY
+- Add descriptions for configs
 
 ## 5.4.1 (02-04-2025)
 

--- a/librespeed/CHANGELOG.md
+++ b/librespeed/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 5.4.1b (03-04-2025)
 
-- Fix PGID issue
+- Fix default PGID
+- Fix ingress port
 
 ## 5.4.1a (03-04-2025)
 

--- a/librespeed/config.json
+++ b/librespeed/config.json
@@ -68,11 +68,6 @@
     "/dev/nvme1",
     "/dev/nvme2"
   ],
-  "environment": {
-    "PGID": "0",
-    "PUID": "0"
-  },
-  "image": "ghcr.io/alexbelgium/librespeed-{arch}",
   "init": false,
   "ingress": true,
   "ingress_stream": true,
@@ -80,10 +75,6 @@
     "addon_config:rw"
   ],
   "name": "LibreSpeed",
-  "options": {
-    "PGID": 0,
-    "PUID": 0
-  },
   "panel_admin": false,
   "panel_icon": "mdi:speedometer",
   "ports": {
@@ -101,8 +92,8 @@
     "PUID": "int",
     "TZ": "str?",
     "IPINFO_APIKEY": "str?",
-    "PASSWORD": "str?",
     "CUSTOM_RESULTS": "bool?",
+    "PASSWORD": "str?",
     "cifsdomain": "str?",
     "cifspassword": "str?",
     "cifsusername": "str?",
@@ -112,5 +103,5 @@
   "slug": "librespeed",
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "5.4.1a"
+  "version": "5.4.1b"
 }

--- a/librespeed/config.json
+++ b/librespeed/config.json
@@ -85,7 +85,7 @@
   "panel_admin": false,
   "panel_icon": "mdi:speedometer",
   "ports": {
-    "80/tcp": 80
+    "80/tcp": 8096
   },
   "ports_description": {
     "80/tcp": "web interface (Not required for Ingress)"

--- a/librespeed/config.json
+++ b/librespeed/config.json
@@ -68,6 +68,7 @@
     "/dev/nvme1",
     "/dev/nvme2"
   ],
+  "image": "ghcr.io/alexbelgium/librespeed-{arch}",
   "init": false,
   "ingress": true,
   "ingress_port": 80,
@@ -79,8 +80,8 @@
   "options": {
     "IPINFO_APIKEY": "",
     "CUSTOM_RESULTS": false,
-    "PGID": "1000",
-    "PUID": "1000"
+    "PGID": 1000,
+    "PUID": 1000
   },
   "panel_admin": false,
   "panel_icon": "mdi:speedometer",

--- a/librespeed/config.json
+++ b/librespeed/config.json
@@ -96,8 +96,8 @@
     "DAC_READ_SEARCH"
   ],
   "schema": {
-    "PGID": "int",
-    "PUID": "int",
+    "PGID": "int?",
+    "PUID": "int?",
     "IPINFO_APIKEY": "str?",
     "CUSTOM_RESULTS": "bool?",
     "PASSWORD": "str?",
@@ -111,5 +111,5 @@
   "slug": "librespeed",
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "5.4.1a"
+  "version": "5.4.1b"
 }

--- a/librespeed/config.json
+++ b/librespeed/config.json
@@ -68,10 +68,6 @@
     "/dev/nvme1",
     "/dev/nvme2"
   ],
-  "environment": {
-    "PGID": "1000",
-    "PUID": "1000"
-  },
   "init": false,
   "ingress": true,
   "ingress_port": 8096,

--- a/librespeed/config.json
+++ b/librespeed/config.json
@@ -77,8 +77,7 @@
   "ingress": true,
   "ingress_stream": true,
   "map": [
-    "config:rw",
-    "share:rw"
+    "addon_config:rw"
   ],
   "name": "LibreSpeed",
   "options": {
@@ -91,7 +90,7 @@
     "8096/tcp": 8096
   },
   "ports_description": {
-    "8096/tcp": "web interface"
+    "8096/tcp": "web interface (Not required for Ingress)"
   },
   "privileged": [
     "SYS_ADMIN",
@@ -113,6 +112,5 @@
   "slug": "librespeed",
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "5.4.1a",
-  "webui": "http://[HOST]:[PORT:8096]"
+  "version": "5.4.1a"
 }

--- a/librespeed/config.json
+++ b/librespeed/config.json
@@ -68,20 +68,18 @@
     "/dev/nvme1",
     "/dev/nvme2"
   ],
-  "environment": {
-    "PGID": "1000",
-    "PUID": "1000"
-  },
   "init": false,
   "ingress": true,
-  "ingress_stream": true,
+  "ingress_port": 8096,
   "map": [
     "addon_config:rw"
   ],
   "name": "LibreSpeed",
   "options": {
     "IPINFO_APIKEY": "",
-    "CUSTOM_RESULTS": false
+    "CUSTOM_RESULTS": false,
+    "PGID": "1000",
+    "PUID": "1000"
   },
   "panel_admin": false,
   "panel_icon": "mdi:speedometer",
@@ -91,25 +89,15 @@
   "ports_description": {
     "8096/tcp": "web interface (Not required for Ingress)"
   },
-  "privileged": [
-    "SYS_ADMIN",
-    "DAC_READ_SEARCH"
-  ],
   "schema": {
-    "PGID": "int?",
-    "PUID": "int?",
     "IPINFO_APIKEY": "str?",
     "CUSTOM_RESULTS": "bool?",
     "PASSWORD": "str?",
     "TZ": "str?",
-    "cifsdomain": "str?",
-    "cifspassword": "str?",
-    "cifsusername": "str?",
-    "localdisks": "str?",
-    "networkdisks": "str?"
+    "PGID": "int",
+    "PUID": "int"
   },
   "slug": "librespeed",
-  "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
   "version": "5.4.1b"
 }

--- a/librespeed/config.json
+++ b/librespeed/config.json
@@ -88,8 +88,6 @@
     "DAC_READ_SEARCH"
   ],
   "schema": {
-    "PGID": "int",
-    "PUID": "int",
     "TZ": "str?",
     "IPINFO_APIKEY": "str?",
     "CUSTOM_RESULTS": "bool?",

--- a/librespeed/config.json
+++ b/librespeed/config.json
@@ -70,7 +70,8 @@
   ],
   "init": false,
   "ingress": true,
-  "ingress_port": 8096,
+  "ingress_port": 80,
+  "ingress_stream": true,
   "map": [
     "addon_config:rw"
   ],
@@ -84,10 +85,10 @@
   "panel_admin": false,
   "panel_icon": "mdi:speedometer",
   "ports": {
-    "8096/tcp": 8096
+    "80/tcp": 80
   },
   "ports_description": {
-    "8096/tcp": "web interface (Not required for Ingress)"
+    "80/tcp": "web interface (Not required for Ingress)"
   },
   "schema": {
     "IPINFO_APIKEY": "str?",

--- a/librespeed/config.json
+++ b/librespeed/config.json
@@ -68,6 +68,10 @@
     "/dev/nvme1",
     "/dev/nvme2"
   ],
+  "environment": {
+    "PGID": "1000",
+    "PUID": "1000"
+  },
   "init": false,
   "ingress": true,
   "ingress_stream": true,
@@ -75,6 +79,10 @@
     "addon_config:rw"
   ],
   "name": "LibreSpeed",
+  "options": {
+    "IPINFO_APIKEY": "",
+    "CUSTOM_RESULTS": false
+  },
   "panel_admin": false,
   "panel_icon": "mdi:speedometer",
   "ports": {
@@ -88,10 +96,12 @@
     "DAC_READ_SEARCH"
   ],
   "schema": {
-    "TZ": "str?",
+    "PGID": "int",
+    "PUID": "int",
     "IPINFO_APIKEY": "str?",
     "CUSTOM_RESULTS": "bool?",
     "PASSWORD": "str?",
+    "TZ": "str?",
     "cifsdomain": "str?",
     "cifspassword": "str?",
     "cifsusername": "str?",
@@ -101,5 +111,5 @@
   "slug": "librespeed",
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "5.4.1b"
+  "version": "5.4.1a"
 }


### PR DESCRIPTION
Fixed the default PGID and ingress ports.

Tested locally 
<img width="1499" alt="SCR-20250503-qmaz" src="https://github.com/user-attachments/assets/54d020fe-5d2c-4eb9-94a1-479ee63094fb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added options for IPINFO API key and custom results.
  - Added ingress port configuration and updated port mapping.

- **Bug Fixes**
  - Fixed default user and group ID settings.
  - Fixed ingress port assignment.

- **Chores**
  - Updated documentation and changelog for version 5.4.1b.
  - Adjusted configuration schema and removed unused options for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->