### PR TITLE
birdnet-pi: ensure pi user can access audio devices

### DIFF
--- a/birdnet-pi/CHANGELOG.md
+++ b/birdnet-pi/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2025.08.11 (11-08-2025)
+- Fix audio group to detect USB sound cards
+
 ## 2025.08.10 (10-08-2025)
 - Fix web terminal password when running container standalone
 

--- a/birdnet-pi/Dockerfile
+++ b/birdnet-pi/Dockerfile
@@ -110,8 +110,8 @@ RUN \
     # Give access to caddy for files owned by the user, to allow files modification
     groupmod -o -g 1000 caddy && usermod -o -u 1000 caddy && \
     \
-    # Give access to audio group
-    groupmod -o -g 1000 audio && usermod -aG audio "$USER" && \
+    # Give access to audio devices
+    usermod -aG audio "$USER" && \
     \
     # Ensure always pi is used
     grep -srl "/etc/passwd" "$HOME/BirdNET-Pi/" | while IFS= read -r file; do sed -i "s=/etc/passwd=/etc/passwd | head -1=g" "$file"; done && \

--- a/birdnet-pi/config.json
+++ b/birdnet-pi/config.json
@@ -121,6 +121,6 @@
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-pi",
   "usb": true,
-  "version": "2025.07.09",
+  "version": "2025.08.11",
   "video": true
 }


### PR DESCRIPTION
## Summary
- allow pi user to access the host audio group so USB sound cards are detected
- bump add-on version

## Testing
- `hadolint birdnet-pi/Dockerfile`
- `markdownlint birdnet-pi/CHANGELOG.md` *(fails: Headings and lists not surrounded by blank lines)*


------
https://chatgpt.com/codex/tasks/task_e_689978275d588325b8f95533bb171449