### PR TITLE
fix: improve pulseaudio start for standalone

### DIFF
--- a/birdnet-pi/CHANGELOG.md
+++ b/birdnet-pi/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2025.09.07 (07-09-2025)
+- Improve pulseaudio start when running container standalone
 ## 2025.08.23 (25-08-2025)
 - Minor bugs fixed
 ## 2025.08.22 (24-08-2025)

--- a/birdnet-pi/rootfs/etc/cont-init.d/81-modifications.sh
+++ b/birdnet-pi/rootfs/etc/cont-init.d/81-modifications.sh
@@ -84,7 +84,7 @@ fi
 
 # Allow pulseaudio system
 echo "... allow pulseaudio as root as backup"
-sed -i 's#pulseaudio --start#su - pi -c "pulseaudio --start"#g' "$HOME"/BirdNET-Pi/scripts/birdnet_recording.sh
+sed -i 's#pulseaudio --start#pulseaudio --start 2>/dev/null && pulseaudio --check || pulseaudio --system#g' "$HOME"/BirdNET-Pi/scripts/birdnet_recording.sh
 
 # Send services log to container logs
 echo "... redirecting services logs to container logs"


### PR DESCRIPTION
## Summary
- ensure pulseaudio falls back to system mode if regular start fails
- document pulseaudio improvement in changelog

## Testing
- `shellcheck birdnet-pi/rootfs/etc/cont-init.d/81-modifications.sh`
- `markdownlint --disable MD022 MD032 MD034 -- birdnet-pi/CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68bd871c8388832591f10a7f7c128c02