### PR TITLE
Update config.json

### DIFF
--- a/calibre_web/config.json
+++ b/calibre_web/config.json
@@ -84,7 +84,7 @@
   "map": [
     "media:rw",
     "share:rw",
-    "addon_config:rw",
+    "addon_configs:rw",
     "homeassistant_config:rw",
     "ssl"
   ],

--- a/calibre_web/config.json
+++ b/calibre_web/config.json
@@ -84,7 +84,7 @@
   "map": [
     "media:rw",
     "share:rw",
-    "addon_configs:rw",
+    "all_addon_configs:rw",
     "homeassistant_config:rw",
     "ssl"
   ],


### PR DESCRIPTION
Calibre-web can not access `/addon_configs` folder. Without that `metadata.db` is not accessible from Calibre config folder.

I belive that the correct location is `/addon_configs`, not `/addon_config`. Please see below output from the current Calibre-web docker

```
root@a0d7ed7f-calibre-web:/homeassistant/addons_config# ls -la
total 32
drwxrwxrwx  8 root     root     4096 May 13 23:12 .
drwxrwxrwx 22 root     root     4096 May 19 02:23 ..
lrwxrwxrwx  1 root     root       35 May 13 23:12 a0d7ed7f_calibre-web -> /addon_configs/a0d7ed7f_calibre-web
lrwxrwxrwx  1 root     root       31 May 13 23:12 a0d7ed7f_calibre -> /addon_configs/a0d7ed7f_calibre
...
...
...
root@a0d7ed7f-calibre-web:/homeassistant/addons_config# cd a0d7ed7f_calibre
bash: cd: a0d7ed7f_calibre: No such file or directory
root@a0d7ed7f-calibre-web:/homeassistant/addons_config#

```