### PR TITLE
feat(collabora): allow custom ssl certificates

### DIFF
--- a/collabora/CHANGELOG.md
+++ b/collabora/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 25.4.5-7 (29-08-2025)
+- Avoid generating default SSL certificate when custom certificates are provided
+## 25.4.5-6 (28-08-2025)
+- Add option to use own SSL certificates
 ## 25.4.5-5 (27-08-2025)
 - Minor bugs fixed
 ## 25.4.5-4 (27-08-2025)

--- a/collabora/README.md
+++ b/collabora/README.md
@@ -48,6 +48,9 @@ Webui can be found at `http://homeassistant:9980` or through Ingress.
 | `aliasgroup1` | str | | Nextcloud external domain with escaped dots using two \ (e.g. `nextcloud_domain\\.com`) |
 | `domain1` | str | | Collabora external domain with escaped dots using two \ (e.g. `code_domain\\.com`) |
 | `extra_params` | str | | Extra parameters passed to the Collabora start script |
+| `ssl` | bool | `false` | Enable SSL using certificates from /ssl |
+| `certfile` | str | `fullchain.pem` | Certificate file name located in /ssl |
+| `keyfile` | str | `privkey.pem` | Private key file name located in /ssl |
 | `username` | str | | Username for the Collabora admin console |
 | `password` | str | | Password for the Collabora admin console |
 | `dictionaries` | str | | Space-separated list of dictionary languages to install |
@@ -58,6 +61,9 @@ Webui can be found at `http://homeassistant:9980` or through Ingress.
 aliasgroup1: nextcloud_domain\\.com
 domain1: code_domain\\.com
 extra_params: ""
+ssl: true
+certfile: fullchain.pem
+keyfile: privkey.pem
 username: admin
 password: changeme
 ```

--- a/collabora/config.json
+++ b/collabora/config.json
@@ -12,13 +12,17 @@
   "image": "ghcr.io/alexbelgium/collabora-{arch}",
   "init": false,
   "map": [
-    "addon_config:rw"
+    "addon_config:rw",
+    "ssl"
   ],
   "name": "Collabora",
   "options": {
     "aliasgroup1": "",
     "domain": "",
     "extra_params": "--o:ssl.enable=false --o:user_interface.use_integration_theme=false --o:net.proto=IPv4",
+    "certfile": "fullchain.pem",
+    "keyfile": "privkey.pem",
+    "ssl": false,
     "password": "",
     "username": ""
   },
@@ -31,6 +35,9 @@
   "schema": {
     "TZ": "str?",
     "aliasgroup1": "str",
+    "certfile": "str",
+    "keyfile": "str",
+    "ssl": "bool",
     "cert_domain": "bool?",
     "server_name": "str?",
     "dictionaries": "str?",
@@ -41,6 +48,6 @@
   },
   "slug": "collabora",
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "25.4.5-5",
+  "version": "25.4.5-7",
   "webui": "[PROTO:ssl]://[HOST]:[PORT:9980]/browser/dist/admin/admin.html"
 }

--- a/collabora/rootfs/etc/cont-init.d/99-run.sh
+++ b/collabora/rootfs/etc/cont-init.d/99-run.sh
@@ -27,10 +27,22 @@ if bashio::config.has_value 'dictionaries'; then
     export dictionaries
 fi
 
+extra_params=""
 if bashio::config.has_value 'extra_params'; then
     extra_params="$(bashio::config 'extra_params')"
-    export extra_params
 fi
+
+if bashio::config.true 'ssl'; then
+    bashio::config.require.ssl
+    certfile="$(bashio::config 'certfile')"
+    keyfile="$(bashio::config 'keyfile')"
+    export DONT_GEN_SSL_CERT=true
+    extra_params="${extra_params/--o:ssl.enable=false/}"
+    extra_params="${extra_params} --o:ssl.enable=true --o:ssl.termination=false --o:ssl.cert_file_path=/ssl/${certfile} \
+        --o:ssl.key_file_path=/ssl/${keyfile} --o:ssl.ca_file_path=/ssl/${certfile}"
+fi
+
+export extra_params
 
 COOL_CONFIG="/etc/coolwsd/coolwsd.xml"
 CONFIG_DEST="/config/coolwsd.xml"


### PR DESCRIPTION
## Summary
- allow using custom SSL certificates for Collabora
- prevent automatic generation of default certificates when custom ones are supplied
- document and expose SSL options

## Testing
- `pre-commit run --files collabora/rootfs/etc/cont-init.d/99-run.sh collabora/config.json collabora/CHANGELOG.md` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68b00646e52483258e41d70f2416aaf3