### PR TITLE
chore: upgrade vectorchord to 0.4.3 which is supported in latest immich version

### DIFF
--- a/postgres_15/build.json
+++ b/postgres_15/build.json
@@ -1,7 +1,7 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/immich-app/postgres:15-vectorchord0.3.0-pgvectors0.3.0",
-    "amd64": "ghcr.io/immich-app/postgres:15-vectorchord0.3.0-pgvectors0.3.0",
+    "aarch64": "ghcr.io/immich-app/postgres:15-vectorchord0.4.3-pgvectors0.3.0",
+    "amd64": "ghcr.io/immich-app/postgres:15-vectorchord0.4.3-pgvectors0.3.0",
     "armv7": "postgres:15-alpine"
   },
   "codenotary": {

--- a/postgres_17/build.json
+++ b/postgres_17/build.json
@@ -1,7 +1,7 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/immich-app/postgres:17-vectorchord0.3.0-pgvectors0.3.0",
-    "amd64": "ghcr.io/immich-app/postgres:17-vectorchord0.3.0-pgvectors0.3.0"
+    "aarch64": "ghcr.io/immich-app/postgres:17-vectorchord0.4.3-pgvectors0.3.0",
+    "amd64": "ghcr.io/immich-app/postgres:17-vectorchord0.4.3-pgvectors0.3.0"
   },
   "codenotary": {
     "signer": "alexandrep.github@gmail.com"

--- a/postgres_17/config.json
+++ b/postgres_17/config.json
@@ -39,5 +39,5 @@
   "slug": "postgres_latest",
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons/tree/master/postgres",
-  "version": "17.4-4"
+  "version": "17.4-5"
 }


### PR DESCRIPTION
In this version it is supported:

https://github.com/immich-app/immich/releases/tag/v1.135.0

