### PR TITLE
birdnet-pi: fix standalone web terminal password

### DIFF
--- a/birdnet-pi/CHANGELOG.md
+++ b/birdnet-pi/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2025.08.10 (10-08-2025)
+- Fix web terminal password when running container standalone
+
 ## 2025.07.09 (04-08-2025)
 - Minor bugs fixed
 ## 2025.07.08 (04-08-2025)

--- a/birdnet-pi/README_standalone.md
+++ b/birdnet-pi/README_standalone.md
@@ -48,7 +48,7 @@ Ensure you have the following installed on your system:
          - ssl=false  # Enable/disable SSL
          - certfile=fullchain.pem  # SSL certificate file (located in /ssl/)
          - keyfile=privkey.pem  # SSL key file (located in /ssl/)
-         - pi_password=  # Optional: Set SSH user password
+         - pi_password=  # Optional: Set web terminal password for user `pi`
          - MQTT_HOST_manual=  # Optional: Manual MQTT host
          - MQTT_PASSWORD_manual=  # Optional: Manual MQTT password
          - MQTT_PORT_manual=  # Optional: Manual MQTT port
@@ -87,6 +87,7 @@ Ensure you have the following installed on your system:
    http://localhost:8001 # Or whatever port you have configured
    ```
    Replace `localhost` with your server's IP address if running on another machine.
+   When prompted for credentials in the web terminal, use the username `pi` and the password defined by `pi_password` (blank if unset).
 
 ## troubleshoot
 

--- a/birdnet-pi/rootfs/etc/cont-init.d/99-run.sh
+++ b/birdnet-pi/rootfs/etc/cont-init.d/99-run.sh
@@ -21,9 +21,17 @@ fi
 # Set password
 bashio::log.info "Setting password for the user pi"
 if bashio::config.has_value "pi_password"; then
-    echo "pi:$(bashio::config "pi_password")" | chpasswd
+    PI_PASSWORD="$(bashio::config "pi_password")"
+elif [[ -n "${pi_password:-}" ]]; then
+    PI_PASSWORD="${pi_password}"
 fi
-bashio::log.info "Password set successfully for user pi."
+
+if [[ -n "${PI_PASSWORD:-}" ]]; then
+    echo "pi:${PI_PASSWORD}" | chpasswd
+    bashio::log.info "Password set successfully for user pi."
+else
+    bashio::log.info "No password specified for user pi. Keeping existing password."
+fi
 
 # Use timezone defined in add-on options if available
 bashio::log.info "Setting timezone :"


### PR DESCRIPTION
## Summary
- ensure `pi_password` env variable sets web terminal password when running standalone
- document standalone login credentials
- update changelog

## Testing
- `shellcheck birdnet-pi/rootfs/etc/cont-init.d/99-run.sh`
- `markdownlint birdnet-pi/README_standalone.md` *(fails: descriptive link text, blank lines around lists and fences)*

------
https://chatgpt.com/codex/tasks/task_e_6898ecb2aef48325b28f843d17b47a6a