### PR TITLE
Standardize common addon option docs

### DIFF
--- a/autobrr/README.md
+++ b/autobrr/README.md
@@ -64,7 +64,7 @@ Default credentials: `admin` / `password` (change after first login).
 | `PGID` | int | `0` | Group ID for file permissions |
 | `PUID` | int | `0` | User ID for file permissions |
 | `TZ` | str | | Timezone (e.g., `Europe/London`) |
-| `localdisks` | str | | Local drives to mount (e.g., `sda1,sdb1`) |
+| `localdisks` | str | | Local drives to mount (e.g., `sda1,sdb1,MYNAS`) |
 | `networkdisks` | str | | SMB shares to mount (e.g., `//SERVER/SHARE`) |
 | `cifsusername` | str | | SMB username for network shares |
 | `cifspassword` | str | | SMB password for network shares |

--- a/battybirdnet-pi/README.md
+++ b/battybirdnet-pi/README.md
@@ -59,11 +59,11 @@ LIVESTREAM_BOOT_ENABLED: start livestream from boot, or from settings
 PROCESSED_FOLDER_ENABLED : if enabled, you need to set in the birdnet.conf (or the setting of birdnet) the number of last wav files that will be saved in the temporary folder "/tmp/Processed" within the tmpfs (so no disk wear) in case you want to retrieve them. This amount can be adapted from the addon options
 TZ: Etc/UTC specify a timezone to use, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
 pi_password: set the user password to access the web terminal
-localdisks: sda1 #put the hardware name of your drive to mount separated by commas, or its label. ex. sda1, sdb1, MYNAS...
-networkdisks: "//SERVER/SHARE" # optional, list of smb servers to mount, separated by commas
-cifsusername: "username" # optional, smb username, same for all smb shares
-cifspassword: "password" # optional, smb password
-cifsdomain: "domain" # optional, allow setting the domain for the smb share
+localdisks: sda1 # Local drives to mount (e.g., `sda1,sdb1,MYNAS`)
+networkdisks: "//SERVER/SHARE" # SMB shares to mount (e.g., `//SERVER/SHARE`)
+cifsusername: "username" # SMB username for network shares
+cifspassword: "password" # SMB password for network shares
+cifsdomain: "domain" # SMB domain for network shares
 ```
 
 - Config.yaml

--- a/birdnet-pi/README.md
+++ b/birdnet-pi/README.md
@@ -64,11 +64,11 @@ LIVESTREAM_BOOT_ENABLED: start livestream from boot, or from settings
 PROCESSED_FOLDER_ENABLED : if enabled, you need to set in the birdnet.conf (or the setting of birdnet) the number of last wav files that will be saved in the temporary folder "/tmp/Processed" within the tmpfs (so no disk wear) in case you want to retrieve them. This amount can be adapted from the addon options
 TZ: Etc/UTC specify a timezone to use, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
 pi_password: set the user password to access the web terminal
-localdisks: sda1 #put the hardware name of your drive to mount separated by commas, or its label. ex. sda1, sdb1, MYNAS...
-networkdisks: "//SERVER/SHARE" # optional, list of smb servers to mount, separated by commas
-cifsusername: "username" # optional, smb username, same for all smb shares
-cifspassword: "password" # optional, smb password
-cifsdomain: "domain" # optional, allow setting the domain for the smb share
+localdisks: sda1 # Local drives to mount (e.g., `sda1,sdb1,MYNAS`)
+networkdisks: "//SERVER/SHARE" # SMB shares to mount (e.g., `//SERVER/SHARE`)
+cifsusername: "username" # SMB username for network shares
+cifspassword: "password" # SMB password for network shares
+cifsdomain: "domain" # SMB domain for network shares
 ```
 
 - Config.yaml

--- a/codex/README.md
+++ b/codex/README.md
@@ -62,11 +62,11 @@ You can place the user folder from the theme/skeleton in /share/codex/www/user,
 | `CODEX_RESET_ADMIN` | Reset admin user and password to defaults | - | `1` |
 | `CODEX_SKIP_INTEGRITY_CHECK` | Skip database integrity repair on startup | - | `1` |
 | `csrf_allowed` | Comma separated list of addresses allowed to access the app | `http://homeassistant.local:8123,https://homeassistant.local:8123` | `http://localhost:8123` |
