### PR TITLE
[postgres 15 & 17] use dbname and username from config for healtcheck

### DIFF
--- a/postgres_15/Dockerfile
+++ b/postgres_15/Dockerfile
@@ -121,4 +121,4 @@ HEALTHCHECK \
     --retries=5 \
     --start-period=90s \
     --timeout=25s \
-    CMD pg_isready -d postgres || exit 1
+    CMD pg_isready --dbname="${POSTGRES_DB}" --username="${POSTGRES_USER}" || exit 1


### PR DESCRIPTION
I noticed i receive this message in my logs every 5 seconds:

```
2025-06-23 21:35:34.421 CEST [3303] FATAL:  role "root" does not exist
```

Turns out this is the health check which had no user configured. I looked at how the base images handle the healthcheck and found this: https://github.com/immich-app/base-images/blob/main/postgres/healthcheck.sh#L6

So i adapted the Dockerfile to do the same here.

This is for both postgress 15 and 17 as they share the same Dockerfile.