### PR TITLE
feat: update tandoor recipes to v2

### DIFF
--- a/tandoor_recipes/CHANGELOG.md
+++ b/tandoor_recipes/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0 (02-08-2025)
+
+- Update to latest version from TandoorRecipes/recipes (integrated nginx, removed armv7)
+
 ## 1.5.35 (28-06-2025)
 
 - Update to latest version from TandoorRecipes/recipes (changelog : https://github.com/TandoorRecipes/recipes/releases)

--- a/tandoor_recipes/CHANGELOG.md
+++ b/tandoor_recipes/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0 (02-08-2025)
+## 2.0.1 (02-08-2025)
 
 - Update to latest version from TandoorRecipes/recipes (integrated nginx, removed armv7)
 

--- a/tandoor_recipes/DOCS.md
+++ b/tandoor_recipes/DOCS.md
@@ -7,9 +7,7 @@ Required :
     "ALLOWED_HOSTS": "your system url", # You need to input your homeassistant urls (comma separated, without space) to allow ingress to work
     "DB_TYPE": "list(sqlite|postgresql_external)" # Type of database to use.
     "SECRET_KEY": "str", # Your secret key
-    "PORT": 9928 # By default, the webui is available on http://HAurl:9928. If you ever need to change the port, you should never do it within the app, but only through this option
     "Environment": 0|1 # 1 is debug mode, 0 is normal mode. You should run in normal mode unless actively developing.
-    "GUNICORN_MEDIA": 0|1 # 1 enables gunicorn media hosting. This is not recommended. You should use an nginx server to host your media - see docs.
 Optional :
     "POSTGRES_HOST": "str?", # Needed for postgresql_external
     "POSTGRES_PORT": "str?", # Needed for postgresql_external
@@ -18,6 +16,8 @@ Optional :
     "POSTGRES_DB": "str?" # Needed for postgresql_external
     "externalfiles_folder": "str?" # a folder that you want to map in to tandoor. Not needed as /share/ and /media/ are mapped. This folder will be created if it doesn't already exist.
 ```
+This add-on now uses Tandoor's integrated Nginx server and exposes port 80 (mapped to 9928 by default).
+
 ### Mariadb
 Mariadb is a popular addon in the home assistant community, however it is not supported by the Tandoor Recipes application.
 
@@ -29,11 +29,6 @@ This is the "Environment" setting.
 ### Authentication
 using external authentication. Tandoor Recipes supports this, but it is not implemented yet.
 
-### Gunicorn Media
-Disabling gunicorn media is a good idea, but needs a webserver running to host the media files. The webserver should map `/media/`.  
-See https://docs.tandoor.dev/install/docker/#nginx-vs-gunicorn for more information on this.  
-0 is gunicorn DISABLED - media won't work without an nginx webserver.  
-1 is gunicorn enabled - mesia will be hosted using gunicorn which is not recommended.
 
 ### External Recipe files
 

--- a/tandoor_recipes/build.json
+++ b/tandoor_recipes/build.json
@@ -1,8 +1,7 @@
 {
   "build_from": {
     "aarch64": "vabene1111/recipes:latest",
-    "amd64": "vabene1111/recipes:latest",
-    "armv7": "vabene1111/recipes:latest"
+    "amd64": "vabene1111/recipes:latest"
   },
   "codenotary": {
     "signer": "alexandrep.github@gmail.com"

--- a/tandoor_recipes/config.json
+++ b/tandoor_recipes/config.json
@@ -115,6 +115,6 @@
   "slug": "tandoor_recipes",
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "webui": "http://[HOST]:[PORT:80]"
 }

--- a/tandoor_recipes/config.json
+++ b/tandoor_recipes/config.json
@@ -1,8 +1,7 @@
 {
   "arch": [
     "aarch64",
-    "amd64",
-    "armv7"
+    "amd64"
   ],
   "codenotary": "alexandrep.github@gmail.com",
   "description": "recipe manager",
@@ -72,7 +71,6 @@
   "environment": {
     "DB_ENGINE": "django.db.backends.sqlite3",
     "DISABLE_INGRESS": "true",
-    "GUNICORN_MEDIA": "1",
     "POSTGRES_DB": "/config/addons_config/tandoor_recipes/recipes.db",
     "TRUSTED_PROXIES": "**"
   },
@@ -94,10 +92,10 @@
   "panel_icon": "mdi:silverware-fork-knife",
   "panel_title": "Tandoor Recipes",
   "ports": {
-    "8080/tcp": 9928
+    "80/tcp": 9928
   },
   "ports_description": {
-    "8080/tcp": "Web interface"
+    "80/tcp": "Web interface"
   },
   "schema": {
     "ALLOWED_HOSTS": "str?",
@@ -117,6 +115,6 @@
   "slug": "tandoor_recipes",
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "1.5.35",
-  "webui": "http://[HOST]:[PORT:8080]"
+  "version": "2.0.0",
+  "webui": "http://[HOST]:[PORT:80]"
 }

--- a/tandoor_recipes/updater.json
+++ b/tandoor_recipes/updater.json
@@ -1,9 +1,9 @@
 {
   "github_beta": false,
-  "last_update": "28-06-2025",
+  "last_update": "02-08-2025",
   "repository": "alexbelgium/hassio-addons",
   "slug": "tandoor_recipes",
   "source": "github",
   "upstream_repo": "TandoorRecipes/recipes",
-  "upstream_version": "1.5.35"
+  "upstream_version": "2.0.0"
 }

--- a/tandoor_recipes/updater.json
+++ b/tandoor_recipes/updater.json
@@ -5,5 +5,5 @@
   "slug": "tandoor_recipes",
   "source": "github",
   "upstream_repo": "TandoorRecipes/recipes",
-  "upstream_version": "2.0.0"
+  "upstream_version": "2.0.1"
 }


### PR DESCRIPTION
## Summary
- upgrade tandoor recipes addon to upstream v2.0.0
- expose web ui via integrated nginx on port 80
- build addon image from vabene1111/recipes:latest

## Testing
- `pre-commit run --files tandoor_recipes/build.json tandoor_recipes/config.json tandoor_recipes/updater.json tandoor_recipes/CHANGELOG.md tandoor_recipes/DOCS.md` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_688e5520c50c832581c49102ea512d97