### PR TITLE
Fix open PR merge step in BirdNET-Pi Dockerfile

### DIFF
--- a/birdnet-pi/Dockerfile
+++ b/birdnet-pi/Dockerfile
@@ -87,7 +87,7 @@ RUN \
     # Use my repository
     sed -i "s|Nachtzuster|alexbelgium|g" /newinstaller.sh && \
     # Install open PR
-    sed -i '/^git clone/a for pr in $(curl -s https://api.github.com/repos/alexbelgium/BirdNET-Pi/pulls?state=open | jq -r ".[].number"); do echo "Merging PR #$pr" && git fetch origin pull/$pr/merge:pr-$pr && git merge --no-ff -m "Merge PR #$pr" pr-$pr || { echo "Skipping PR #$pr"; git merge --abort || true; }; done' /newinstaller.sh && \
+    sed -i '/^git clone/a for pr in $(curl -s https://api.github.com/repos/alexbelgium/BirdNET-Pi/pulls?state=open | jq -r ".[].number"); do echo "Merging PR #$pr" && git -C "$HOME/BirdNET-Pi" fetch origin pull/$pr/merge:pr-$pr && git -C "$HOME/BirdNET-Pi" merge --no-ff -m "Merge PR #$pr" pr-$pr || { echo "Skipping PR #$pr"; git -C "$HOME/BirdNET-Pi" merge --abort || true; }; done' /newinstaller.sh && \
     # Avoid rebooting at end of installation
     sed -i "/reboot/d" /newinstaller.sh && \
     # Use apt-get as without user action


### PR DESCRIPTION
## Summary
- ensure BirdNET-Pi installer merges open PRs from the correct repository

## Testing
- `hadolint birdnet-pi/Dockerfile`


------
https://chatgpt.com/codex/tasks/task_e_68a4c2abfac883258b7432242359ea76