### PR TITLE
Add shared concurrency guard to automated commit workflows

### DIFF
--- a/.github/workflows/daily_README.yaml
+++ b/.github/workflows/daily_README.yaml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: 0 17 * * *
   workflow_dispatch: null
+
+concurrency:
+  group: auto-commit-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   README_updater:
     if: github.repository_owner == 'alexbelgium'

--- a/.github/workflows/helper_stats_graphs.yaml
+++ b/.github/workflows/helper_stats_graphs.yaml
@@ -5,6 +5,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+concurrency:
+  group: auto-commit-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   stats_graphs:
     if: github.repository_owner == 'alexbelgium'

--- a/.github/workflows/on_issues.yml
+++ b/.github/workflows/on_issues.yml
@@ -7,6 +7,10 @@ on:
     types: [opened, edited, closed]
   workflow_dispatch:
 
+concurrency:
+  group: auto-commit-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   ISSUES_linked:
     runs-on: ubuntu-latest

--- a/.github/workflows/onpush_builder.yaml
+++ b/.github/workflows/onpush_builder.yaml
@@ -11,6 +11,10 @@ on:
     paths:
       - "**/config.*"
 
+concurrency:
+  group: auto-commit-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   BUILD_ARGS: ""
 

--- a/.github/workflows/weekly_crlftolf.yaml
+++ b/.github/workflows/weekly_crlftolf.yaml
@@ -2,9 +2,13 @@
 ---
 # This workflow finds and fixes CRLF endings in a repository
 name: Fix CRLF Endings
-on: 
+on:
   workflow_call:
   workflow_dispatch:
+
+concurrency:
+  group: auto-commit-${{ github.ref }}
+  cancel-in-progress: false
   
 jobs:
   crlf-to-lf:

--- a/.github/workflows/weekly_reduceimagesize.yml
+++ b/.github/workflows/weekly_reduceimagesize.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron: '00 23 * * 0'
 
+concurrency:
+  group: auto-commit-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   calibre:
     if: github.repository_owner == 'alexbelgium'

--- a/.github/workflows/weekly_stats.yaml
+++ b/.github/workflows/weekly_stats.yaml
@@ -6,6 +6,10 @@ on:
     - cron: "0 12 * * 5"
   workflow_dispatch:
 
+concurrency:
+  group: auto-commit-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   stats_updater:
     if: github.repository_owner == 'alexbelgium'


### PR DESCRIPTION
## Summary
- add a shared concurrency group to every workflow that pushes commits to master so they no longer race each other

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6905fce904108325b442c2af24b3ddb8