### PR TITLE
mealie: limit nginx rewriting to fix recipe import

### DIFF
--- a/mealie/CHANGELOG.md
+++ b/mealie/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v3.0.2-3 (05-08-2025)
+- Prevent nginx from rewriting JSON responses to resolve recipe import errors
+
 ## v3.0.2-2 (25-07-2025)
 - Minor bugs fixed
 

--- a/mealie/config.json
+++ b/mealie/config.json
@@ -120,5 +120,5 @@
   "slug": "mealie",
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "v3.0.2-2"
+  "version": "v3.0.2-3"
 }

--- a/mealie/rootfs/etc/nginx/servers/ingress.conf
+++ b/mealie/rootfs/etc/nginx/servers/ingress.conf
@@ -31,7 +31,8 @@
       absolute_redirect off;
       proxy_redirect / %%ingress_entry%%/;
       sub_filter_once off;
-      sub_filter_types *;
+      # Limit rewriting to text-based responses to avoid corrupting JSON payloads
+      sub_filter_types text/html text/css application/javascript;
       sub_filter '"/api' '"%%ingress_entry%%/api';
       sub_filter '`/api' '`%%ingress_entry%%/api';
       sub_filter "'/api" "'%%ingress_entry%%/api";

--- a/mealie/updater.json
+++ b/mealie/updater.json
@@ -1,7 +1,7 @@
 {
   "github_beta": "true",
   "github_fulltag": "true",
-  "last_update": "25-07-2025",
+  "last_update": "05-08-2025",
   "paused": "false",
   "repository": "alexbelgium/hassio-addons",
   "slug": "mealie",


### PR DESCRIPTION
## Summary
- prevent nginx from rewriting JSON responses to stop recipe import errors
- bump mealie add-on to v3.0.2-3 and document the change

## Testing
- `nginx -t -c $(pwd)/mealie/rootfs/etc/nginx/nginx.conf` *(fails: invalid port in "%%interface%%:%%port%%" in ingress.conf)*

------
https://chatgpt.com/codex/tasks/task_e_68919a4c428483258a8cb412e3d6dc74