### PR TITLE
Fix Portainer connection upgrade

### DIFF
--- a/portainer/rootfs/etc/nginx/includes/proxy_params.conf
+++ b/portainer/rootfs/etc/nginx/includes/proxy_params.conf
@@ -7,9 +7,7 @@ proxy_send_timeout          30m;
 proxy_max_temp_file_size    0;
 
 proxy_set_header Accept-Encoding "";
-proxy_set_header Connection $connection_upgrade;
 proxy_set_header Origin $http_origin;
-proxy_set_header Upgrade $http_upgrade;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $scheme;
 proxy_set_header X-NginX-Proxy true;

--- a/portainer/rootfs/etc/nginx/templates/ingress.gtpl
+++ b/portainer/rootfs/etc/nginx/templates/ingress.gtpl
@@ -8,13 +8,10 @@ server {
   location / {
     proxy_pass {{ .protocol }}://backend/;
     resolver 127.0.0.11 valid=180s;
-    proxy_set_header Host $http_host;
-    proxy_set_header X-Forwarded-Host $http_host;
-  }
 
-  location /api/websocket/ {
-    proxy_pass {{ .protocol }}://backend/api/websocket/;
-    resolver 127.0.0.11 valid=180s;
+    # These headers must be under location section, if they moved into proxy_params.conf, even if this is valid, they won't work
+    proxy_set_header Connection $connection_upgrade;
+    proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-Host $http_host;
   }


### PR DESCRIPTION
Exec-ing into a container is still broken, we get the black terminal, but no prompt, because we have to copy Connection and Upgrade headers into the location section also, like the Host headers. I have no clue why... I haven't noticed this a few hours ago, I was happy with the black terminal "window", haven't noticed the missing prompt. :/

Additionally the 2nd location section for the websocket api is removed, it is unnecessary, it is identical with the first, I assume it was there, because originally it differed from the "/" location only by these upgrade headers, and yes, it is for the websockets, though doesn't harm in case of the whole site.

Related #1877