### PR TITLE
feat(birdnet-pi): add tphakala model v2 toggle

### DIFF
--- a/birdnet-pi/README.md
+++ b/birdnet-pi/README.md
@@ -61,6 +61,7 @@ Options can be configured through three ways :
 BIRDSONGS_FOLDER: folder to store birdsongs file # It should be an ssd if you want to avoid clogging of analysis
 MQTT_DISABLED : if true, disables automatic mqtt publishing. Only valid if there is a local broker already available
 LIVESTREAM_BOOT_ENABLED: start livestream from boot, or from settings
+Use_tphakala_model_v2: false # switch to BirdNET-Go classifier files
 PROCESSED_FOLDER_ENABLED : if enabled, you need to set in the birdnet.conf (or the setting of birdnet) the number of last wav files that will be saved in the temporary folder "/tmp/Processed" within the tmpfs (so no disk wear) in case you want to retrieve them. This amount can be adapted from the addon options
 TZ: Etc/UTC specify a timezone to use, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
 pi_password: set the user password to access the web terminal

--- a/birdnet-pi/README_standalone.md
+++ b/birdnet-pi/README_standalone.md
@@ -45,6 +45,7 @@ Ensure you have the following installed on your system:
          - TZ=Europe/Vienna  # Optional: Set your timezone according to https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
          - BIRDSONGS_FOLDER=/config/BirdSongs  # Folder to store bird songs, be sure to use a path that is mapped to a volume (such as /config)
          - LIVESTREAM_BOOT_ENABLED=false  # Enable/disable livestream on boot
+         - Use_tphakala_model_v2=false  # Switch to BirdNET-Go classifier files
          - ssl=false  # Enable/disable SSL
          - certfile=fullchain.pem  # SSL certificate file (located in /ssl/)
          - keyfile=privkey.pem  # SSL key file (located in /ssl/)
@@ -53,8 +54,8 @@ Ensure you have the following installed on your system:
          - MQTT_PASSWORD_manual=  # Optional: Manual MQTT password
          - MQTT_PORT_manual=  # Optional: Manual MQTT port
          - MQTT_USER_manual=  # Optional: Manual MQTT user
-         - PULSE_SERVER=unix:/tmp/pulseaudio.socket 
-         - PULSE_COOKIE=/tmp/pulseaudio.cookie 
+         - PULSE_SERVER=unix:/tmp/pulseaudio.socket
+         - PULSE_COOKIE=/tmp/pulseaudio.cookie
 
        volumes:
          - ./config:/config  # All your configuration files - and location of the default Birdsongs folder

--- a/birdnet-pi/config.json
+++ b/birdnet-pi/config.json
@@ -76,6 +76,7 @@
     "LIVESTREAM_BOOT_ENABLED": false,
     "MQTT_DISABLED": true,
     "TZ": "Europe/Paris",
+    "Use_tphakala_model_v2": false,
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",
     "ssl": false
@@ -103,6 +104,7 @@
     "MQTT_PORT_manual": "int?",
     "MQTT_USER_manual": "str?",
     "TZ": "str?",
+    "Use_tphakala_model_v2": "bool",
     "certfile": "str",
     "cifsdomain": "str?",
     "cifspassword": "str?",

--- a/birdnet-pi/rootfs/etc/cont-init.d/81-modifications.sh
+++ b/birdnet-pi/rootfs/etc/cont-init.d/81-modifications.sh
@@ -43,6 +43,12 @@ fi
 ##################
 
 # Use tphakala model v2 if enabled
+if [[ -f "$HOME/BirdNET-Pi/model/BirdNET_GLOBAL_6K_V2.4_MData_Model_V2_FP16.tflite2" ]]; then
+    mv "$HOME/BirdNET-Pi/model/BirdNET_GLOBAL_6K_V2.4_MData_Model_V2_FP16.tflite2" "$HOME/BirdNET-Pi/model/BirdNET_GLOBAL_6K_V2.4_MData_Model_V2_FP16.tflite"
+fi
+if [[ -d "$HOME/BirdNET-Pi/model/labels_nm2" ]]; then
+    mv "$HOME/BirdNET-Pi/model/labels_nm2" "$HOME/BirdNET-Pi/model/labels_nm"
+fi
 if bashio::config.true 'Use_tphakala_model_v2'; then
     echo "... applying tphakala model v2"
     if  [[ -f "$HOME/BirdNET-Pi/model/BirdNET-Go_classifier.tflite" ]] && [[ -d "$HOME/BirdNET-Pi/model/labels_go" ]]; then

