### PR TITLE
Rerelease immich addon

### DIFF
--- a/immich/CHANGELOG.md
+++ b/immich/CHANGELOG.md
@@ -1,5 +1,6 @@
-## "2.2.1" (01-11-2025)
-- Minor bugs fixed
+## 2.2.1-2 (02-11-2025)
+- 2.2.0 and 2.2.1 did not actually update immich correctly and still used 2.1.0. Fixed now
+
 ## 2.2.1 (01-11-2025)
 - Update to latest version from imagegenius/docker-immich (changelog : https://github.com/imagegenius/docker-immich/releases)
 

--- a/immich/config.yaml
+++ b/immich/config.yaml
@@ -138,6 +138,6 @@ slug: immich
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "2.2.1"
+version: "2.2.1-2"
 video: true
 webui: http://[HOST]:[PORT:8080]


### PR DESCRIPTION
The upstream arm image was not built before, it is now. All the other variants were already correct.

If you need help with this repo, I'm happy to help.

Fixes #2156
