### PR TITLE
fix: parse OpenAI responses for triage

### DIFF
--- a/.github/workflows/ai-triage.yml
+++ b/.github/workflows/ai-triage.yml
@@ -83,6 +83,7 @@ jobs:
 
             const data = await res.json();
             const text = data.output_text
+              || data.output?.map(p => p.content?.map(c => c.text ?? '').join('')).join('\n')
               || data?.choices?.[0]?.message?.content
               || 'Thanks for opening this issue — we will take a look!';
 
@@ -161,7 +162,12 @@ jobs:
               core.setFailed(`OpenAI error ${res.status}: ${txt}`);
             } else {
               const data = await res.json();
-              const patch = (data.output_text || data?.choices?.[0]?.message?.content || '').trim();
+              const patch = (
+                data.output_text
+                || data.output?.map(p => p.content?.map(c => c.text ?? '').join('')).join('\n')
+                || data?.choices?.[0]?.message?.content
+                || ''
+              ).trim();
               return patch;
             }
 


### PR DESCRIPTION
## Summary
- fix AI triage workflow to read `output` content so issues receive full answers instead of a fallback
- ensure auto-fix PR generation also parses `output`

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 200}}}' .github/workflows/ai-triage.yml`


------
https://chatgpt.com/codex/tasks/task_e_689b921c5a3c832599ec5f3d58b18f07