### PR TITLE
fix(sonarr): replace s6-test with test

### DIFF
--- a/sonarr/rootfs/etc/services.d/nginx/finish
+++ b/sonarr/rootfs/etc/services.d/nginx/finish
@@ -2,7 +2,7 @@
 # ==============================================================================
 # Take down the S6 supervision tree when Nginx fails
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
+if { test ${1} -ne 0 }
+if { test ${1} -ne 256 }
 
 s6-svscanctl -t /var/run/s6/services


### PR DESCRIPTION
## Summary
- use `test` instead of `s6-test` in nginx finish script to avoid missing binary error

## Testing
- `shellcheck sonarr/rootfs/etc/services.d/nginx/finish` *(fails: execlineb not supported)*

------
https://chatgpt.com/codex/tasks/task_e_6898ea89d5f08325b8c26b07bb5a75e2