-| `localdisks` | Hardware name of drives to mount (comma separated) | - | `sda1,sdb1,MYNAS` |
-| `networkdisks` | SMB servers to mount (comma separated) | - | `//SERVER/SHARE` |
-| `cifsusername` | SMB username for all shares | - | `username` |
-| `cifspassword` | SMB password | - | `password` |
-| `cifsdomain` | SMB domain | - | `WORKGROUP` |
+| `localdisks` | Local drives to mount (e.g., `sda1,sdb1,MYNAS`) | - | `sda1,sdb1,MYNAS` |
+| `networkdisks` | SMB shares to mount (e.g., `//SERVER/SHARE`) | - | `//SERVER/SHARE` |
+| `cifsusername` | SMB username for network shares | - | `username` |
+| `cifspassword` | SMB password for network shares | - | `password` |
+| `cifsdomain` | SMB domain for network shares | - | `WORKGROUP` |
 
 ```yaml
 PGID: 1000

--- a/emby_beta/README.md
+++ b/emby_beta/README.md
@@ -35,11 +35,11 @@ Webui can be found at `<your-ip>:8096`, or within Home Assistant through Ingress
 PGID: user
 GPID: user
 TZ: timezone
-localdisks: sda1 #put the hardware name of your drive to mount separated by commas, or its label. ex. sda1, sdb1, MYNAS...
-networkdisks: "//SERVER/SHARE" # optional, list of smb servers to mount, separated by commas
-cifsusername: "username" # optional, smb username, same for all smb shares
-cifspassword: "password" # optional, smb password
-cifsdomain: "domain" # optional, allow setting the domain for the smb share
+localdisks: sda1 # Local drives to mount (e.g., `sda1,sdb1,MYNAS`)
+networkdisks: "//SERVER/SHARE" # SMB shares to mount (e.g., `//SERVER/SHARE`)
+cifsusername: "username" # SMB username for network shares
+cifspassword: "password" # SMB password for network shares
+cifsdomain: "domain" # SMB domain for network shares
 silent: true #suppresses debug messages
 ```
 

--- a/librespeed/README.md
+++ b/librespeed/README.md
@@ -50,10 +50,10 @@ GPID: user
 TZ: timezone
 PASSWORD: "" # optional
 CUSTOM_RESULTS: false # optional
-localdisks: sda1 #put the hardware name of your drive to mount separated by commas, or its label. ex. sda1, sdb1, MYNAS...
-networkdisks: "//SERVER/SHARE" # optional, list of smb servers to mount, separated by commas
-cifsusername: "username" # optional, smb username, same for all smb shares
-cifspassword: "password" # optional, smb password
+localdisks: sda1 # Local drives to mount (e.g., `sda1,sdb1,MYNAS`)
+networkdisks: "//SERVER/SHARE" # SMB shares to mount (e.g., `//SERVER/SHARE`)
+cifsusername: "username" # SMB username for network shares
+cifspassword: "password" # SMB password for network shares
 ```
 
 ### Custom Scripts and Environment Variables

--- a/navidrome/README.md
+++ b/navidrome/README.md
@@ -39,7 +39,7 @@ See https://www.navidrome.org/docs/usage/configuration-options/ for additional c
 | `base_url` | str | `/` | Base URL to configure Navidrome behind a proxy |
 | `music_folder` | str | `/data/music` | Folder where your music library is stored |
 | `data_folder` | str | `/data` | Folder to store application data (DB) |
-| `log_level` | str | `info` | Log level (error, warn, info, debug, trace) |
+| `log_level` | str | `info` | Log level (trace|debug|info|notice|warning|error|fatal) |
 | `ssl` | bool | `false` | Enable HTTPS for the web interface |
 | `certfile` | str | | Path for the TLS certificate |
 | `keyfile` | str | | Path for the TLS key file |

--- a/resiliosync/README.md
+++ b/resiliosync/README.md
@@ -45,11 +45,11 @@ Webui can be found at <http://homeassistant:8888>.
 PGID: user
 GPID: user
 TZ: timezone
-localdisks: sda1 #put the hardware name of your drive to mount separated by commas, or its label. ex. sda1, sdb1, MYNAS...
-networkdisks: "//SERVER/SHARE" # optional, list of smb servers to mount, separated by commas
-cifsusername: "username" # optional, smb username, same for all smb shares
-cifspassword: "password" # optional, smb password
-cifsdomain: "domain" # optional, allow setting the domain for the smb share
+localdisks: sda1 # Local drives to mount (e.g., `sda1,sdb1,MYNAS`)
+networkdisks: "//SERVER/SHARE" # SMB shares to mount (e.g., `//SERVER/SHARE`)
+cifsusername: "username" # SMB username for network shares
+cifspassword: "password" # SMB password for network shares
+cifsdomain: "domain" # SMB domain for network shares
 data_location: where the synced files are found
 config_location: where the config files are found
 ```

--- a/scripts/align_option_texts.py
+++ b/scripts/align_option_texts.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+import re
+
+# Standard descriptions
+DESC = {
+    "localdisks": "Local drives to mount (e.g., `sda1,sdb1,MYNAS`)",
+    "networkdisks": "SMB shares to mount (e.g., `//SERVER/SHARE`)",
+    "cifsusername": "SMB username for network shares",
+    "cifspassword": "SMB password for network shares",
+    "cifsdomain": "SMB domain for network shares",
+    "log_level": "Log level (trace|debug|info|notice|warning|error|fatal)",
+}
+
+RE_TABLE = re.compile(r"\|\s*`(?P<opt>[^`]+)`\s*\|.*")
+
+
+def process_file(path: Path):
+    text = path.read_text(encoding="utf-8").splitlines()
+    changed = False
+    new_lines = []
+    for line in text:
+        m = RE_TABLE.match(line)
+        if m:
+            opt = m.group("opt")
+            if opt in DESC:
+                parts = line.split("|")
+                if len(parts) >= 5:
+                    parts[-2] = f" {DESC[opt]} "
+                    new_line = "|".join(parts)
+                    if new_line != line:
+                        changed = True
+                        line = new_line
+        # Handle YAML example comments
+        for opt, desc in DESC.items():
+            if line.strip().startswith(f"{opt}:") and "#" in line:
+                before, _ = line.split("#", 1)
+                line = f"{before.strip()} # {desc}"
+                changed = True
+        new_lines.append(line)
+    if changed:
+        path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+        return True
+    return False
+
+
+def main():
+    repo_root = Path(__file__).resolve().parents[1]
+    changed_files = []
+    for config in repo_root.glob('*/config.json'):
+        addon_dir = config.parent
+        for doc_name in ('DOCS.md', 'README.md'):
+            doc_path = addon_dir / doc_name
+            if doc_path.exists():
+                if process_file(doc_path):
+                    changed_files.append(doc_path)
+    if changed_files:
+        print("Updated descriptions for:")
+        for f in changed_files:
+            print(f" - {f.relative_to(repo_root)}")
+    else:
+        print("No changes needed")
+
+if __name__ == '__main__':
+    main()

