### PR TITLE
filebrowser: disable PCRE JIT to prevent crashes on some CPUs

### DIFF
--- a/filebrowser/CHANGELOG.md
+++ b/filebrowser/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.42.2-3 (10-08-2025)
+- Fix: disable PCRE JIT in Nginx to prevent crashes on some x86 systems
+
 ## 2.42.2-2 (09-08-2025)
 - Minor bugs fixed
 

--- a/filebrowser/config.json
+++ b/filebrowser/config.json
@@ -129,5 +129,5 @@
   "slug": "filebrowser",
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "2.42.2-2"
+  "version": "2.42.2-3"
 }

--- a/filebrowser/rootfs/etc/nginx/nginx.conf
+++ b/filebrowser/rootfs/etc/nginx/nginx.conf
@@ -12,7 +12,9 @@ pid /var/run/nginx.pid;
 worker_processes 1;
 
 # Enables the use of JIT for regular expressions to speed-up their processing.
-pcre_jit on;
+# Disabled for compatibility with CPUs that do not support PCRE JIT, which caused
+# crashes on some systems (see issue #1993).
+pcre_jit off;
 
 # Write error log to Hass.io add-on log.
 error_log /proc/1/fd/1 error;

--- a/filebrowser/updater.json
+++ b/filebrowser/updater.json
@@ -1,6 +1,6 @@
 {
   "github_beta": "true",
-  "last_update": "09-08-2025",
+  "last_update": "10-08-2025",
   "paused": false,
   "repository": "alexbelgium/hassio-addons",
   "slug": "filebrowser",


### PR DESCRIPTION
## Summary
- disable PCRE JIT in Nginx to avoid illegal instruction crashes on x86 systems without the required CPU features
- bump filebrowser addon version to 2.42.2-3

## Testing
- `pre-commit run --files filebrowser/CHANGELOG.md filebrowser/config.json filebrowser/rootfs/etc/nginx/nginx.conf filebrowser/updater.json` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_6898e773a46c8325a66c7a9d7870d21c