### PR TITLE
docs: document internal Scrutiny API domain

### DIFF
--- a/scrutiny/CHANGELOG.md
+++ b/scrutiny/CHANGELOG.md
@@ -1,4 +1,6 @@
-- Disable port by default for security purposes, it can be readded from the addon options. Ingress access is not affected @soosp
+## v0.8.1-10 (13-08-2025)
+- Disable port by default for security purposes; it can be readded from the addon options. Ingress access is not affected @soosp
+- Document internal domain name for accessing the REST API without exposing the port.
 
 ## v0.8.1-9 (14-11-2024)
 - Align behavior with other addons : map /addons_config/xxx-scrutiny to enable env injection or custom scripts

--- a/scrutiny/README.md
+++ b/scrutiny/README.md
@@ -96,12 +96,15 @@ The installation of this add-on is pretty straightforward and not different in c
 
 Integration with HA can be done with the [rest platform](https://www.home-assistant.io/integrations/rest) in configuration.yaml.
 
-Two types of api endpoints are available:
+The API is available on Home Assistant's internal network even when the port is not exposed. Use the add-on's internal
+domain name (`http://db21ed7f-scrutiny:8080`) to query it from Home Assistant or other add-ons. If you need to reach the API from your local network, expose the port in the add-on options and replace the domain with your Home Assistant IP address.
 
-- Summary data : http://YOURIP:ADDONPORT/api/summary
-- Detailed data : http://YOURIP:ADDONPORT/api/device/WWN/details
+Two types of API endpoints are available:
 
-For the detailed data, wmn can be found for each hdd within the scrutiny app. For example: http://192.168.178.23:8086/api/device/0x50014ee606c14537/details
+- Summary data: <http://db21ed7f-scrutiny:8080/api/summary>
+- Detailed data: <http://db21ed7f-scrutiny:8080/api/device/WWN/details>
+
+For the detailed data, wwn can be found for each HDD within the Scrutiny app. For example: <http://db21ed7f-scrutiny:8080/api/device/0x50014ee606c14537/details>
 
 Example to get data from the first hdd.
 
@@ -109,7 +112,7 @@ Example to get data from the first hdd.
 rest:
   - verify_ssl: false
     scan_interval: 60
-    resource: http://192.168.178.4:8086/api/device/0x57c35481f82a7a9c/details
+    resource: http://db21ed7f-scrutiny:8080/api/device/0x57c35481f82a7a9c/details
     sensor:
       - name: "HDD - WWN"
         value_template: "{{ value_json.data.smart_results[0].device_wwn }}"
@@ -151,6 +154,6 @@ rest:
 
 Create an issue on github, or ask on the [home assistant thread](https://community.home-assistant.io/t/home-assistant-addon-scrutiny-smart-dashboard/295747)
 
-https://github.com/alexbelgium/hassio-addons
+<https://github.com/alexbelgium/hassio-addons>
 
 [repository]: https://github.com/alexbelgium/hassio-addons

--- a/scrutiny/config.json
+++ b/scrutiny/config.json
@@ -120,5 +120,5 @@
   "slug": "scrutiny",
   "udev": true,
   "url": "https://github.com/AnalogJ/scrutiny",
-  "version": "v0.8.1-9"
+  "version": "v0.8.1-10"
 }


### PR DESCRIPTION
## Summary
- clarify that Scrutiny's REST API can be reached via its internal add-on domain `db21ed7f-scrutiny` without exposing a port
- note this in README and changelog
- bump Scrutiny add-on version to v0.8.1-10

## Testing
- `jq . scrutiny/config.json`
- `markdownlint scrutiny/README.md`


------
https://chatgpt.com/codex/tasks/task_e_689cd9024d588325856007813061139a