### PR TITLE
Update stats workflow to support YAML configs

### DIFF
--- a/.github/workflows/weekly_stats.yaml
+++ b/.github/workflows/weekly_stats.yaml
@@ -36,23 +36,41 @@ jobs:
           # shellcheck disable=SC2086
           for f in $( find -- * -maxdepth 0 -type d | sort -r ); do
             DOWNLOADS=0
-            if [ -f "$f"/config.json ] && jq -e '.image' "$f/config.json"; then
-              SLUG="$(jq -r '.image' "$f/config.json" | awk -F 'alexbelgium/|-{arch' '{print $2}')"
-              if [[ "$(jq '.arch[]' "$f/config.json")" == *"armv7"* ]]; then
+            COUNT1="-"
+            COUNT2="-"
+            COUNT3="-"
+            IMAGE=""
+            ARCHES=""
+            if [ -f "$f"/config.json ] && jq -e '.image' "$f/config.json" >/dev/null; then
+              IMAGE="$(jq -r '.image' "$f/config.json")"
+              ARCHES="$(jq -r '.arch[]?' "$f/config.json")"
+            elif [ -f "$f/config.yaml" ]; then
+              IMAGE="$(ruby -ryaml -e 'conf = YAML.load_file(ARGV[0]) rescue nil; img = conf && conf["image"]; exit 1 if img.nil? || img.to_s.empty?; puts img' "$f/config.yaml" 2>/dev/null || true)"
+              if [ -n "$IMAGE" ]; then
+                ARCHES="$(ruby -ryaml -e 'conf = YAML.load_file(ARGV[0]) rescue nil; Array(conf && conf["arch"]).compact.each { |a| puts a }' "$f/config.yaml" 2>/dev/null || true)"
+              fi
+            fi
+            if [ -n "$IMAGE" ]; then
+              SLUG="$(printf '%s\n' "$IMAGE" | awk -F 'alexbelgium/|-{arch' '{print $2}')"
+            else
+              SLUG=""
+            fi
+            if [ -n "$SLUG" ]; then
+              if printf '%s\n' "$ARCHES" | grep -qx 'armv7'; then
                 ARCH=armv7 && COUNT="$(curl  --connect-timeout 5 -f -s -L https://github.com/alexbelgium/hassio-addons/pkgs/container/$SLUG-$ARCH/latest | awk '/Total downloads/{getline; print}' | awk -F '<|>' '{print $3}')"
                 until [ -n "$COUNT" ]; do COUNT="$(curl --connect-timeout 5 -f -s -L https://github.com/alexbelgium/hassio-addons/pkgs/container/$SLUG-$ARCH/latest | awk '/Total downloads/{getline; print}' | awk -F '<|>' '{print $3}')" && sleep 5; ((c++)) && echo "repeat $c" && if [[ "$c" == 10 ]]; then COUNT=0; fi; done
                 COUNT="${COUNT//,/}"
                 COUNT1="$COUNT"
                 echo "$COUNT $ARCH users with $SLUG" && DOWNLOADS="$(( DOWNLOADS + COUNT))"
               else COUNT1="-"; fi
-              if [[ "$(jq '.arch[]' "$f/config.json")" == *"amd64"* ]]; then
+              if printf '%s\n' "$ARCHES" | grep -qx 'amd64'; then
                 ARCH=amd64 && COUNT="$(curl  --connect-timeout 5 -f -s -L https://github.com/alexbelgium/hassio-addons/pkgs/container/$SLUG-$ARCH/latest | awk '/Total downloads/{getline; print}' | awk -F '<|>' '{print $3}')"
                 until [ -n "$COUNT" ]; do COUNT="$(curl --connect-timeout 5 -f -s -L https://github.com/alexbelgium/hassio-addons/pkgs/container/$SLUG-$ARCH/latest | awk '/Total downloads/{getline; print}' | awk -F '<|>' '{print $3}')" && sleep 5; ((c++)) && echo "repeat $c" && if [[ "$c" == 10 ]]; then COUNT=0; fi; done
                 COUNT="${COUNT//,/}"
                 COUNT2="$COUNT"
                 echo "$COUNT $ARCH users with $SLUG" && DOWNLOADS="$(( DOWNLOADS + COUNT))"
               else COUNT2="-"; fi
-              if [[ "$(jq '.arch[]' "$f/config.json")" == *"aarch64"* ]]; then
+              if printf '%s\n' "$ARCHES" | grep -qx 'aarch64'; then
                 ARCH=aarch64 && COUNT="$(curl --connect-timeout 5 -f -s -L https://github.com/alexbelgium/hassio-addons/pkgs/container/$SLUG-$ARCH/latest | awk '/Total downloads/{getline; print}' | awk -F '<|>' '{print $3}')"
                 until [ -n "$COUNT" ]; do COUNT="$(curl --connect-timeout 5 -f -s -L https://github.com/alexbelgium/hassio-addons/pkgs/container/$SLUG-$ARCH/latest | awk '/Total downloads/{getline; print}' | awk -F '<|>' '{print $3}')" && sleep 5; ((c++)) && echo "repeat $c" && if [[ "$c" == 10 ]]; then COUNT=0; fi; done
                 COUNT="${COUNT//,/}"
@@ -71,6 +89,8 @@ jobs:
               fi
               # Add data
               sed -i "/${SLUG}$/s|^-|$DOWNLOADS|" "$file"
+            else
+              continue
             fi
           done
 


### PR DESCRIPTION
## Summary
- update the weekly stats workflow to pull addon metadata from either config.json or config.yaml
- parse YAML configs with Ruby to extract the image slug and declared architectures
- default per-architecture counters when an architecture is not published so totals remain accurate

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_690ca808ee988325acf7ffa06852ac6c