### PR TITLE
chore: update immich to 1.138.1

### DIFF
--- a/immich/CHANGELOG.md
+++ b/immich/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.138.1 (19-08-2025)
+- Update to latest version from imagegenius/docker-immich (changelog : https://github.com/imagegenius/docker-immich/releases)
+
 ## 1.138.0-1 (19-08-2025)
 - New option : skip_permissions_check to skip permissions check
 

--- a/immich/config.json
+++ b/immich/config.json
@@ -148,7 +148,7 @@
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
   "usb": true,
-  "version": "1.138.0-2",
+  "version": "1.138.1",
   "video": true,
   "webui": "http://[HOST]:[PORT:8080]"
 }

--- a/immich/updater.json
+++ b/immich/updater.json
@@ -5,5 +5,5 @@
   "slug": "immich",
   "source": "github",
   "upstream_repo": "imagegenius/docker-immich",
-  "upstream_version": "1.138.0"
+  "upstream_version": "1.138.1"
 }

--- a/immich_cuda/CHANGELOG.md
+++ b/immich_cuda/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.138.1 (19-08-2025)
+- Update to latest version from imagegenius/docker-immich (changelog : https://github.com/imagegenius/docker-immich/releases)
+
 ## 1.138.0-1 (19-08-2025)
 - New option : skip_permissions_check to skip permissions check
 

--- a/immich_cuda/config.json
+++ b/immich_cuda/config.json
@@ -147,7 +147,7 @@
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
   "usb": true,
-  "version": "1.138.0",
+  "version": "1.138.1",
   "video": true,
   "webui": "http://[HOST]:[PORT:8080]"
 }

--- a/immich_cuda/updater.json
+++ b/immich_cuda/updater.json
@@ -5,5 +5,5 @@
   "slug": "immich",
   "source": "github",
   "upstream_repo": "imagegenius/docker-immich",
-  "upstream_version": "1.138.0"
+  "upstream_version": "1.138.1"
 }

--- a/immich_noml/CHANGELOG.md
+++ b/immich_noml/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.138.1 (19-08-2025)
+- Update to latest version from imagegenius/docker-immich (changelog : https://github.com/imagegenius/docker-immich/releases)
+
 ## 1.138.0-1 (19-08-2025)
 - New option : skip_permissions_check to skip permissions check
 

--- a/immich_noml/config.json
+++ b/immich_noml/config.json
@@ -148,7 +148,7 @@
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
   "usb": true,
-  "version": "1.138.0",
+  "version": "1.138.1",
   "video": true,
   "webui": "http://[HOST]:[PORT:8080]"
 }

--- a/immich_noml/updater.json
+++ b/immich_noml/updater.json
@@ -5,5 +5,5 @@
   "slug": "immich",
   "source": "github",
   "upstream_repo": "imagegenius/docker-immich",
-  "upstream_version": "1.138.0"
+  "upstream_version": "1.138.1"
 }

--- a/immich_openvino/CHANGELOG.md
+++ b/immich_openvino/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.138.1 (19-08-2025)
+- Update to latest version from imagegenius/docker-immich (changelog : https://github.com/imagegenius/docker-immich/releases)
+
 ## 1.138.0-1 (19-08-2025)
 - New option : skip_permissions_check to skip permissions check
 

--- a/immich_openvino/config.json
+++ b/immich_openvino/config.json
@@ -147,7 +147,7 @@
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
   "usb": true,
-  "version": "1.138.0",
+  "version": "1.138.1",
   "video": true,
   "webui": "http://[HOST]:[PORT:8080]"
 }

--- a/immich_openvino/updater.json
+++ b/immich_openvino/updater.json
@@ -5,5 +5,5 @@
   "slug": "immich",
   "source": "github",
   "upstream_repo": "imagegenius/docker-immich",
-  "upstream_version": "1.138.0"
+  "upstream_version": "1.138.1"
 }


### PR DESCRIPTION
## Summary
- bump immich base addons to 1.138.1

## Testing
- `jq . immich/config.json`
- `jq . immich/updater.json`
- `jq . immich_cuda/config.json`
- `jq . immich_cuda/updater.json`
- `jq . immich_noml/config.json`
- `jq . immich_noml/updater.json`
- `jq . immich_openvino/config.json`
- `jq . immich_openvino/updater.json`
- `markdownlint immich/CHANGELOG.md immich_cuda/CHANGELOG.md immich_noml/CHANGELOG.md immich_openvino/CHANGELOG.md` *(fails: Headings should be surrounded by blank lines, Lists should be surrounded by blank lines, Bare URL used)*

------
https://chatgpt.com/codex/tasks/task_e_68a43bafefb883258cb301ce88d602fa