### PR TITLE
Update 99-run.sh

### DIFF
--- a/openproject/rootfs/etc/cont-init.d/99-run.sh
+++ b/openproject/rootfs/etc/cont-init.d/99-run.sh
@@ -3,19 +3,19 @@
 bashio::log.info "Starting OpenProject"
 
 # Ensure persistence for PGDATA and asset folders
-for folder in pg assets; do
-    mkdir -p /config/"$folder"
-    if [ -d /data/"$folder" ] && [ "$(ls -A /data/"$folder")" ]; then
+#for folder in pg assets; do
+#    mkdir -p /config/"$folder"
+#    if [ -d /data/"$folder" ] && [ "$(ls -A /data/"$folder")" ]; then
         # Copy only if source is non-empty
-        cp -a /data/"$folder"/. /config/"$folder"/
-        rm -rf /data/"$folder"
-    fi
-    chmod 700 /config/"$folder"
-done
+#        cp -a /data/"$folder"/. /config/"$folder"/
+#        rm -rf /data/"$folder"
+#    fi
+#    chmod 700 /config/"$folder"
+#done
 
-echo "Setting permissions"
-mkdir -p /config/assets/files
-chown -R postgres:postgres /config
+#echo "Setting permissions"
+#mkdir -p /config/assets/files
+#chown -R postgres:postgres /config
 
 cd /app || true
 


### PR DESCRIPTION
If moving pgdata is not important in order enable the config.yaml env exports, we'd let users to decide attachments location by specifying OPENPROJECT_ATTACHMENTS__STORAGE__PATH.