--- a/birdnet-pi/rootfs/etc/cont-init.d/81-modifications.sh
+++ b/birdnet-pi/rootfs/etc/cont-init.d/81-modifications.sh
@@ -45,17 +45,15 @@ fi
 # Use tphakala model v2 if enabled
 if bashio::config.true 'Use_tphakala_model_v2'; then
     echo "... applying tphakala model v2"
-    if [ -d "$HOME/BirdNET-Pi/model/labels_nm" ]; then
+    if  [[ -f "$HOME/BirdNET-Pi/model/BirdNET-Go_classifier.tflite" ]] && [[ -d "$HOME/BirdNET-Pi/model/labels_go" ]]; then
+        # Move labels
         mv "$HOME/BirdNET-Pi/model/labels_nm" "$HOME/BirdNET-Pi/model/labels_nm2" || bashio::log.warning "Failed to move labels_nm"
-    fi
-    if [ -d "$HOME/BirdNET-Pi/model/labels_go" ]; then
         mv "$HOME/BirdNET-Pi/model/labels_go" "$HOME/BirdNET-Pi/model/labels_nm" || bashio::log.warning "Failed to move labels_go"
-    fi
-    if [ -f "$HOME/BirdNET-Pi/model/BirdNET_GLOBAL_6K_V2.4_MData_Model_V2_FP16.tflite" ]; then
+        # Move model
         mv "$HOME/BirdNET-Pi/model/BirdNET_GLOBAL_6K_V2.4_MData_Model_V2_FP16.tflite" "$HOME/BirdNET-Pi/model/BirdNET_GLOBAL_6K_V2.4_MData_Model_V2_FP16.tflite2" || bashio::log.warning "Failed to move base model"
-    fi
-    if [ -f "$HOME/BirdNET-Pi/model/BirdNET-Go_classifier.tflite" ]; then
         mv "$HOME/BirdNET-Pi/model/BirdNET-Go_classifier.tflite" "$HOME/BirdNET-Pi/model/BirdNET_GLOBAL_6K_V2.4_MData_Model_V2_FP16.tflite" || bashio::log.warning "Failed to move Go classifier"
+    else
+    bashio::log.fatal "model or labels not found, skipping"
     fi
 fi
 

--- a/birdnet-pi/rootfs/etc/cont-init.d/81-modifications.sh
+++ b/birdnet-pi/rootfs/etc/cont-init.d/81-modifications.sh
@@ -42,6 +42,23 @@ fi
 # General elements
 ##################
 
+# Use tphakala model v2 if enabled
+if bashio::config.true 'Use_tphakala_model_v2'; then
+    echo "... applying tphakala model v2"
+    if [ -d "$HOME/BirdNET-Pi/model/labels_nm" ]; then
+        mv "$HOME/BirdNET-Pi/model/labels_nm" "$HOME/BirdNET-Pi/model/labels_nm2" || bashio::log.warning "Failed to move labels_nm"
+    fi
+    if [ -d "$HOME/BirdNET-Pi/model/labels_go" ]; then
+        mv "$HOME/BirdNET-Pi/model/labels_go" "$HOME/BirdNET-Pi/model/labels_nm" || bashio::log.warning "Failed to move labels_go"
+    fi
+    if [ -f "$HOME/BirdNET-Pi/model/BirdNET_GLOBAL_6K_V2.4_MData_Model_V2_FP16.tflite" ]; then
+        mv "$HOME/BirdNET-Pi/model/BirdNET_GLOBAL_6K_V2.4_MData_Model_V2_FP16.tflite" "$HOME/BirdNET-Pi/model/BirdNET_GLOBAL_6K_V2.4_MData_Model_V2_FP16.tflite2" || bashio::log.warning "Failed to move base model"
+    fi
+    if [ -f "$HOME/BirdNET-Pi/model/BirdNET-Go_classifier.tflite" ]; then
+        mv "$HOME/BirdNET-Pi/model/BirdNET-Go_classifier.tflite" "$HOME/BirdNET-Pi/model/BirdNET_GLOBAL_6K_V2.4_MData_Model_V2_FP16.tflite" || bashio::log.warning "Failed to move Go classifier"
+    fi
+fi
+
 # Correct language labels according to birdnet.conf
 echo "... adapting labels according to birdnet.conf"
 if export "$(grep "^DATABASE_LANG" /config/birdnet.conf)"; then


### PR DESCRIPTION
## Summary
- add `Use_tphakala_model_v2` option
- swap BirdNET-Go labels and model files when enabled
- document new option in readme

## Testing
- `jq . config.json`
- `shellcheck rootfs/etc/cont-init.d/81-modifications.sh`
- `markdownlint README.md README_standalone.md` *(fails: line length and formatting warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f8927f348325a1e88381e2cc7566