### PR TITLE
Fix wger env sourcing

### DIFF
--- a/wger/Dockerfile
+++ b/wger/Dockerfile
@@ -38,7 +38,7 @@ USER root
 
 RUN echo "wger ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
     sed -i "1a sudo -E /./ha_entrypoint.sh" /home/wger/entrypoint.sh && \
-    sed -i "/ha_entrypoint/a source /data/env.sh" /home/wger/entrypoint.sh
+    sed -i "/ha_entrypoint/a . /data/env.sh" /home/wger/entrypoint.sh
 
 ##################
 # 3 Install apps #


### PR DESCRIPTION
## Summary
- ensure the wger entrypoint sources /data/env.sh using the POSIX-compatible dot command so variables from 01-config_yaml.sh are applied

## Testing
- No tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0e06409ac83259247c3f3aa40a288