### PR TITLE
portainer: fix ingress headers

### DIFF
--- a/portainer/CHANGELOG.md
+++ b/portainer/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.32.0-7 (13-08-2025)
+- Fix ingress by clearing conflicting security headers
+
 ## 2.32.0-6 (25-07-2025)
 - Update to latest version from portainer/portainer (changelog : https://github.com/portainer/portainer/releases)
 

--- a/portainer/config.json
+++ b/portainer/config.json
@@ -48,5 +48,5 @@
   "slug": "portainer",
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "2.32.0-6"
+  "version": "2.32.0-7"
 }

--- a/portainer/rootfs/etc/nginx/templates/ingress.gtpl
+++ b/portainer/rootfs/etc/nginx/templates/ingress.gtpl
@@ -5,6 +5,9 @@ server {
   include /etc/nginx/includes/proxy_params.conf;
   client_max_body_size 0;
 
+  proxy_hide_header X-Frame-Options;
+  proxy_hide_header Content-Security-Policy;
+  add_header X-Frame-Options "SAMEORIGIN";
   add_header Content-Security-Policy "frame-ancestors *";
 
   location / {

--- a/portainer/updater.json
+++ b/portainer/updater.json
@@ -1,6 +1,6 @@
 {
   "github_havingasset": "true",
-  "last_update": "25-07-2025",
+  "last_update": "13-08-2025",
   "repository": "alexbelgium/hassio-addons",
   "slug": "portainer",
   "source": "github",


### PR DESCRIPTION
## Summary
- remove upstream frame blocking headers so Portainer ingress works again

## Testing
- `jq empty portainer/config.json`
- `jq empty portainer/updater.json`
- `pre-commit run --files portainer/rootfs/etc/nginx/templates/ingress.gtpl portainer/config.json portainer/updater.json portainer/CHANGELOG.md` *(fails: `.pre-commit-config.yaml is not a file`)*
- `nginx -t -c $PWD/portainer/rootfs/etc/nginx/nginx.conf` *(fails: open() "/etc/nginx/includes/mime.types" failed)*

Fixes #2030

------
https://chatgpt.com/codex/tasks/task_e_689cd80bda4883259032749bd4174154