### PR TITLE
Fix FlareSolverr startup on HA by patching Chromium wrapper

### DIFF
--- a/flaresolverr/CHANGELOG.md
+++ b/flaresolverr/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 3.4.1-1 (21-09-2025)
+
+- Work around Chromium 140 wrapper regression by forcing the script to run with bash to avoid startup failures on Home Assistant.
+
 ## 3.4.1 (20-09-2025)
 - Update to latest version from FlareSolverr/FlareSolverr (changelog : https://github.com/FlareSolverr/FlareSolverr/releases)
 ## 3.4.0 (26-08-2025)

--- a/flaresolverr/config.json
+++ b/flaresolverr/config.json
@@ -80,6 +80,6 @@
   "slug": "flaresolverr",
   "udev": true,
   "url": "https://github.com/alexbelgium/hassio-addons",
-  "version": "3.3.25",
+  "version": "3.4.1-1",
   "webui": "[PROTO:ssl]://[HOST]:[PORT:8191]"
 }

--- a/flaresolverr/rootfs/etc/cont-init.d/99-run.sh
+++ b/flaresolverr/rootfs/etc/cont-init.d/99-run.sh
@@ -2,6 +2,21 @@
 # shellcheck shell=bash
 set -euo pipefail
 
+chromium_wrapper="/usr/bin/chromium"
+
+if [[ -f "${chromium_wrapper}" ]]; then
+  if [[ ! -x /bin/bash ]]; then
+    bashio::log.warning "Chromium wrapper patch skipped: /bin/bash is not available."
+  else
+    if grep -q '^#!/bin/sh' "${chromium_wrapper}"; then
+      if grep -q '==' "${chromium_wrapper}"; then
+        bashio::log.info "Adjusting Chromium wrapper to use bash for compatibility with Chromium 140."
+        sed -i '1s|/bin/sh|/bin/bash|' "${chromium_wrapper}"
+      fi
+    fi
+  fi
+fi
+
 bashio::log.warning "Warning - minimum configuration recommended: 2 CPU cores and 4 GB of memory. Otherwise the system may become unresponsive or crash."
 
 ##############

--- a/flaresolverr/updater.json
+++ b/flaresolverr/updater.json
@@ -1,5 +1,5 @@
 {
-  "last_update": "20-09-2025",
+  "last_update": "21-09-2025",
   "repository": "alexbelgium/hassio-addons",
   "slug": "flaresolverr",
   "source": "github",


### PR DESCRIPTION
## Summary
- update the main cont-init script to force the Chromium wrapper shipped with FlareSolverr 3.4.1 to run under bash to avoid the `/usr/bin/chromium: unexpected operator` failure seen on Home Assistant OS
- bump the add-on version to 3.4.1-1 and document the regression fix in the changelog

## Testing
- bash -n flaresolverr/rootfs/etc/cont-init.d/99-run.sh

------
https://chatgpt.com/codex/tasks/task_e_68d045ab7c1c8325840d81db14976589