### PR TITLE
scrutiny: remove s6 dependency in finish script

### DIFF
--- a/.templates/ha_entrypoint.sh
+++ b/.templates/ha_entrypoint.sh
@@ -99,8 +99,11 @@ if $PID1; then
         sed -i "1s|^.*|#!$shebang|" "$runfile"
         # Replace s6-setuidgid calls with 'su' (bash-based) equivalents
         sed -i -E 's|^s6-setuidgid[[:space:]]+([a-zA-Z0-9._-]+)[[:space:]]+(.*)$|su -s /bin/bash \1 -c "\2"|g' "$runfile"
+        # Replace s6-svwait calls with bash-based waiting loops
+        sed -i -E 's|s6-svwait[[:space:]]+-d[[:space:]]+([^[:space:]]+)|bash -c '\''while [ -f \1/supervise/pid ]; do sleep 0.5; done'\''|g' "$runfile"
+        sed -i -E 's|s6-svwait[[:space:]]+-u[[:space:]]+([^[:space:]]+)|bash -c '\''until [ -f \1/supervise/pid ]; do sleep 0.5; done'\''|g' "$runfile"
         chmod +x "$runfile"
-        ( exec "$runfile" ) & true        
+        ( exec "$runfile" ) & true
     done
     shopt -u nullglob
 fi

--- a/scrutiny/CHANGELOG.md
+++ b/scrutiny/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.8.1-12 (16-08-2025)
+- Replace s6-based shutdown with standard command to avoid s6-svwait error
+
 ## v0.8.1-11 (15-08-2025)
 - Minor bugs fixed
 ## v0.8.1-10 (13-08-2025)

--- a/scrutiny/config.json
+++ b/scrutiny/config.json
@@ -120,5 +120,5 @@
   "slug": "scrutiny",
   "udev": true,
   "url": "https://github.com/AnalogJ/scrutiny",
-  "version": "v0.8.1-11"
+  "version": "v0.8.1-12"
 }

--- a/scrutiny/rootfs/etc/services.d/nginx/finish
+++ b/scrutiny/rootfs/etc/services.d/nginx/finish
@@ -1,8 +1,9 @@
-#!/usr/bin/execlineb -S0
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
 # ==============================================================================
-# Take down the S6 supervision tree when Nginx fails
+# Stop the container when Nginx fails
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
-
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 && "$1" -ne 256 ]]; then
+    bashio::log.error "Nginx exited with code $1"
+    kill -15 1
+fi


### PR DESCRIPTION
## Summary
- replace s6-based shutdown logic with standard bash to avoid `s6-svwait` errors
- bump scrutiny addon to v0.8.1-12
- convert `s6-svwait` calls in `ha_entrypoint.sh` template to portable bash loops

## Testing
- `shellcheck scrutiny/rootfs/etc/services.d/nginx/finish`
- `shellcheck .templates/ha_entrypoint.sh`
- `jq . scrutiny/config.json`


------
https://chatgpt.com/codex/tasks/task_e_689f543f9b108325bb51d78d70578567