### PR TITLE
fix(calibre): use https port

### DIFF
--- a/calibre/CHANGELOG.md
+++ b/calibre/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 8.8.0-3 (22-08-2025)
+- Switch desktop GUI to HTTPS for ingress
+
 ## 8.8.0-2 (12-08-2025)
 - Minor bugs fixed
 

--- a/calibre/config.json
+++ b/calibre/config.json
@@ -78,6 +78,7 @@
   },
   "image": "ghcr.io/alexbelgium/calibre-{arch}",
   "ingress": true,
+  "ingress_port": 8181,
   "init": false,
   "map": [
     "media:rw",
@@ -94,15 +95,13 @@
   "panel_admin": false,
   "panel_icon": "mdi:book-multiple",
   "ports": {
-    "8080/tcp": 8080,
+    "8181/tcp": 8181,
     "8081/tcp": 8081,
-    "8181/tcp": null,
     "9090/tcp": 9090
   },
   "ports_description": {
-    "8080/tcp": "Calibre desktop gui",
+    "8181/tcp": "Calibre desktop gui (https)",
     "8081/tcp": "Calibre webserver gui, to be enabled within the desktop gui",
-    "8181/tcp": "Calibre https webserver gui, to be enabled within the desktop gui",
     "9090/tcp": "Calibre wireless connection, to be enabled within the desktop gui"
   },
   "privileged": [
@@ -125,6 +124,6 @@
   "slug": "calibre",
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons/tree/master/calibre",
-  "version": "8.8.0-2",
+  "version": "8.8.0-3",
   "video": true
 }

--- a/calibre/rootfs/etc/cont-init.d/90-ingress.sh
+++ b/calibre/rootfs/etc/cont-init.d/90-ingress.sh
@@ -16,6 +16,8 @@ mv tmpfile "${NGINX_CONFIG}"
 sed -i '/listen \[::\]/d' "${NGINX_CONFIG}"
 # Add ingress parameters
 sed -i "s|3000|$(bashio::addon.ingress_port)|g" "${NGINX_CONFIG}"
+sed -i 's|proxy_pass http://|proxy_pass https://|g' "${NGINX_CONFIG}"
+sed -i '/proxy_pass/a proxy_ssl_verify off;' "${NGINX_CONFIG}"
 sed -i '/proxy_buffering/a proxy_set_header Accept-Encoding "";' "${NGINX_CONFIG}"
 sed -i '/proxy_buffering/a sub_filter_once off;' "${NGINX_CONFIG}"
 sed -i '/proxy_buffering/a sub_filter_types *;' "${NGINX_CONFIG}"


### PR DESCRIPTION
## Summary
- switch calibre desktop GUI to HTTPS port 8181 for ingress
- proxy via nginx using HTTPS upstream
- bump to version 8.8.0-3 and document in changelog

## Testing
- `shellcheck calibre/rootfs/etc/cont-init.d/90-ingress.sh`
- `jq . calibre/config.json`


------
https://chatgpt.com/codex/tasks/task_e_68a80ecd1cbc83259a816b542292e58b