### PR TITLE
Remove helper scripts and restore README text

### DIFF
--- a/librespeed/README.md
+++ b/librespeed/README.md
@@ -46,10 +46,11 @@ Configurations can be done through the app webUI, except for the following optio
 
 ```yaml
 PGID: user
-GPID: user
+PUID: user
 TZ: timezone
 PASSWORD: "" # optional
 CUSTOM_RESULTS: false # optional
+IPINFO_APIKEY: "" # optional
 localdisks: sda1 #put the hardware name of your drive to mount separated by commas, or its label. ex. sda1, sdb1, MYNAS...
 networkdisks: "//SERVER/SHARE" # optional, list of smb servers to mount, separated by commas
 cifsusername: "username" # optional, smb username, same for all smb shares


### PR DESCRIPTION
## Summary
- remove helper scripts that aligned option wording
- restore original option descriptions across add-on READMEs
- document missing `PUID` and `IPINFO_APIKEY` options for LibreSpeed

## Testing
- `npx --yes markdownlint-cli autobrr/README.md battybirdnet-pi/README.md birdnet-pi/README.md codex/README.md emby_beta/README.md librespeed/README.md navidrome/README.md resiliosync/README.md seafile/README.md tor/README.md unpackerr/README.md webtop/README.md webtop_kde/README.md webtrees/README.md zzz_archived_code-server/README.md zzz_archived_paperless_ngx/README.md zzz_archived_papermerge/README.md` *(fails: multiple markdownlint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a97f1b71e0832586ee71e7f38bad8d