### PR TITLE
fix: use default branch in updater

### DIFF
--- a/addons_updater/rootfs/etc/cont-init.d/99-run.sh
+++ b/addons_updater/rootfs/etc/cont-init.d/99-run.sh
@@ -12,7 +12,7 @@ if bashio::config.true "dry_run"; then
     bashio::log.warning "Dry run mode : on"
 fi
 
-bashio::log.info "Checking status of referenced repositoriess..."
+bashio::log.info "Checking status of referenced repositories..."
 VERBOSE=$(bashio::config 'verbose')
 
 #Defining github value
@@ -42,7 +42,8 @@ if [ ! -d "/data/$BASENAME" ]; then
 else
     LOGINFO="... updating ${REPOSITORY}" && if [ "$VERBOSE" = true ]; then bashio::log.info "$LOGINFO"; fi
     cd "/data/$BASENAME" || exit
-    git pull --rebase origin > /dev/null || git reset --hard origin/master > /dev/null
+    DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
+    git pull --rebase origin > /dev/null || git reset --hard "origin/${DEFAULT_BRANCH}" > /dev/null
     git pull --rebase origin > /dev/null || (rm -r "/data/$BASENAME" && git clone "https://github.com/${REPOSITORY}")
 fi
 


### PR DESCRIPTION
## Summary
- resolve upstream repository default branch automatically in updater
- fix typo in repositories status log message

## Testing
- `shellcheck addons_updater/rootfs/etc/cont-init.d/99-run.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e04f8217c8325a063d3fd7cc6bee6