### PR TITLE
Bump Immich add-on versions

### DIFF
--- a/immich/config.json
+++ b/immich/config.json
@@ -148,7 +148,7 @@
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
   "usb": true,
-  "version": "1.142.1",
+  "version": "1.142.1-2",
   "video": true,
   "webui": "http://[HOST]:[PORT:8080]"
 }

--- a/immich_cuda/config.json
+++ b/immich_cuda/config.json
@@ -147,7 +147,7 @@
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
   "usb": true,
-  "version": "1.142.1",
+  "version": "1.142.1-2",
   "video": true,
   "webui": "http://[HOST]:[PORT:8080]"
 }

--- a/immich_noml/config.json
+++ b/immich_noml/config.json
@@ -148,7 +148,7 @@
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
   "usb": true,
-  "version": "1.142.1",
+  "version": "1.142.1-2",
   "video": true,
   "webui": "http://[HOST]:[PORT:8080]"
 }

--- a/immich_openvino/config.json
+++ b/immich_openvino/config.json
@@ -147,7 +147,7 @@
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
   "usb": true,
-  "version": "1.142.1",
+  "version": "1.142.1-2",
   "video": true,
   "webui": "http://[HOST]:[PORT:8080]"
 }


### PR DESCRIPTION
## Summary
- bump the Immich add-on version to 1.142.1-2
- bump the Immich CUDA add-on version to 1.142.1-2
- bump the Immich no machine learning add-on version to 1.142.1-2
- bump the Immich OpenVINO add-on version to 1.142.1-2

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca4ae8dc9883259b7149a6988ff035