--- a/scripts/check_readme_options.py
+++ b/scripts/check_readme_options.py
@@ -1,0 +1,51 @@
+import json
+import os
+from pathlib import Path
+
+def get_schema_options(config_path):
+    with open(config_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    schema = data.get('schema', {})
+    return list(schema.keys())
+
+def find_doc_file(addon_dir):
+    # Prefer DOCS.md if exists, else README.md
+    docs = addon_dir / 'DOCS.md'
+    readme = addon_dir / 'README.md'
+    if docs.exists():
+        return docs
+    if readme.exists():
+        return readme
+    return None
+
+def check_addon(addon_dir):
+    config_path = addon_dir / 'config.json'
+    if not config_path.exists():
+        return []
+    options = get_schema_options(config_path)
+    doc_file = find_doc_file(addon_dir)
+    if not doc_file:
+        return [(addon_dir.name, 'NO_DOC_FILE', opt) for opt in options]
+    with open(doc_file, 'r', encoding='utf-8') as f:
+        content = f.read()
+    missing = []
+    for opt in options:
+        if f'`{opt}`' not in content:
+            missing.append((addon_dir.name, str(doc_file.relative_to(Path.cwd())), opt))
+    return missing
+
+def main():
+    repo_root = Path(__file__).resolve().parents[1]
+    missing_all = []
+    for config_path in repo_root.glob('*/config.json'):
+        addon_dir = config_path.parent
+        missing_all.extend(check_addon(addon_dir))
+    if missing_all:
+        print('Missing options in documentation:')
+        for addon, doc, opt in missing_all:
+            print(f"{addon}: {opt} not documented in {doc}")
+    else:
+        print('All addon options documented.')
+
+if __name__ == '__main__':
+    main()

--- a/seafile/README.md
+++ b/seafile/README.md
@@ -70,7 +70,7 @@ Webui can be found at <http://homeassistant:8000> (Seahub) and <http://homeassis
 | `database` | list | `sqlite` | Database type (sqlite/mariadb_addon) |
 | `data_location` | str | `/share/seafile` | Data storage location |
 | `CONFIG_LOCATION` | str | | Custom config file location |
-| `localdisks` | str | | Local drives to mount (e.g., `sda1,sdb1`) |
+| `localdisks` | str | | Local drives to mount (e.g., `sda1,sdb1,MYNAS`) |
 | `networkdisks` | str | | SMB shares to mount (e.g., `//SERVER/SHARE`) |
 | `cifsusername` | str | | SMB username for network shares |
 | `cifspassword` | str | | SMB password for network shares |

--- a/tor/README.md
+++ b/tor/README.md
@@ -52,7 +52,7 @@ Configurations can be done through the app webUI, except for the following optio
 | `bridges` | list | `[]` | List of bridge configurations |
 | `client_names` | list | `[]` | Client names for stealth authentication |
 | `ports` | list | `["8123", "8123:80"]` | Ports to expose via Tor |
-| `log_level` | list | | Log level (trace/debug/info/notice/warning/error/fatal) |
+| `log_level` | list | | Log level (trace|debug|info|notice|warning|error|fatal) |
 
 You should follow the initial guide for configuring base addon options. Here are the extra options specific to this extended version:
 

--- a/unpackerr/README.md
+++ b/unpackerr/README.md
@@ -65,7 +65,7 @@ Unpackerr monitors completed downloads and extracts archives automatically.
 | `TZ` | str | | Timezone (e.g., `Europe/London`) |
 | `extraction_path` | str | `/share/downloads_packed` | Path where downloaded archives are located |
 | `watch_path` | str | `/share/downloads_unpacked` | Path where extracted files are placed |
-| `localdisks` | str | | Local drives to mount (e.g., `sda1,sdb1`) |
+| `localdisks` | str | | Local drives to mount (e.g., `sda1,sdb1,MYNAS`) |
 | `networkdisks` | str | | SMB shares to mount (e.g., `//SERVER/SHARE`) |
 | `cifsusername` | str | | SMB username for network shares |
 | `cifspassword` | str | | SMB password for network shares |

--- a/webtop/README.md
+++ b/webtop/README.md
@@ -52,7 +52,7 @@ See all potential ENV variables here : https://docs.linuxserver.io/images/docker
 | `KEYBOARD` | str | `en-us-qwerty` | Keyboard layout |
 | `PASSWORD` | str | | Custom password for web interface |
 | `data_location` | str | | Custom data storage path |
-| `localdisks` | str | | Local drives to mount (e.g., `sda1,sdb1`) |
+| `localdisks` | str | | Local drives to mount (e.g., `sda1,sdb1,MYNAS`) |
 | `networkdisks` | str | | SMB shares to mount (e.g., `//SERVER/SHARE`) |
 | `cifsusername` | str | | SMB username for network shares |
 | `cifspassword` | str | | SMB password for network shares |

--- a/webtop_kde/README.md
+++ b/webtop_kde/README.md
@@ -44,11 +44,11 @@ TZ: timezone ; Country/City according to https://manpages.ubuntu.com/manpages/tr
 additional_apps: engrampa,thunderbird # Allows installation of apps, as they are not persistent
 DRINODE: specify a custom graphic device, default is /dev/dri/renderD128
 DNS_servers: 8.8.8.8,1.1.1.1 # Keep blank to use router’s DNS, or set custom DNS to avoid spamming in case of local DNS ad-remover
-localdisks: sda1 #put the hardware name of your drive to mount separated by commas, or its label. ex. sda1, sdb1, MYNAS...
-networkdisks: "//SERVER/SHARE" # optional, list of smb servers to mount, separated by commas
-cifsusername: "username" # optional, smb username, same for all smb shares
-cifspassword: "password" # optional, smb password
-cifsdomain: "domain" # optional, allow setting the domain for the smb share
+localdisks: sda1 # Local drives to mount (e.g., `sda1,sdb1,MYNAS`)
+networkdisks: "//SERVER/SHARE" # SMB shares to mount (e.g., `//SERVER/SHARE`)
+cifsusername: "username" # SMB username for network shares
+cifspassword: "password" # SMB password for network shares
+cifsdomain: "domain" # SMB domain for network shares
 ```
 
 ## Installation

--- a/webtrees/README.md
+++ b/webtrees/README.md
@@ -41,10 +41,10 @@ LANG: "en-US" # Default language for webtrees
 BASE_URL: "http://192.168.178.69" # The url with which you access webtrees
 DB_TYPE: "sqlite" # Your database type : sqlite for automatic configuration, or external for manual config
 CONFIG_LOCATION: location of the config.yaml (see below)
-localdisks: sda1 #put the hardware name of your drive to mount separated by commas, or its label. ex. sda1, sdb1, MYNAS...
-networkdisks: "//SERVER/SHARE" # optional, list of smb servers to mount, separated by commas
-cifsusername: "username" # optional, smb username, same for all smb shares
-cifspassword: "password" # optional, smb password
+localdisks: sda1 # Local drives to mount (e.g., `sda1,sdb1,MYNAS`)
+networkdisks: "//SERVER/SHARE" # SMB shares to mount (e.g., `//SERVER/SHARE`)
+cifsusername: "username" # SMB username for network shares
+cifspassword: "password" # SMB password for network shares
 trusted_headers: single address, or a range of addresses in CIDR format
 base_url_portless: base url without port
 ```

--- a/zzz_archived_code-server/README.md
+++ b/zzz_archived_code-server/README.md
@@ -36,10 +36,10 @@ Webui can be found at `<your-ip>:8443`.
 PGID: user
 GPID: user
 TZ: timezone
-localdisks: sda1 #put the hardware name of your drive to mount separated by commas, or its label. ex. sda1, sdb1, MYNAS...
-networkdisks: "//SERVER/SHARE" # optional, list of smbv2/3 servers to mount, separated by commas
-cifsusername: "username" # optional, smb username, same for all smb shares
-cifspassword: "password" # optional, smb password, same for all smb shares)
+localdisks: sda1 # Local drives to mount (e.g., `sda1,sdb1,MYNAS`)
+networkdisks: "//SERVER/SHARE" # SMB shares to mount (e.g., `//SERVER/SHARE`)
+cifsusername: "username" # SMB username for network shares
+cifspassword: "password" # SMB password for network shares
 ```
 
 ## Installation

--- a/zzz_archived_paperless_ngx/README.md
+++ b/zzz_archived_paperless_ngx/README.md
@@ -51,10 +51,10 @@ Options can be configured through two ways :
 ```yaml
 PGID: user
 GPID: user
-localdisks: sda1 #put the hardware name of your drive to mount separated by commas, or its label. ex. sda1, sdb1, MYNAS...
-networkdisks: "<//SERVER/SHARE>" # list of smbv2/3 servers to mount (optional)
-cifsusername: "username" # smb username (optional)
-cifspassword: "password" # smb password (optional)
+localdisks: sda1 # Local drives to mount (e.g., `sda1,sdb1,MYNAS`)
+networkdisks: "<//SERVER/SHARE>" # SMB shares to mount (e.g., `//SERVER/SHARE`)
+cifsusername: "username" # SMB username for network shares
+cifspassword: "password" # SMB password for network shares
 CONFIG_LOCATION: Location of the config.yaml (see below)
 OCRLANG: eng fra #Any language can be set from this page (always three letters) [here](https://tesseract-ocr.github.io/tessdoc/Data-Files#data-files-for-version-400-november-29-2016).
 TZ: Europe/Paris # Sets a specific timezone

--- a/zzz_archived_papermerge/README.md
+++ b/zzz_archived_papermerge/README.md
@@ -52,10 +52,10 @@ Options can be configured through two ways :
 PGID: user
 GPID: user
 ocrlang: Any language can be set from this page (always three letters) [here](https://tesseract-ocr.github.io/tessdoc/Data-Files#data-files-for-version-400-november-29-2016).
-localdisks: sda1 #put the hardware name of your drive to mount separated by commas, or its label. ex. sda1, sdb1, MYNAS...
-networkdisks: "<//SERVER/SHARE>" # list of smbv2/3 servers to mount (optional)
-cifsusername: "username" # smb username (optional)
-cifspassword: "password" # smb password (optional)
+localdisks: sda1 # Local drives to mount (e.g., `sda1,sdb1,MYNAS`)
+networkdisks: "<//SERVER/SHARE>" # SMB shares to mount (e.g., `//SERVER/SHARE`)
+cifsusername: "username" # SMB username for network shares
+cifspassword: "password" # SMB password for network shares
 storage_dir: storage dir location (https://papermerge.readthedocs.io/en/v2.0.1/consumption.html)
 import_dir: import dir location (https://papermerge.readthedocs.io/en/v2.0.1/consumption.html)
 imaphost: import from email (https://papermerge.readthedocs.io/en/v2.0.1/consumption.html#imap-email)


### PR DESCRIPTION
## Summary
- add helper scripts to check and align option documentation
- unify common option descriptions across addon readmes

## Testing
- `python -m py_compile scripts/align_option_texts.py scripts/check_readme_options.py`
- `npx markdownlint-cli autobrr/README.md battybirdnet-pi/README.md birdnet-pi/README.md codex/README.md emby_beta/README.md librespeed/README.md navidrome/README.md resiliosync/README.md seafile/README.md tor/README.md unpackerr/README.md webtop/README.md webtop_kde/README.md webtrees/README.md zzz_archived_code-server/README.md zzz_archived_paperless_ngx/README.md zzz_archived_papermerge/README.md` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68a97f1b71e0832586ee71e7f38bad8d