### PR TITLE
feat(immich): add optional permission check skip

### DIFF
--- a/immich/CHANGELOG.md
+++ b/immich/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.138.0-1 (19-08-2025)
+- New option : skip_permissions_check to skip permissions check
 
 ## 1.138.0 (16-08-2025)
 - Update to latest version from imagegenius/docker-immich (changelog : https://github.com/imagegenius/docker-immich/releases)

--- a/immich/README.md
+++ b/immich/README.md
@@ -54,6 +54,7 @@ Webui can be found at `<your-ip>:8080`. PostgreSQL/MySQL can be either internal 
 | `DISABLE_MACHINE_LEARNING` | bool | `false` | Disable ML features |
 | `MACHINE_LEARNING_WORKERS` | int | `1` | Number of ML workers |
 | `MACHINE_LEARNING_WORKER_TIMEOUT` | int | `120` | ML worker timeout (seconds) |
+| `skip_permissions_check` | bool | `false` | Skip file permissions checking |
 
 ### Example Configuration
 

--- a/immich/config.json
+++ b/immich/config.json
@@ -138,7 +138,8 @@
     "data_location": "str",
     "library_location": "str?",
     "localdisks": "str?",
-    "networkdisks": "str?"
+    "networkdisks": "str?",
+    "skip_permissions_check": "bool?"
   },
   "services": [
     "mysql:want"

--- a/immich/rootfs/etc/cont-init.d/20-folders.sh
+++ b/immich/rootfs/etc/cont-init.d/20-folders.sh
@@ -52,11 +52,16 @@ mkdir -p "$REVERSE_GEOCODING_DUMP_DIRECTORY"
 
 if ! bashio::config.true "skip_permissions_check" && [ "${PUID:-0}" != "0" ] && [ "${PGID:-0}" != "0" ]; then
     echo "... setting permissions, this might take a long time. If it takes too long at each boot, you could instead activate skip_permissions_check in the addon options"
+    echo "..... $DATA_LOCATION"
+    chmod -R 755 "$DATA_LOCATION"
     chown -R "$PUID:$PGID" "$DATA_LOCATION"
-    chmod -R 777 "$DATA_LOCATION"
+    echo "..... /photos"
     chown "$PUID:$PGID" /photos
+    echo "..... $MACHINE_LEARNING_CACHE_FOLDER"
     chown -R "$PUID:$PGID" "$MACHINE_LEARNING_CACHE_FOLDER"
+    echo "..... $REVERSE_GEOCODING_DUMP_DIRECTORY"
     chown -R "$PUID:$PGID" "$REVERSE_GEOCODING_DUMP_DIRECTORY"
+    echo "..... /data"
     chown -R "$PUID:$PGID" /data
 elif bashio::config.true "skip_permissions_check"; then
     bashio::log.warning "... skipping permissions check as 'skip_permissions_check' is set"

--- a/immich/rootfs/etc/cont-init.d/20-folders.sh
+++ b/immich/rootfs/etc/cont-init.d/20-folders.sh
@@ -41,21 +41,26 @@ printf "%s\n" "IMMICH_MEDIA_LOCATION=\"$DATA_LOCATION\"" >> ~/.bashrc
 echo "... check $DATA_LOCATION folder exists"
 mkdir -p "$DATA_LOCATION"
 
-echo "... setting permissions"
-chown -R "$PUID":"$PGID" "$DATA_LOCATION"
-
 echo "... correcting official script"
 # shellcheck disable=SC2013
 for file in $(grep -sril '/photos' /etc); do sed -i "s|/photos|$DATA_LOCATION|g" "$file"; done
 if [ -f /photos ]; then rm -r /photos; fi
 ln -sf "$DATA_LOCATION" /photos
-chown "$PUID":"$PGID" /photos
 
 mkdir -p "$MACHINE_LEARNING_CACHE_FOLDER"
 mkdir -p "$REVERSE_GEOCODING_DUMP_DIRECTORY"
-chown -R "$PUID":"$PGID" "$MACHINE_LEARNING_CACHE_FOLDER"
-chown -R "$PUID":"$PGID" "$REVERSE_GEOCODING_DUMP_DIRECTORY"
-chown -R "$PUID":"$PGID" /data
+
+if ! bashio::config.true "skip_permissions_check" && [ "${PUID:-0}" != "0" ] && [ "${PGID:-0}" != "0" ]; then
+    echo "... setting permissions, this might take a long time. If it takes too long at each boot, you could instead activate skip_permissions_check in the addon options"
+    chown -R "$PUID:$PGID" "$DATA_LOCATION"
+    chmod -R 777 "$DATA_LOCATION"
+    chown "$PUID:$PGID" /photos
+    chown -R "$PUID:$PGID" "$MACHINE_LEARNING_CACHE_FOLDER"
+    chown -R "$PUID:$PGID" "$REVERSE_GEOCODING_DUMP_DIRECTORY"
+    chown -R "$PUID:$PGID" /data
+elif bashio::config.true "skip_permissions_check"; then
+    bashio::log.warning "... skipping permissions check as 'skip_permissions_check' is set"
+fi
 chmod 755 /data
 
 ####################

--- a/immich_cuda/CHANGELOG.md
+++ b/immich_cuda/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.138.0-1 (19-08-2025)
+- New option : skip_permissions_check to skip permissions check
 
 ## 1.138.0 (16-08-2025)
 - Update to latest version from imagegenius/docker-immich (changelog : https://github.com/imagegenius/docker-immich/releases)

--- a/immich_cuda/README.md
+++ b/immich_cuda/README.md
@@ -60,6 +60,7 @@ Webui can be found at `<your-ip>:8080`. PostgreSQL can be either internal or ext
 | `DISABLE_MACHINE_LEARNING` | bool | `false` | Disable ML features (not recommended for CUDA variant) |
 | `MACHINE_LEARNING_WORKERS` | int | `1` | Number of ML workers (can be increased with CUDA) |
 | `MACHINE_LEARNING_WORKER_TIMEOUT` | int | `120` | ML worker timeout (seconds) |
+| `skip_permissions_check` | bool | `false` | Skip file permissions checking |
 
 ### Example Configuration
 

--- a/immich_cuda/config.json
+++ b/immich_cuda/config.json
@@ -137,7 +137,8 @@
     "data_location": "str",
     "library_location": "str?",
     "localdisks": "str?",
-    "networkdisks": "str?"
+    "networkdisks": "str?",
+    "skip_permissions_check": "bool?"
   },
   "services": [
     "mysql:want"

--- a/immich_noml/CHANGELOG.md
+++ b/immich_noml/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.138.0-1 (19-08-2025)
+- New option : skip_permissions_check to skip permissions check
 
 ## 1.138.0 (16-08-2025)
 - Update to latest version from imagegenius/docker-immich (changelog : https://github.com/imagegenius/docker-immich/releases)

--- a/immich_noml/README.md
+++ b/immich_noml/README.md
@@ -64,6 +64,7 @@ Webui can be found at `<your-ip>:8080`. PostgreSQL can be either internal or ext
 | `DISABLE_MACHINE_LEARNING` | bool | `false` | Disable ML features (recommended for NoML variant) |
 | `MACHINE_LEARNING_WORKERS` | int | `1` | Number of ML workers (keep at 1 for NoML) |
 | `MACHINE_LEARNING_WORKER_TIMEOUT` | int | `120` | ML worker timeout (seconds) |
+| `skip_permissions_check` | bool | `false` | Skip file permissions checking |
 
 ### Example Configuration
 

--- a/immich_noml/config.json
+++ b/immich_noml/config.json
@@ -138,7 +138,8 @@
     "data_location": "str",
     "library_location": "str?",
     "localdisks": "str?",
-    "networkdisks": "str?"
+    "networkdisks": "str?",
+    "skip_permissions_check": "bool?"
   },
   "services": [
     "mysql:want"

--- a/immich_openvino/CHANGELOG.md
+++ b/immich_openvino/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.138.0-1 (19-08-2025)
+- New option : skip_permissions_check to skip permissions check
 
 ## 1.138.0 (16-08-2025)
 - Update to latest version from imagegenius/docker-immich (changelog : https://github.com/imagegenius/docker-immich/releases)

--- a/immich_openvino/README.md
+++ b/immich_openvino/README.md
@@ -61,6 +61,7 @@ Webui can be found at `<your-ip>:8080`. PostgreSQL can be either internal or ext
 | `DISABLE_MACHINE_LEARNING` | bool | `false` | Disable ML features (not recommended for OpenVINO variant) |
 | `MACHINE_LEARNING_WORKERS` | int | `1` | Number of ML workers (can be increased with OpenVINO) |
 | `MACHINE_LEARNING_WORKER_TIMEOUT` | int | `120` | ML worker timeout (seconds) |
+| `skip_permissions_check` | bool | `false` | Skip file permissions checking |
 
 ### Example Configuration
 

--- a/immich_openvino/config.json
+++ b/immich_openvino/config.json
@@ -137,7 +137,8 @@
     "data_location": "str",
     "library_location": "str?",
     "localdisks": "str?",
-    "networkdisks": "str?"
+    "networkdisks": "str?",
+    "skip_permissions_check": "bool?"
   },
   "services": [
     "mysql:want"


### PR DESCRIPTION
## Summary
- allow skipping permission fixes with `skip_permissions_check` option
- warn that permission setting may take a long time and suggest enabling `skip_permissions_check` if startup is slow

## Testing
- `shellcheck immich/rootfs/etc/cont-init.d/20-folders.sh`
- `jq empty immich/config.json immich_cuda/config.json immich_noml/config.json immich_openvino/config.json`


------
https://chatgpt.com/codex/tasks/task_e_68a415b0286c8325a3444bcf0e09633d