### PR TITLE
feat(collabora): expose env options and persist config

### DIFF
--- a/collabora/CHANGELOG.md
+++ b/collabora/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 25.04.4.2.2-5 (05-08-2025)
+- Expose additional Collabora environment options
+- Persist coolwsd.xml in /config and symlink original path
 ## 25.04.4.2.2-4 (05-08-2025)
 - Minor bugs fixed
 ## 25.04.4.2.2-3 (05-08-2025)

--- a/collabora/README.md
+++ b/collabora/README.md
@@ -30,6 +30,9 @@ Configure the add-on to allow access from your Nextcloud instance:
 
 - `domain`: Regex matching the Nextcloud host (for example `cloud\\.example\\.com`).
 - `username` and `password`: Optional credentials for the Collabora admin console.
+- `aliasgroup1`: Additional allowed hostnames for WOPI connections.
+- `dictionaries`: Space separated list of dictionary languages to install.
+- `extra_params`: Extra parameters passed to the Collabora start script.
 
 ### Custom Scripts and Environment Variables
 

--- a/collabora/config.json
+++ b/collabora/config.json
@@ -18,7 +18,10 @@
   "options": {
     "domain": "",
     "username": "",
-    "password": ""
+    "password": "",
+    "aliasgroup1": "",
+    "dictionaries": "",
+    "extra_params": ""
   },
   "ports": {
     "9980/tcp": 9980
@@ -30,9 +33,12 @@
     "domain": "str?",
     "username": "str?",
     "password": "password?",
+    "aliasgroup1": "str?",
+    "dictionaries": "str?",
+    "extra_params": "str?",
     "TZ": "str?"
   },
   "slug": "collabora",
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "25.04.4.2.2-4"
+  "version": "25.04.4.2.2-5"
 }

--- a/collabora/rootfs/etc/cont-init.d/99-run.sh
+++ b/collabora/rootfs/etc/cont-init.d/99-run.sh
@@ -17,5 +17,33 @@ if bashio::config.has_value 'password'; then
     export password
 fi
 
+if bashio::config.has_value 'aliasgroup1'; then
+    aliasgroup1="$(bashio::config 'aliasgroup1')"
+    export aliasgroup1
+fi
+
+if bashio::config.has_value 'dictionaries'; then
+    dictionaries="$(bashio::config 'dictionaries')"
+    export dictionaries
+fi
+
+if bashio::config.has_value 'extra_params'; then
+    extra_params="$(bashio::config 'extra_params')"
+    export extra_params
+fi
+
+COOL_CONFIG="/etc/coolwsd/coolwsd.xml"
+CONFIG_DEST="/config/coolwsd.xml"
+
+mkdir -p /config
+if [ ! -e "${CONFIG_DEST}" ]; then
+    mv "${COOL_CONFIG}" "${CONFIG_DEST}"
+    chown root:root "${CONFIG_DEST}"
+    chmod 644 "${CONFIG_DEST}"
+else
+    rm -f "${COOL_CONFIG}"
+fi
+ln -sf "${CONFIG_DEST}" "${COOL_CONFIG}"
+
 bashio::log.info "Starting Collabora Online..."
 su -s /bin/bash -c "/start-collabora-online.sh" "$(getent passwd 1001 | cut -d: -f1)"


### PR DESCRIPTION
## Summary
- expose aliasgroup1, dictionaries, and extra_params options
- store coolwsd.xml in /config and symlink original path

## Testing
- `shellcheck rootfs/etc/cont-init.d/99-run.sh`

------
https://chatgpt.com/codex/tasks/task_e_6892e7844e988325b2c48b34363bb77c