### PR TITLE
Fix BirdNET-Pi MQTT callback compatibility with paho 2.x

### DIFF
--- a/birdnet-pi/rootfs/helpers/birdnet_to_mqtt.py
+++ b/birdnet-pi/rootfs/helpers/birdnet_to_mqtt.py
@@ -113,7 +113,14 @@ def automatic_mqtt_publish(file, detection, path):
         log.info("Posted to MQTT: ok")
 
 
-mqttc = mqtt.Client("birdnet_mqtt", callback_api_version=4)
+# Create MQTT client using legacy callback API when available for
+# compatibility with paho-mqtt >= 2.0
+callback_api = getattr(mqtt, "CallbackAPIVersion", None)
+
+if callback_api is not None:
+    mqttc = mqtt.Client("birdnet_mqtt", callback_api_version=callback_api.VERSION1)
+else:
+    mqttc = mqtt.Client("birdnet_mqtt")
 mqttc.username_pw_set(mqtt_user, mqtt_pass)
 mqttc.on_connect = on_connect
 


### PR DESCRIPTION
## Summary
- detect the availability of paho-mqtt's CallbackAPIVersion enum
- instantiate the MQTT client with the legacy callback API to prevent startup failures while keeping backward compatibility

## Testing
- python -m compileall birdnet-pi/rootfs/helpers/birdnet_to_mqtt.py

------
https://chatgpt.com/codex/tasks/task_e_690bbd5da9248325adb63c8c5bfe0ebc