### PR TITLE
Embed env_vars usage guidance and update changelogs

### DIFF
--- a/arpspoof/CHANGELOG.md
+++ b/arpspoof/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 - Implemented healthcheck
 - WARNING : update to supervisor 2022.11 before installing
 - Add codenotary sign

--- a/arpspoof/README.md
+++ b/arpspoof/README.md
@@ -42,6 +42,8 @@ The installation of this add-on is pretty straightforward and not different in c
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:PORT>.
 
 ```yaml
@@ -74,3 +76,5 @@ Create an issue on github
 ## Illustration
 
 No illustration
+
+

--- a/arpspoof/config.yaml
+++ b/arpspoof/config.yaml
@@ -82,7 +82,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   INTERFACE_NAME: str?
   ROUTER_IP: str

--- a/autobrr/CHANGELOG.md
+++ b/autobrr/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 1.68.0 (11-10-2025)
 - Update to latest version from autobrr/autobrr (changelog : https://github.com/autobrr/autobrr/releases)

--- a/autobrr/README.md
+++ b/autobrr/README.md
@@ -95,10 +95,12 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom script execution and environment variable injection:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Support
 
 Create an issue on github
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/autobrr/config.yaml
+++ b/autobrr/config.yaml
@@ -97,7 +97,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/battybirdnet-pi/CHANGELOG.md
+++ b/battybirdnet-pi/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## 2025.06.06 (03-06-2025)
 - Minor bugs fixed
 ## 2025.06.05 (03-06-2025)

--- a/battybirdnet-pi/README.md
+++ b/battybirdnet-pi/README.md
@@ -84,7 +84,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -169,4 +169,6 @@ Not yet available
 Create an issue on github
 
 ---
+
+
 

--- a/battybirdnet-pi/config.yaml
+++ b/battybirdnet-pi/config.yaml
@@ -91,7 +91,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   BIRDSONGS_FOLDER: str?
   LIVESTREAM_BOOT_ENABLED: bool

--- a/bazarr/CHANGELOG.md
+++ b/bazarr/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 1.5.3 (27-09-2025)
 - Update to latest version from linuxserver/docker-bazarr (changelog : https://github.com/linuxserver/docker-bazarr/releases)

--- a/bazarr/README.md
+++ b/bazarr/README.md
@@ -29,6 +29,8 @@ This addon is based on the docker image https://github.com/linuxserver/docker-ba
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:PORT> or through the sidebar using Ingress.
 Configurations can be done through the app webUI, except for the following options.
 
@@ -89,3 +91,5 @@ Create an issue on github
 ---
 
 ![illustration](https://www.bazarr.media/assets/img/upgrade.png)
+
+

--- a/bazarr/config.yaml
+++ b/bazarr/config.yaml
@@ -94,7 +94,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/binance-trading-bot/CHANGELOG.md
+++ b/binance-trading-bot/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 0.0.101 (13-06-2025)
 - Update to latest version from chrisleekr/binance-trading-bot (changelog : https://github.com/chrisleekr/binance-trading-bot/releases)

--- a/binance-trading-bot/README.md
+++ b/binance-trading-bot/README.md
@@ -29,6 +29,8 @@ This is a test app ; for any issues please contact the link above.
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:80>.
 Please see https://github.com/chrisleekr/binance-trading-bot for configuration.
 
@@ -48,3 +50,5 @@ comparison to installing any other Hass.io add-on.
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
+
+

--- a/binance-trading-bot/config.yaml
+++ b/binance-trading-bot/config.yaml
@@ -98,7 +98,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   BINANCE_AUTHENTICATION_ENABLED: bool
   BINANCE_AUTHENTICATION_PASSWORD: str

--- a/birdnet-go/CHANGELOG.md
+++ b/birdnet-go/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "nightly-20251028" (01-11-2025)
 - Minor bugs fixed
 

--- a/birdnet-go/README.md
+++ b/birdnet-go/README.md
@@ -62,7 +62,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -150,4 +150,6 @@ Create an issue on github
 ---
 
 ![illustration](https://raw.githubusercontent.com/tphakala/birdnet-go/main/doc/BirdNET-Go-dashboard.webp)
+
+
 

--- a/birdnet-go/config.yaml
+++ b/birdnet-go/config.yaml
@@ -101,7 +101,7 @@ privileged:
   - SYS_RESOURCE
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   BIRDSONGS_FOLDER: str?
   TZ: str?

--- a/birdnet-pi/CHANGELOG.md
+++ b/birdnet-pi/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## 2025.11.04 (05-11-2025)
 - Minor bugs fixed
 ## 2025.11.03 (04-11-2025)

--- a/birdnet-pi/README.md
+++ b/birdnet-pi/README.md
@@ -89,7 +89,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -176,3 +176,5 @@ Create an issue on github
 ---
 
 ![illustration](https://raw.githubusercontent.com/tphakala/birdnet-pi/main/doc/birdnet-pi-dashboard.webp)
+
+

--- a/birdnet-pi/config.yaml
+++ b/birdnet-pi/config.yaml
@@ -90,7 +90,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   BIRDSONGS_FOLDER: str?
   LIVESTREAM_BOOT_ENABLED: bool

--- a/booksonic_air/CHANGELOG.md
+++ b/booksonic_air/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 2201.1.0 (26-08-2023)
 

--- a/booksonic_air/README.md
+++ b/booksonic_air/README.md
@@ -92,7 +92,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom script execution and environment variable injection:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Support
 
@@ -105,3 +105,5 @@ Create an issue on github
 ![illustration](https://booksonic-air.com/img/slider/artistdetails.png)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/booksonic_air/config.yaml
+++ b/booksonic_air/config.yaml
@@ -87,7 +87,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/browserless_chrome/CHANGELOG.md
+++ b/browserless_chrome/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "2.38.2" (01-11-2025)
 - Minor bugs fixed
 

--- a/browserless_chrome/README.md
+++ b/browserless_chrome/README.md
@@ -46,7 +46,7 @@ TIMEOUT: 60000
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -66,3 +66,5 @@ The installation of this add-on is pretty straightforward and not different in c
 ## Support
 
 Create an issue on github
+
+

--- a/browserless_chrome/config.yaml
+++ b/browserless_chrome/config.yaml
@@ -81,7 +81,7 @@ ports_description:
   3000/tcp: Webui
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   TIMEOUT: int
 slug: browserless_chrome

--- a/calibre/CHANGELOG.md
+++ b/calibre/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "8.13.0" (18-10-2025)
 - Minor bugs fixed
 

--- a/calibre/README.md
+++ b/calibre/README.md
@@ -95,7 +95,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Support
 
@@ -108,3 +108,5 @@ Create an issue on github
 ![illustration](https://calibre.com/img/slider/artistdetails.png)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/calibre/config.yaml
+++ b/calibre/config.yaml
@@ -102,7 +102,7 @@ privileged:
   - NET_ADMIN
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   CLI_ARGS: str?
   PASSWORD: str?

--- a/calibre_web/CHANGELOG.md
+++ b/calibre_web/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 0.6.25 (30-08-2025)
 - Update to latest version from linuxserver/docker-calibre-web (changelog : https://github.com/linuxserver/docker-calibre-web/releases)

--- a/calibre_web/README.md
+++ b/calibre_web/README.md
@@ -95,7 +95,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom scripts and environment variables:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Support
 
@@ -108,3 +108,5 @@ Create an issue on github
 ![illustration](https://calibre-web.com/img/slider/artistdetails.png)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/calibre_web/config.yaml
+++ b/calibre_web/config.yaml
@@ -101,7 +101,7 @@ privileged:
   - NET_ADMIN
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   DOCKER_MODS: str?
   OAUTHLIB_RELAX_TOKEN_SCOPE: str?

--- a/changedetection.io/CHANGELOG.md
+++ b/changedetection.io/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "0.50.38" (01-11-2025)
 - Minor bugs fixed
 

--- a/changedetection.io/README.md
+++ b/changedetection.io/README.md
@@ -28,6 +28,8 @@ This addon is based on the [docker image](https://github.com/linuxserver/docker-
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ### Main app
 
 Web UI can be found at `<your-ip>:5000`, also accessible from the add-on page.
@@ -94,3 +96,5 @@ comparison to installing any other Hass.io add-on.
 1. Carefully configure the add-on to your preferences, see the official documentation for for that.
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/changedetection.io/config.yaml
+++ b/changedetection.io/config.yaml
@@ -22,7 +22,7 @@ ports_description:
   5000/tcp: Webui
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   BASE_URL: str?
   PGID: int

--- a/cloudcommander/CHANGELOG.md
+++ b/cloudcommander/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 19.0.13 (27-09-2025)
 - Update to latest version from coderaiser/cloudcmd (changelog : https://github.com/coderaiser/cloudcmd/releases)

--- a/cloudcommander/README.md
+++ b/cloudcommander/README.md
@@ -68,7 +68,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom scripts and environment variables:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -82,3 +82,5 @@ comparison to installing any other Hass.io add-on.
 1. Check the logs of the add-on to see if everything went well.
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/cloudcommander/config.yaml
+++ b/cloudcommander/config.yaml
@@ -90,7 +90,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   CUSTOM_OPTIONS: str?
   DROPBOX_TOKEN: str?

--- a/codex/CHANGELOG.md
+++ b/codex/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "1.8.16" (25-10-2025)
 - Minor bugs fixed
 

--- a/codex/README.md
+++ b/codex/README.md
@@ -87,7 +87,7 @@ cifsdomain: "WORKGROUP"
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ### Mounting Drives
 
@@ -105,3 +105,5 @@ This addon supports mounting both local drives and remote SMB shares:
 Create an issue on github
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/codex/config.yaml
+++ b/codex/config.yaml
@@ -86,7 +86,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   CODEX_RESET_ADMIN: int?
   CODEX_SKIP_INTEGRITY_CHECK: int?

--- a/collabora/CHANGELOG.md
+++ b/collabora/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "25.4.7" (01-11-2025)
 - Minor bugs fixed
 

--- a/collabora/README.md
+++ b/collabora/README.md
@@ -81,9 +81,11 @@ password: changeme
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Support
 
 Create an issue on GitHub
+
+
 

--- a/collabora/config.yaml
+++ b/collabora/config.yaml
@@ -30,7 +30,7 @@ ports_description:
   9980/tcp: Web interface
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   TZ: str?
   aliasgroup1: str

--- a/comixed/CHANGELOG.md
+++ b/comixed/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 1.3 (11-03-2024)
 

--- a/comixed/README.md
+++ b/comixed/README.md
@@ -84,10 +84,11 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom script execution and environment variable injection:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Support
 
 Create an issue on github
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+

--- a/comixed/config.yaml
+++ b/comixed/config.yaml
@@ -75,7 +75,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   TZ: str?
   cifsdomain: str?

--- a/emby/CHANGELOG.md
+++ b/emby/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 4.9.1.80 (04-10-2025)
 - Update to latest version from linuxserver/docker-emby (changelog : https://github.com/linuxserver/docker-emby/releases)

--- a/emby/README.md
+++ b/emby/README.md
@@ -29,6 +29,8 @@ Inital addon version : https://github.com/petersendev/hassio-addons
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at `<your-ip>:8096`, or within Home Assistant through Ingress.
 
 ### Options
@@ -80,3 +82,5 @@ comparison to installing any other Hass.io add-on.
 1. Carefully configure the add-on to your preferences, see the official documentation for for that.
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/emby/config.yaml
+++ b/emby/config.yaml
@@ -107,7 +107,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/emby_beta/CHANGELOG.md
+++ b/emby_beta/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 4.9.2.6 (01-11-2025)
 - Update to latest version from linuxserver/docker-emby (changelog : https://github.com/linuxserver/docker-emby/releases)

--- a/emby_beta/README.md
+++ b/emby_beta/README.md
@@ -29,6 +29,8 @@ Inital addon version : https://github.com/petersendev/hassio-addons
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at `<your-ip>:8096`, or within Home Assistant through Ingress.
 
 ```yaml
@@ -56,3 +58,5 @@ comparison to installing any other Hass.io add-on.
 1. Carefully configure the add-on to your preferences, see the official documentation for for that.
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/emby_beta/config.yaml
+++ b/emby_beta/config.yaml
@@ -108,7 +108,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/enedisgateway2mqtt/CHANGELOG.md
+++ b/enedisgateway2mqtt/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## 0.13.2 (30-05-2024)
 
 - Update to latest version from m4dm4rtig4n/myelectricaldata (changelog : <https://github.com/m4dm4rtig4n/myelectricaldata/releases>)

--- a/enedisgateway2mqtt/README.md
+++ b/enedisgateway2mqtt/README.md
@@ -26,6 +26,8 @@ MyElectricalData allows an automated access to your Enedis data. See its github 
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:5000> or through Ingress.
 Initial setup requires starting the addon once to initialize configuration templates.
 
@@ -77,3 +79,5 @@ comparison to installing any other Hass.io add-on.
 1. Carefully configure the add-on to your preferences, see the official documentation for for that.
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/enedisgateway2mqtt/config.yaml
+++ b/enedisgateway2mqtt/config.yaml
@@ -85,7 +85,7 @@ ports_description:
   5000/tcp: Portail
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   CONFIG_LOCATION: str
   TZ: str?

--- a/enedisgateway2mqtt_dev/CHANGELOG.md
+++ b/enedisgateway2mqtt_dev/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 1.0.0rc14 (03-08-2024)
 - Update to latest version from m4dm4rtig4n/myelectricaldata (changelog : https://github.com/m4dm4rtig4n/myelectricaldata/releases)

--- a/enedisgateway2mqtt_dev/README.md
+++ b/enedisgateway2mqtt_dev/README.md
@@ -26,6 +26,8 @@ MyElectricalData allows an automated access to your Enedis data. See its github 
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:5000> or through Ingress.
 Initial setup requires starting the addon once to initialize configuration templates.
 
@@ -77,3 +79,5 @@ comparison to installing any other Hass.io add-on.
 1. Carefully configure the add-on to your preferences, see the official documentation for for that.
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/enedisgateway2mqtt_dev/config.yaml
+++ b/enedisgateway2mqtt_dev/config.yaml
@@ -85,7 +85,7 @@ ports_description:
   5000/tcp: Portail
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   CONFIG_LOCATION: str
   TZ: str?

--- a/ente/CHANGELOG.md
+++ b/ente/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "4.4.6-3" (05-11-2025)
 - Minor bugs fixed
 ## "4.4.6-2" (04-11-2025)

--- a/ente/README.md
+++ b/ente/README.md
@@ -83,7 +83,7 @@ TZ: "America/New_York"
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ### Mounting Drives
 
@@ -157,3 +157,4 @@ For data safety, regularly backup:
 Create an issue on github
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+

--- a/ente/config.yaml
+++ b/ente/config.yaml
@@ -98,7 +98,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   DB_DATABASE_NAME: str?
   DB_HOSTNAME: str?

--- a/filebrowser/CHANGELOG.md
+++ b/filebrowser/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "2.44.2" (25-10-2025)
 - Minor bugs fixed
 

--- a/filebrowser/README.md
+++ b/filebrowser/README.md
@@ -103,7 +103,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Support
 
@@ -113,3 +113,5 @@ Create an issue on GitHub, or ask on the [Home Assistant Community thread](https
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
+
+

--- a/filebrowser/config.yaml
+++ b/filebrowser/config.yaml
@@ -109,7 +109,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   NoAuth: bool
   base_folder: str?

--- a/fireflyiii/CHANGELOG.md
+++ b/fireflyiii/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "6.4.3" (01-11-2025)
 - Minor bugs fixed
 

--- a/fireflyiii/README.md
+++ b/fireflyiii/README.md
@@ -28,6 +28,8 @@ This addon is based on the docker image https://hub.docker.com/r/fireflyiii/core
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:PORT> or through the sidebar using Ingress.
 Configurations can be done through the app webUI, except for the following options.
 
@@ -91,3 +93,5 @@ Create an issue on github
 ![illustration](https://raw.githubusercontent.com/firefly-iii/firefly-iii/develop/.github/assets/img/imac-complete.png)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/fireflyiii/config.yaml
+++ b/fireflyiii/config.yaml
@@ -87,7 +87,7 @@ ports_description:
   8443/tcp: ssl web interface
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   APP_KEY: str
   CONFIG_LOCATION: str

--- a/fireflyiii_data_importer/CHANGELOG.md
+++ b/fireflyiii_data_importer/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "1.9.0" (25-10-2025)
 - Minor bugs fixed
 

--- a/fireflyiii_data_importer/README.md
+++ b/fireflyiii_data_importer/README.md
@@ -91,7 +91,7 @@ silent: false
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -113,3 +113,5 @@ Create an issue on github
 ## Illustration
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/fireflyiii_data_importer/config.yaml
+++ b/fireflyiii_data_importer/config.yaml
@@ -84,7 +84,7 @@ ports_description:
   8080/tcp: web interface
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   AUTO_IMPORT_SECRET: str?
   CAN_POST_AUTOIMPORT: bool?

--- a/fireflyiii_fints_importer/CHANGELOG.md
+++ b/fireflyiii_fints_importer/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## 1.3.0-6 (18-10-2025)
 - Minor bugs fixed
 ## 1.3.0-5 (06-10-2025)

--- a/fireflyiii_fints_importer/README.md
+++ b/fireflyiii_fints_importer/README.md
@@ -28,6 +28,8 @@ This addon is based on the docker image https://hub.docker.com/r/benkl/firefly-i
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:3476>.
 
 This tool allows you to import transactions from your FinTS enabled bank (primarily German banks) into Firefly III.
@@ -99,3 +101,5 @@ Create an issue on github
 ## Illustration
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/fireflyiii_fints_importer/config.yaml
+++ b/fireflyiii_fints_importer/config.yaml
@@ -81,7 +81,7 @@ ports_description:
   8080/tcp: web interface
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   Updates: list(|hourly|daily2|daily4|daily6|daily8|daily10|daily12|weekly)?
   silent: bool?

--- a/flexget/CHANGELOG.md
+++ b/flexget/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "3.18.20" (01-11-2025)
 - Minor bugs fixed
 

--- a/flexget/README.md
+++ b/flexget/README.md
@@ -46,6 +46,8 @@ The installation of this add-on is pretty straightforward and not different in c
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:5050>.
 Default password: `homeassistant123` (change via addon options).
 
@@ -98,3 +100,5 @@ For complete configuration documentation, see: https://flexget.com/Configuration
 ## Support
 
 If you have an issue with your installation, please be sure to checkout github.
+
+

--- a/flexget/config.yaml
+++ b/flexget/config.yaml
@@ -86,7 +86,7 @@ ports_description:
   5050/tcp: Web interface
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   FG_LOG_LEVEL: list(critical|error|warning|info|verbose|debug|trace)?
   FG_PLUGINS: str?

--- a/free_games_claimer/CHANGELOG.md
+++ b/free_games_claimer/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 1.8 (17-05-2025)
 - Update to latest version from vogler/free-games-claimer (changelog : https://github.com/vogler/free-games-claimer/releases)

--- a/free_games_claimer/README.md
+++ b/free_games_claimer/README.md
@@ -97,7 +97,7 @@ For complete configuration options and advanced settings, see: https://github.co
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -117,3 +117,5 @@ The installation of this add-on is pretty straightforward and not different in c
 Create an issue on github
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/free_games_claimer/config.yaml
+++ b/free_games_claimer/config.yaml
@@ -87,7 +87,7 @@ ports_description:
   6080/tcp: NOVNC port
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   CMD_ARGUMENTS: str
   CONFIG_LOCATION: str

--- a/gazpar2mqtt/CHANGELOG.md
+++ b/gazpar2mqtt/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 - WARNING : update to supervisor 2022.11 before installing
 
 ## 0.8.2 (17-07-2022)

--- a/gazpar2mqtt/README.md
+++ b/gazpar2mqtt/README.md
@@ -27,6 +27,8 @@ See its github for all informations : https://github.com/yukulehe/gazpar2mqtt
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 This addon fetches gas consumption data from GRDF (French gas utility) and publishes it to MQTT for Home Assistant integration.
 
 ### Setup Steps
@@ -97,3 +99,5 @@ comparison to installing any other Hass.io add-on.
 1. Carefully configure the add-on to your preferences, see the official documentation for for that.
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/gazpar2mqtt/config.yaml
+++ b/gazpar2mqtt/config.yaml
@@ -79,7 +79,7 @@ options:
   verbose: true
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   CONFIG_LOCATION: str
   TZ: str?

--- a/gitea/CHANGELOG.md
+++ b/gitea/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "1.25.0" (01-11-2025)
 - Minor bugs fixed
 

--- a/gitea/README.md
+++ b/gitea/README.md
@@ -60,7 +60,7 @@ ROOT_URL: "http://homeassistant.local:3000"
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -76,3 +76,5 @@ comparison to installing any other Hass.io add-on.
 1. Restart the addon, to apply any option that should be applied
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/gitea/config.yaml
+++ b/gitea/config.yaml
@@ -87,7 +87,7 @@ ports_description:
   3000/tcp: Web interface
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   APP_NAME: str?
   DOMAIN: str?

--- a/grampsweb/CHANGELOG.md
+++ b/grampsweb/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 25.10.2 (01-11-2025)
 - Update to latest version from gramps-project/gramps-web (changelog : https://github.com/gramps-project/gramps-web/releases)

--- a/grampsweb/README.md
+++ b/grampsweb/README.md
@@ -89,7 +89,7 @@ GRAMPSWEB_DEFAULT_FROM_EMAIL: "gramps@example.com"
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -145,3 +145,4 @@ For data safety, regularly backup:
 Create an issue on github
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+

--- a/grampsweb/config.yaml
+++ b/grampsweb/config.yaml
@@ -95,7 +95,7 @@ ports_description:
   5001/tcp: webui
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   CELERY_NUM_WORKERS: int
   GUNICORN_NUM_WORKERS: int

--- a/grav/CHANGELOG.md
+++ b/grav/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "1.7.50.4" (01-11-2025)
 - Minor bugs fixed
 

--- a/grav/README.md
+++ b/grav/README.md
@@ -44,6 +44,8 @@ The installation of this add-on is pretty straightforward and not different in c
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:9191>.
 Configurations can be done through the app webUI, except for the following options.
 
@@ -88,3 +90,5 @@ Create an issue on github
 ![illustration](https://getgrav.org/user/pages/01.tour/_easy-to-use/001-dashboard.png)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/grav/config.yaml
+++ b/grav/config.yaml
@@ -82,7 +82,7 @@ ports_description:
   80/tcp: web interface
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/guacamole/CHANGELOG.md
+++ b/guacamole/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## 1.6.0-11 (16-09-2025)
 - Minor bugs fixed
 ## 1.6.0-10 (16-09-2025)

--- a/guacamole/README.md
+++ b/guacamole/README.md
@@ -57,7 +57,7 @@ The addon automatically configures a PostgreSQL database for storing Guacamole c
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -87,3 +87,5 @@ After installation and first login:
 Create an issue on [GitHub][repository]
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/guacamole/config.yaml
+++ b/guacamole/config.yaml
@@ -93,7 +93,7 @@ ports_description:
   8080/tcp: web interface
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   EXTENSIONS: str?
   TZ: str?

--- a/immich/CHANGELOG.md
+++ b/immich/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "2.2.1-2" (02-11-2025)
 - Minor bugs fixed
 ## 2.2.1-2 (02-11-2025)

--- a/immich/README.md
+++ b/immich/README.md
@@ -84,7 +84,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -109,3 +109,5 @@ Create an issue on github, or ask on the [home assistant thread](https://communi
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
+
+

--- a/immich/config.yaml
+++ b/immich/config.yaml
@@ -115,7 +115,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   DB_DATABASE_NAME: str
   DB_HOSTNAME: str

--- a/immich_cuda/CHANGELOG.md
+++ b/immich_cuda/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "2.2.1" (01-11-2025)
 - Minor bugs fixed
 ## 2.2.1 (01-11-2025)

--- a/immich_cuda/README.md
+++ b/immich_cuda/README.md
@@ -94,7 +94,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -123,3 +123,5 @@ Beware to change the password BEFORE starting it ; it won't change afterwards
 Create an issue on github, or ask on the [home assistant thread](https://community.home-assistant.io/t/home-assistant-addon-immich/282108/3)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/immich_cuda/config.yaml
+++ b/immich_cuda/config.yaml
@@ -114,7 +114,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   DB_DATABASE_NAME: str
   DB_HOSTNAME: str

--- a/immich_frame/CHANGELOG.md
+++ b/immich_frame/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "1.0.29.0" (18-10-2025)
 - Minor bugs fixed
 

--- a/immich_frame/README.md
+++ b/immich_frame/README.md
@@ -59,7 +59,7 @@ TZ: "Europe/London"
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -81,3 +81,4 @@ Create an issue on github, or ask on the [home assistant community forum](https:
 For more information about Immich Frame, visit: https://immichframe.online/
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+

--- a/immich_frame/config.yaml
+++ b/immich_frame/config.yaml
@@ -15,7 +15,7 @@ ports_description:
   8080/tcp: Web UI port
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   ApiKey: str
   ImmichServerUrl: str

--- a/immich_noml/CHANGELOG.md
+++ b/immich_noml/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## 2.2.1 (01-11-2025)
 - Update to latest version from imagegenius/docker-immich (changelog : https://github.com/imagegenius/docker-immich/releases)
 

--- a/immich_noml/README.md
+++ b/immich_noml/README.md
@@ -98,7 +98,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -122,3 +122,4 @@ Beware to change the password BEFORE starting it ; it won't change afterwards
 Create an issue on github, or ask on the [home assistant thread](https://community.home-assistant.io/t/home-assistant-addon-immich/282108/3)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+

--- a/immich_noml/config.yaml
+++ b/immich_noml/config.yaml
@@ -115,7 +115,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   DB_DATABASE_NAME: str
   DB_HOSTNAME: str

--- a/immich_openvino/CHANGELOG.md
+++ b/immich_openvino/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "2.2.1" (01-11-2025)
 - Minor bugs fixed
 ## 2.2.1 (01-11-2025)

--- a/immich_openvino/README.md
+++ b/immich_openvino/README.md
@@ -95,7 +95,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -124,3 +124,5 @@ Beware to change the password BEFORE starting it ; it won't change afterwards
 Create an issue on github, or ask on the [home assistant thread](https://community.home-assistant.io/t/home-assistant-addon-immich/282108/3)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/immich_openvino/config.yaml
+++ b/immich_openvino/config.yaml
@@ -114,7 +114,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   DB_DATABASE_NAME: str
   DB_HOSTNAME: str

--- a/immich_power_tools/CHANGELOG.md
+++ b/immich_power_tools/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "0.19.0" (01-11-2025)
 - Minor bugs fixed
 

--- a/immich_power_tools/README.md
+++ b/immich_power_tools/README.md
@@ -99,7 +99,7 @@ Before using this addon, ensure you have:
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -121,3 +121,4 @@ Create an issue on github, or ask on the [home assistant community forum](https:
 For more information about Immich Power Tools, visit: https://github.com/varun-raj/immich-power-tools
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+

--- a/immich_power_tools/config.yaml
+++ b/immich_power_tools/config.yaml
@@ -15,7 +15,7 @@ ports_description:
   3000/tcp: Web UI port
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   DB_DATABASE_NAME: str
   DB_HOST: str

--- a/inadyn/CHANGELOG.md
+++ b/inadyn/CHANGELOG.md
@@ -1,0 +1,2 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+

--- a/inadyn/README.md
+++ b/inadyn/README.md
@@ -41,6 +41,8 @@ comparison to installing any other Hass.io add-on.
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 This addon has no web interface - all configuration is done through addon options.
 For detailed configuration information, see the [official documentation](https://github.com/troglobit/inadyn).
 
@@ -189,3 +191,5 @@ If you want use this add-on with several subdomains with the same provider, you 
 ```
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/inadyn/config.yaml
+++ b/inadyn/config.yaml
@@ -84,7 +84,7 @@ options:
       username: username
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   allow_ipv6: bool?
   fake_address: bool?

--- a/jackett/CHANGELOG.md
+++ b/jackett/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "0.24.234" (01-11-2025)
 - Minor bugs fixed
 

--- a/jackett/README.md
+++ b/jackett/README.md
@@ -28,6 +28,8 @@ This addon is based on the [docker image](https://github.com/linuxserver/docker-
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at the configured port or through the sidebar using Ingress.
 Configurations can be done through the app webUI, except for the following options.
 
@@ -77,3 +79,5 @@ comparison to installing any other Hass.io add-on.
 1. Carefully configure the add-on to your preferences, see the official documentation for for that.
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/jackett/config.yaml
+++ b/jackett/config.yaml
@@ -95,7 +95,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/jellyfin/CHANGELOG.md
+++ b/jellyfin/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 10.11.1 (01-11-2025)
 - Update to latest version from linuxserver/docker-jellyfin (changelog : https://github.com/linuxserver/docker-jellyfin/releases)

--- a/jellyfin/README.md
+++ b/jellyfin/README.md
@@ -81,7 +81,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ### Enable ssl
 #### Creating the PFX certificate file first
@@ -114,3 +114,5 @@ comparison to installing any other Hass.io add-on.
 1. Carefully configure the add-on to your preferences, see the official documentation for for that.
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/jellyfin/config.yaml
+++ b/jellyfin/config.yaml
@@ -111,7 +111,7 @@ privileged:
   - NET_ADMIN
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   DOCKER_MODS: list(linuxserver/mods:jellyfin-opencl-intel|linuxserver/mods:jellyfin-amd|linuxserver/mods:jellyfin-rffmpeg|)?
   PGID: int

--- a/jellyseerr/CHANGELOG.md
+++ b/jellyseerr/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## v2.7.3 (16-08-2025)
 - Update to latest version from Fallenbagel/jellyseerr (changelog : https://github.com/Fallenbagel/jellyseerr/releases)

--- a/jellyseerr/README.md
+++ b/jellyseerr/README.md
@@ -44,6 +44,8 @@ The installation of this add-on is pretty straightforward and not different in c
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:PORT> or through the sidebar using Ingress.
 Configurations can be done through the app webUI, except for the following options.
 
@@ -72,3 +74,5 @@ Create an issue on github
 ![illustration](https://jellyseerr.com/img/slider/artistdetails.png)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/jellyseerr/config.yaml
+++ b/jellyseerr/config.yaml
@@ -83,7 +83,7 @@ ports_description:
 privileged: []
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   TYPE: list(emby|jellyfin)
   TZ: str?

--- a/joal/CHANGELOG.md
+++ b/joal/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 2.1.36 (04-11-2023)
 

--- a/joal/README.md
+++ b/joal/README.md
@@ -28,6 +28,8 @@ All credits for the app go to Anthony Raymond, please visit his repository here 
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:PORT> or through the sidebar using Ingress.
 Configuration details are available in the addon logs.
 
@@ -72,3 +74,5 @@ For Joal : see the upstream repo here https://github.com/anthonyraymond/joal
 ![image](https://user-images.githubusercontent.com/44178713/117990142-29c3b200-b33d-11eb-86c8-a3007d73c3da.png)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/joal/config.yaml
+++ b/joal/config.yaml
@@ -25,7 +25,7 @@ ports_description:
   8081/tcp: Web UI port (required)
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   run_duration: str?
   secret_token: str

--- a/joplin/CHANGELOG.md
+++ b/joplin/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 3.4.4 (27-09-2025)
 - Update to latest version from etechonomy/joplin-server (changelog : https://github.com/etechonomy/joplin-server/releases)

--- a/joplin/README.md
+++ b/joplin/README.md
@@ -100,7 +100,7 @@ To enable email functionality for user registration and notifications:
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -127,3 +127,5 @@ comparison to installing any other Hass.io add-on.
 Create an issue on [GitHub](https://github.com/alexbelgium/hassio-addons/issues).
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/joplin/config.yaml
+++ b/joplin/config.yaml
@@ -84,7 +84,7 @@ privileged:
   - SYS_TIME
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   APP_BASE_URL: str
   DB_CLIENT: str?

--- a/kometa/CHANGELOG.md
+++ b/kometa/CHANGELOG.md
@@ -1,0 +1,2 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+

--- a/kometa/README.md
+++ b/kometa/README.md
@@ -47,6 +47,8 @@ The installation of this add-on is pretty straightforward and not different in c
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 There is a [walkthrough](https://github.com/Kometa-Team/Kometa#setting-up-the-initial-config-file) available to help get you up and running.
 For more information see the [official wiki](https://github.com/Kometa-Team/Kometa).
 
@@ -80,3 +82,5 @@ Create an issue on github
 ---
 
 ![illustration](https://dausruddin.com/wp-content/uploads/2020/05/plex-meta-manager-v3-1024x515.png)
+
+

--- a/kometa/config.yaml
+++ b/kometa/config.yaml
@@ -84,7 +84,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   KOMETA_CONFIG: str
   KOMETA_NO_MISSING: bool?

--- a/librespeed/CHANGELOG.md
+++ b/librespeed/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## 5.4.1b (03-04-2025)
 
 - Fix default PGID

--- a/librespeed/README.md
+++ b/librespeed/README.md
@@ -62,7 +62,7 @@ cifspassword: "password" # optional, smb password
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Support
 
@@ -73,3 +73,5 @@ Create an issue on github
 ![illustration](https://speedtest.fdossena.com/mpot_v6.gif)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/librespeed/config.yaml
+++ b/librespeed/config.yaml
@@ -89,7 +89,7 @@ ports_description:
   80/tcp: web interface (Not required for Ingress)
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   CUSTOM_RESULTS: bool?
   IPINFO_APIKEY: str?

--- a/lidarr/CHANGELOG.md
+++ b/lidarr/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 3.0.1.4866 (01-11-2025)
 - Update to latest version from linuxserver/docker-lidarr (changelog : https://github.com/linuxserver/docker-lidarr/releases)

--- a/lidarr/README.md
+++ b/lidarr/README.md
@@ -44,6 +44,8 @@ The installation of this add-on is pretty straightforward and not different in c
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:PORT> or through the sidebar using Ingress.
 Configurations can be done through the app webUI, except for the following options.
 
@@ -91,3 +93,5 @@ Create an issue on github
 ![illustration](https://www.geekzone.fr/wp-content/uploads/2018/05/lidarr_1.png)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/lidarr/config.yaml
+++ b/lidarr/config.yaml
@@ -90,7 +90,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/linkwarden/CHANGELOG.md
+++ b/linkwarden/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "2.13.1" (18-10-2025)
 - Minor bugs fixed
 

--- a/linkwarden/README.md
+++ b/linkwarden/README.md
@@ -79,7 +79,7 @@ AUTHENTIK_CLIENT_SECRET: "your-client-secret"
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ### Authentik Integration
 
@@ -119,3 +119,5 @@ Create an issue on github, or ask on the [home assistant thread](https://communi
 ---
 
 ![illustration](https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/linkwarden/illustration.png)
+
+

--- a/linkwarden/config.yaml
+++ b/linkwarden/config.yaml
@@ -27,7 +27,7 @@ ports_description:
   3000/tcp: Webui
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   AUTHENTIK_CLIENT_ID: str?
   AUTHENTIK_CLIENT_SECRET: str?

--- a/mealie/CHANGELOG.md
+++ b/mealie/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "v3.4.0" (01-11-2025)
 - Minor bugs fixed
 

--- a/mealie/README.md
+++ b/mealie/README.md
@@ -69,7 +69,7 @@ ALLOW_SIGNUP: false
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 You can add environment variables by creating `/homeassistant/addons_config/xxx-mealie/config.yaml`.
 
@@ -142,3 +142,5 @@ comparison to installing any other Hass.io add-on.
 If you have in issue with your installation, please be sure to checkout github.
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/mealie/config.yaml
+++ b/mealie/config.yaml
@@ -101,7 +101,7 @@ ports_description:
   9001/tcp: Web interface
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   ALLOW_SIGNUP: bool
   BASE_URL: str?

--- a/monica/CHANGELOG.md
+++ b/monica/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## v5.0_beta4-2 (07-12-2024)
 - Increase default storage size to 1024 Mo
 

--- a/monica/README.md
+++ b/monica/README.md
@@ -105,7 +105,7 @@ Configure SMTP settings to enable:
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -136,3 +136,5 @@ Create an issue on github, or ask on the [home assistant community forum](https:
 For more information about Monica, visit: https://www.monicahq.com/
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/monica/config.yaml
+++ b/monica/config.yaml
@@ -83,7 +83,7 @@ ports_description:
   80/tcp: webui
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   database: list(sqlite|MariaDB_addon|Mysql_external)
   APP_KEY: str?

--- a/mylar3/CHANGELOG.md
+++ b/mylar3/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 0.8.3 (23-08-2025)
 - Update to latest version from linuxserver/docker-mylar3 (changelog : https://github.com/linuxserver/docker-mylar3/releases)

--- a/mylar3/README.md
+++ b/mylar3/README.md
@@ -40,6 +40,8 @@ The installation of this add-on is pretty straightforward and not different in c
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:PORT> or through the sidebar using Ingress.
 Configurations can be done through the app webUI, except for the following options.
 
@@ -85,3 +87,5 @@ Create an issue on github
 ![illustration](https://d33wubrfki0l68.cloudfront.net/664a5e42eeb092c4e544606ea29b09a8379ff234/cfe2c/images/mylar.jpg)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/mylar3/config.yaml
+++ b/mylar3/config.yaml
@@ -89,7 +89,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/navidrome/CHANGELOG.md
+++ b/navidrome/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 0.58.0 (01-08-2025)
 - Update to latest version from navidrome/navidrome (changelog : https://github.com/navidrome/navidrome/releases)

--- a/navidrome/README.md
+++ b/navidrome/README.md
@@ -90,7 +90,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom scripts and environment variables:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -106,3 +106,5 @@ comparison to installing any other Hass.io add-on.
 1. Restart the addon, to apply any option that should be applied
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/navidrome/config.yaml
+++ b/navidrome/config.yaml
@@ -28,7 +28,7 @@ ports_description:
   4533/tcp: Web interface
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   base_url: str
   certfile: str?

--- a/netalertx/CHANGELOG.md
+++ b/netalertx/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 25.10.1 (04-10-2025)
 - Update to latest version from jokob-sk/NetAlertX (changelog : https://github.com/jokob-sk/NetAlertX/releases)

--- a/netalertx/README.md
+++ b/netalertx/README.md
@@ -60,6 +60,8 @@ GPID: user
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/netalertx/config.yaml
+++ b/netalertx/config.yaml
@@ -36,7 +36,7 @@ privileged:
   - NET_RAW
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   APP_CONF_OVERRIDE: str?
   TZ: str?

--- a/netalertx_fa/CHANGELOG.md
+++ b/netalertx_fa/CHANGELOG.md
@@ -1,0 +1,2 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+

--- a/netalertx_fa/README.md
+++ b/netalertx_fa/README.md
@@ -61,7 +61,7 @@ This addon supports MQTT integration and will automatically connect to your Home
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -90,3 +90,4 @@ Use this version if you need enhanced network scanning capabilities or if the st
 Create an issue on github, or ask on the [home assistant community forum](https://community.home-assistant.io/)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+

--- a/netalertx_fa/config.yaml
+++ b/netalertx_fa/config.yaml
@@ -37,7 +37,7 @@ privileged:
   - NET_RAW
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   APP_CONF_OVERRIDE: str?
   TZ: str?

--- a/nextcloud/CHANGELOG.md
+++ b/nextcloud/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "32.0.1" (25-10-2025)
 - Minor bugs fixed
 

--- a/nextcloud/README.md
+++ b/nextcloud/README.md
@@ -95,7 +95,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ### Custom Script Example
 
@@ -171,3 +171,5 @@ See this component : https://www.home-assistant.io/integrations/nextcloud/
 [repository]: https://github.com/alexbelgium/hassio-addons
 [elasticsearch-shield]: https://img.shields.io/badge/Elasticsearch-optional-blue.svg?logo=elasticsearch
 continu
+
+

--- a/nextcloud/config.yaml
+++ b/nextcloud/config.yaml
@@ -120,7 +120,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   Full_Text_Search: bool?
   OCR: bool?

--- a/nzbget/CHANGELOG.md
+++ b/nzbget/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "v25.4-ls218" (01-11-2025)
 - Minor bugs fixed
 

--- a/nzbget/README.md
+++ b/nzbget/README.md
@@ -69,7 +69,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -93,3 +93,5 @@ Create an issue on github
 ![illustration](https://nzbget.com/img/slider/artistdetails.png)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/nzbget/config.yaml
+++ b/nzbget/config.yaml
@@ -93,7 +93,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/ombi/CHANGELOG.md
+++ b/ombi/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 4.47.1 (11-01-2025)
 - Update to latest version from linuxserver/docker-ombi (changelog : https://github.com/linuxserver/docker-ombi/releases)

--- a/ombi/README.md
+++ b/ombi/README.md
@@ -39,6 +39,8 @@ comparison to installing any other Hass.io add-on.
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:3579> or through the sidebar using Ingress.
 Configurations can be done through the app webUI, except for the following options.
 
@@ -61,3 +63,5 @@ PUID: 1000
 Create an issue on github
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/ombi/config.yaml
+++ b/ombi/config.yaml
@@ -81,7 +81,7 @@ ports_description:
   3579/tcp: Web interface
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/openproject/CHANGELOG.md
+++ b/openproject/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "16.5.1" (18-10-2025)
 - Minor bugs fixed
 

--- a/openproject/README.md
+++ b/openproject/README.md
@@ -26,6 +26,8 @@ This addon is based on the [docker image](https://hub.docker.com/r/openproject/o
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Fill the default addon options to be able to start the addon. Be sure especially to configure the hostname with your homeassistant ip + addon exposed port
 For additional options, use the config.yaml system : https://github.com/alexbelgium/hassio-addons/wiki/Addons-feature:-add-env-variables
 
@@ -47,3 +49,5 @@ comparison to installing any other Hass.io add-on.
 Default administration password (login: admin, password: admin).
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/openproject/config.yaml
+++ b/openproject/config.yaml
@@ -26,7 +26,7 @@ ports_description:
   8080/tcp: Web interface
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   OPENPROJECT_DEFAULT__LANGUAGE: str
   OPENPROJECT_HOST__NAME: str

--- a/organizr/CHANGELOG.md
+++ b/organizr/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 - WARNING : update to supervisor 2022.11 before installing
 - Add codenotary sign
 - New standardized logic for Dockerfile build and packages installation

--- a/organizr/README.md
+++ b/organizr/README.md
@@ -39,6 +39,8 @@ comparison to installing any other Hass.io add-on.
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:80> or through the sidebar using Ingress.
 Configurations can be done through the app webUI, except for the following options.
 
@@ -74,3 +76,5 @@ Create an issue on github
 ![bjaSt3fTfdXhw5vyl-7Lqz1EOjJIyh8lrdqxA53qO6E](https://user-images.githubusercontent.com/44178713/123061812-43601b00-d40c-11eb-993c-2aed31072775.jpg)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/organizr/config.yaml
+++ b/organizr/config.yaml
@@ -81,7 +81,7 @@ ports_description:
   80/tcp: web interface
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/overseerr/CHANGELOG.md
+++ b/overseerr/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 1.34.0 (29-03-2025)
 - Update to latest version from linuxserver/docker-overseerr (changelog : https://github.com/linuxserver/docker-overseerr/releases)

--- a/overseerr/README.md
+++ b/overseerr/README.md
@@ -44,6 +44,8 @@ The installation of this add-on is pretty straightforward and not different in c
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:PORT> or through the sidebar using Ingress.
 Configurations can be done through the app webUI, except for the following options.
 
@@ -76,3 +78,5 @@ Create an issue on github
 ![illustration](https://overseerr.com/img/slider/artistdetails.png)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/overseerr/config.yaml
+++ b/overseerr/config.yaml
@@ -85,7 +85,7 @@ ports_description:
 privileged: []
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   CONFIG_LOCATION: str
   PGID: int

--- a/photoprism/CHANGELOG.md
+++ b/photoprism/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "ubuntu-2025-10-18" (25-10-2025)
 - Minor bugs fixed
 

--- a/photoprism/README.md
+++ b/photoprism/README.md
@@ -44,6 +44,8 @@ comparison to installing any other Hass.io add-on.
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:2342> or through the sidebar using Ingress.
 Configurations can be done through the app webUI, except for the following options.
 
@@ -137,3 +139,5 @@ You can access it via portainer addon or executing `docker exec -it <photoprism 
 Create an issue on github
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/photoprism/config.yaml
+++ b/photoprism/config.yaml
@@ -107,7 +107,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   BACKUP_PATH: str
   CONFIG_LOCATION: str

--- a/piwigo/CHANGELOG.md
+++ b/piwigo/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 15.6.0 (25-07-2025)
 - Update to latest version from linuxserver/docker-piwigo (changelog : https://github.com/linuxserver/docker-piwigo/releases)

--- a/piwigo/README.md
+++ b/piwigo/README.md
@@ -39,6 +39,8 @@ comparison to installing any other Hass.io add-on.
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:81> or through the sidebar using Ingress.
 Configurations can be done through the app webUI, except for the following options.
 
@@ -84,3 +86,5 @@ This addon supports mounting both local drives and remote SMB shares:
 - **Remote shares**: See [Mounting Remote Shares in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Mounting-remote-shares-in-Addons)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/piwigo/config.yaml
+++ b/piwigo/config.yaml
@@ -89,7 +89,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/plex/CHANGELOG.md
+++ b/plex/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "1.42.2.10156-f737b826c-ls284" (01-11-2025)
 - Minor bugs fixed
 

--- a/plex/README.md
+++ b/plex/README.md
@@ -35,6 +35,8 @@ This addon is based on the [docker image](https://github.com/linuxserver/docker-
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at `<your-ip>:32400`.
 
 ### Options
@@ -87,3 +89,5 @@ comparison to installing any other Hass.io add-on.
 1. Carefully configure the add-on to your preferences, see the official documentation for for that.
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/plex/config.yaml
+++ b/plex/config.yaml
@@ -157,7 +157,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/portainer/CHANGELOG.md
+++ b/portainer/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "2.35.0" (18-10-2025)
 - Minor bugs fixed
 

--- a/portainer/README.md
+++ b/portainer/README.md
@@ -89,7 +89,7 @@ password: "your-secure-password-123"
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Support
 
@@ -100,3 +100,5 @@ Create an issue on github
 ---
 
 ![illustration](https://github.com/hassio-addons/addon-portainer/raw/main/images/screenshot.png)
+
+

--- a/portainer/config.yaml
+++ b/portainer/config.yaml
@@ -35,7 +35,7 @@ ports_description:
   9099/tcp: Web UI port
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   certfile: str
   keyfile: str

--- a/portainer_agent/CHANGELOG.md
+++ b/portainer_agent/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## alpine-sts (24-05-2025)
 - Update to latest version from portainer/agent

--- a/portainer_agent/README.md
+++ b/portainer_agent/README.md
@@ -55,6 +55,8 @@ Disable protection mode, then from the other Portainer cluster, add a new enviro
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ---
 
 Main options :
@@ -67,3 +69,5 @@ Other options : see https://github.com/portainer/agent#deployment-options
 ## Support
 
 Create an issue on github
+
+

--- a/portainer_agent/config.yaml
+++ b/portainer_agent/config.yaml
@@ -24,7 +24,7 @@ ports_description:
   9001/tcp: Portainer agent
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   AGENT_CLUSTER_ADDR: str?
   AGENT_CLUSTER_PROBE_INTERVAL: str?

--- a/postgres_15/CHANGELOG.md
+++ b/postgres_15/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## 15.7-47 (24-06-2025)
 
 - Fix healthcheck to run with correct user and database

--- a/postgres_15/README.md
+++ b/postgres_15/README.md
@@ -58,7 +58,7 @@ For more information, check the [official PostgreSQL image docs](https://hub.doc
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 **Configuration File**: By default `postgresql.conf` is stored in `/config/postgresql.conf` accessible by other addons and Home Assistant. You can modify it using the File Editor addon. For better security, change `CONFIG_LOCATION` to `/data/orig/postgresql.conf` to make it accessible only to this addon.
 
@@ -89,3 +89,5 @@ By default, Postgres will be reachable on the local network of your host system.
 Create an issue on github
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/postgres_15/config.yaml
+++ b/postgres_15/config.yaml
@@ -26,7 +26,7 @@ ports_description:
   5432/tcp: Postgres
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   POSTGRES_DB: str?
   POSTGRES_HOST_AUTH_METHOD: str?

--- a/postgres_17/CHANGELOG.md
+++ b/postgres_17/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## 17.4-13 (22-08-2025)
 - Minor bugs fixed
 ## 17.4-12 (15-07-2025)

--- a/postgres_17/README.md
+++ b/postgres_17/README.md
@@ -52,7 +52,7 @@ By default `postgresql.conf` is stored in volume accessible by other addons and 
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -87,3 +87,5 @@ By default, Postgres will be reachable on the local network of your host system.
 Create an issue on github
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/postgres_17/config.yaml
+++ b/postgres_17/config.yaml
@@ -25,7 +25,7 @@ ports_description:
   5432/tcp: Postgres
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   POSTGRES_DB: str?
   POSTGRES_HOST_AUTH_METHOD: str?

--- a/prowlarr/CHANGELOG.md
+++ b/prowlarr/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "nightly-2.2.0.5222-ls217" (01-11-2025)
 - Minor bugs fixed
 

--- a/prowlarr/README.md
+++ b/prowlarr/README.md
@@ -44,6 +44,8 @@ The installation of this add-on is pretty straightforward and not different in c
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:PORT> or through the sidebar using Ingress.
 Configurations can be done through the app webUI, except for the following options.
 
@@ -93,3 +95,5 @@ Create an issue on github
 ![illustration](https://wiki.servarr.com/assets/prowlarr/hist_1_history.png)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/prowlarr/config.yaml
+++ b/prowlarr/config.yaml
@@ -91,7 +91,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/qbittorrent/CHANGELOG.md
+++ b/qbittorrent/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## 5.1.2-7 (17-08-2025)
 - Minor bugs fixed
 ## 5.1.2-6 (31-07-2025)

--- a/qbittorrent/README.md
+++ b/qbittorrent/README.md
@@ -107,7 +107,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -242,3 +242,5 @@ Create an issue on github, or ask on the [home assistant thread](https://communi
 ---
 
 ![illustration](https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/qbittorrent/illustration.png)
+
+

--- a/qbittorrent/config.yaml
+++ b/qbittorrent/config.yaml
@@ -113,7 +113,7 @@ privileged:
   - NET_ADMIN
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   DNS_server: str?
   PGID: int?

--- a/radarr/CHANGELOG.md
+++ b/radarr/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "5.28.0.10274" (18-10-2025)
 - Minor bugs fixed
 

--- a/radarr/README.md
+++ b/radarr/README.md
@@ -45,6 +45,8 @@ The installation of this add-on is pretty straightforward and not different in c
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:PORT> or through the sidebar using Ingress.
 Configurations can be done through the app webUI, except for the following options.
 
@@ -100,3 +102,5 @@ Create an issue on github
 ![illustration](https://dausruddin.com/wp-content/uploads/2020/05/radarr-v3-1024x515.png)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/radarr/config.yaml
+++ b/radarr/config.yaml
@@ -95,7 +95,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/readarr/CHANGELOG.md
+++ b/readarr/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## 0.4.19.2811 (28-06-2025)
 
 - Update to latest version from linuxserver/docker-readarr (changelog : https://github.com/linuxserver/docker-readarr/releases)

--- a/readarr/README.md
+++ b/readarr/README.md
@@ -95,7 +95,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom scripts and environment variables:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 You can add environment variables by creating `/config/addons_config/readarr_nas.yml`:
 
@@ -114,3 +114,5 @@ Create an issue on github
 ![illustration](https://readarr.com/img/slider/artistdetails.png)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/readarr/config.yaml
+++ b/readarr/config.yaml
@@ -94,7 +94,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   CONFIG_LOCATION: str
   PGID: int

--- a/requestrr/CHANGELOG.md
+++ b/requestrr/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 2.1.9 (20-09-2025)
 - Update to latest version from thomst08/requestrr (changelog : https://github.com/thomst08/requestrr/releases)

--- a/requestrr/README.md
+++ b/requestrr/README.md
@@ -71,7 +71,7 @@ TZ: "Europe/London"
 This addon supports custom scripts and environment variables:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Support
 
@@ -84,3 +84,5 @@ Create an issue on github
 ---
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/requestrr/config.yaml
+++ b/requestrr/config.yaml
@@ -89,7 +89,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/resiliosync/CHANGELOG.md
+++ b/resiliosync/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 3.1.0.1073 (18-07-2025)
 - Update to latest version from linuxserver/docker-resilio-sync (changelog : https://github.com/linuxserver/docker-resilio-sync/releases)

--- a/resiliosync/README.md
+++ b/resiliosync/README.md
@@ -39,6 +39,8 @@ comparison to installing any other Hass.io add-on.
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:8888>.
 
 ```yaml
@@ -59,3 +61,5 @@ config_location: where the config files are found
 Create an issue on github
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/resiliosync/config.yaml
+++ b/resiliosync/config.yaml
@@ -98,7 +98,7 @@ privileged:
   - NET_ADMIN
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/sabnzbd/CHANGELOG.md
+++ b/sabnzbd/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "4.5.5" (25-10-2025)
 - Minor bugs fixed
 

--- a/sabnzbd/README.md
+++ b/sabnzbd/README.md
@@ -69,7 +69,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -93,3 +93,5 @@ Create an issue on github
 ![illustration](https://sabnzbd.com/img/slider/artistdetails.png)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/sabnzbd/config.yaml
+++ b/sabnzbd/config.yaml
@@ -94,7 +94,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/scrutiny/CHANGELOG.md
+++ b/scrutiny/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## v0.8.1-12 (16-08-2025)
 - Replace s6-based shutdown with standard command to avoid s6-svwait error
 

--- a/scrutiny/README.md
+++ b/scrutiny/README.md
@@ -74,7 +74,7 @@ expose_collector: false
 This addon supports custom scripts and environment variables:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Installation
 
@@ -157,3 +157,5 @@ Create an issue on github, or ask on the [home assistant thread](https://communi
 <https://github.com/alexbelgium/hassio-addons>
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/scrutiny/config.yaml
+++ b/scrutiny/config.yaml
@@ -100,7 +100,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   COLLECTOR_API_ENDPOINT: str?
   COLLECTOR_HOST_ID: str?

--- a/scrutiny_fa/README.md
+++ b/scrutiny_fa/README.md
@@ -36,6 +36,8 @@ Features :
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ---
 
 Webui can be found at <http://homeassistant:8080>, or through Ingress.
@@ -128,3 +130,5 @@ Create an issue on github, or ask on the [home assistant thread](https://communi
 https://github.com/alexbelgium/hassio-addons
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/scrutiny_fa/config.yaml
+++ b/scrutiny_fa/config.yaml
@@ -32,7 +32,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   COLLECTOR_API_ENDPOINT: str?
   COLLECTOR_HOST_ID: str?

--- a/seafile/CHANGELOG.md
+++ b/seafile/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 12.0.14 (13-09-2025)
 - Update to latest version from franchetti/seafile-arm

--- a/seafile/README.md
+++ b/seafile/README.md
@@ -46,6 +46,8 @@ The installation of this add-on is pretty straightforward and not different in c
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:8000> (Seahub) and <http://homeassistant:8082> (File server).
 
 ### Setup Steps
@@ -117,3 +119,5 @@ Create an issue on github
 ![illustration](https://seafile.com/img/slider/artistdetails.png)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/seafile/config.yaml
+++ b/seafile/config.yaml
@@ -106,7 +106,7 @@ privileged:
   - NET_ADMIN
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   CONFIG_LOCATION: str?
   FILE_SERVER_ROOT: str

--- a/sonarr/CHANGELOG.md
+++ b/sonarr/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "4.0.16.2942" (01-11-2025)
 - Minor bugs fixed
 

--- a/sonarr/README.md
+++ b/sonarr/README.md
@@ -45,6 +45,8 @@ The installation of this add-on is pretty straightforward and not different in c
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:PORT> or through the sidebar using Ingress.
 Configurations can be done through the app webUI, except for the following options.
 
@@ -100,3 +102,5 @@ Create an issue on github
 ![illustration](https://b0b.fr/wp-content/uploads/2016/02/Sonarr-1-1000x924.jpg)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/sonarr/config.yaml
+++ b/sonarr/config.yaml
@@ -97,7 +97,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/sponsorblockcast/CHANGELOG.md
+++ b/sponsorblockcast/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 0.8.2 (08-03-2025)
 - Update to latest version from gabe565/CastSponsorSkip (changelog : https://github.com/gabe565/CastSponsorSkip/releases)

--- a/sponsorblockcast/README.md
+++ b/sponsorblockcast/README.md
@@ -65,7 +65,7 @@ CSS_DEVICES: "192.168.1.100,192.168.1.101"
 This addon supports custom script execution and environment variable injection:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ### Additional Resources
 
@@ -89,3 +89,5 @@ Addon : here
 App : [CastSponsorSkip](https://github.com/gabe565/CastSponsorSkip)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/sponsorblockcast/config.yaml
+++ b/sponsorblockcast/config.yaml
@@ -16,7 +16,7 @@ options:
   CSS_CATEGORIES: sponsor, intro, outro, selfpromo
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   CSS_CATEGORIES: str
   CSS_DISCOVER_INTERVAL: str?

--- a/spotweb/CHANGELOG.md
+++ b/spotweb/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## 1.5.8-5 (13-01-2025)
 - Allow non ssl servers
 - Use /usr/bin/maria instead of mysql

--- a/spotweb/README.md
+++ b/spotweb/README.md
@@ -1,6 +1,8 @@
 ## &#9888; Open Request : [✨ [REQUEST] [spotweb] Own dbsettings.inc.php (opened 2025-04-29)](https://github.com/alexbelgium/hassio-addons/issues/1850) by [@wimb0](https://github.com/wimb0)
 # Home Assistant Add-ons: Spotweb
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 [![Donate][donation-badge]](https://www.buymeacoffee.com/alexbelgium)
 [![Donate][paypal-badge]](https://www.paypal.com/donate/?hosted_button_id=DZFULJZTP3UQA)
 
@@ -61,3 +63,5 @@ To import your ownsettings.php, place the file in "/config/addons_config/spotweb
 [repository]: https://github.com/alexbelgium/hassio-addons
 [spotnet]: https://github.com/spotnet/spotnet/wiki
 [spotweb]: https://github.com/spotweb/spotweb
+
+

--- a/spotweb/config.yaml
+++ b/spotweb/config.yaml
@@ -27,7 +27,7 @@ ports_description:
   80/tcp: Not required for Ingress
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   certfile: str
   keyfile: str

--- a/tandoor_recipes/CHANGELOG.md
+++ b/tandoor_recipes/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "2.3.3" (18-10-2025)
 - Minor bugs fixed
 

--- a/tandoor_recipes/README.md
+++ b/tandoor_recipes/README.md
@@ -26,6 +26,8 @@ _Thanks to everyone having starred my repo! To star it click on the image below,
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:PORT> or through the sidebar using Ingress.
 Configurations can be done through the app webUI, except for the following options.
 
@@ -93,3 +95,5 @@ If you have in issue with your installation, please be sure to checkout github.
 ## External Recipe files
 The directory /config/addons_config/tandoor_recipes/externalfiles can be used for importing external files in to Tandoor. You can map this with /opt/recipes/externalfiles within Docker.
 As per directions here: https://docs.tandoor.dev/features/external_recipes/
+
+

--- a/tandoor_recipes/config.yaml
+++ b/tandoor_recipes/config.yaml
@@ -93,7 +93,7 @@ ports_description:
   80/tcp: Web interface
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   AI_API_KEY: str?
   AI_MODEL_NAME: str?

--- a/tdarr/CHANGELOG.md
+++ b/tdarr/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 2.49.01 (11-10-2025)
 - Update to latest version from haveagitgat/tdarr

--- a/tdarr/README.md
+++ b/tdarr/README.md
@@ -104,7 +104,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ### Hardware Acceleration Notes
 
@@ -122,3 +122,5 @@ Configure hardware acceleration in the Tdarr Web UI under Settings > FFmpeg/Hand
 - Ask on the [Home Assistant Community thread](https://community.home-assistant.io/t/home-assistant-addon-tdarr/282108/3)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/tdarr/config.yaml
+++ b/tdarr/config.yaml
@@ -111,7 +111,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   CONFIG_LOCATION: str
   TZ: str?

--- a/tor/CHANGELOG.md
+++ b/tor/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## 5.0.1-1 (13-08-2024)
 
 - Update apparmomr profile to fix start up

--- a/tor/README.md
+++ b/tor/README.md
@@ -41,6 +41,8 @@ The installation of this add-on is pretty straightforward and not different in c
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Configurations can be done through the app webUI, except for the following options.
 
 ### Options
@@ -126,3 +128,5 @@ If you have in issue with your installation, please be sure to checkout github.
 [tor-bridges-obfs4]: https://bridges.torproject.org/bridges/?transport=obfs4
 [tor-bridges-webtunnel]: https://bridges.torproject.org/bridges/?transport=webtunnel
 [what-is-snowflake]: https://support.torproject.org/censorship/what-is-snowflake/
+
+

--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -28,7 +28,7 @@ ports_description:
   9080/tcp: Tor HTTP tunnel port
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   bridges:
     - str

--- a/transmission/CHANGELOG.md
+++ b/transmission/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## 4.0.6-r0-ls272-4 (21-02-2025)
 - Minor bugs fixed
 ## 4.0.6-r0-ls272-3 (20-02-2025)

--- a/transmission/README.md
+++ b/transmission/README.md
@@ -40,6 +40,8 @@ comparison to installing any other Hass.io add-on.
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:9091> or through the sidebar using Ingress.
 Configurations can be done through the app webUI, except for the following options.
 
@@ -100,3 +102,5 @@ This addon supports mounting both local drives and remote SMB shares:
 - Delete the folders /homeassistant/addons_config/transmission and /homeassistant/addons_config/transmission-ls
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/transmission/config.yaml
+++ b/transmission/config.yaml
@@ -104,7 +104,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   DNS_server: str?
   PGID: int

--- a/transmission_openvpn/CHANGELOG.md
+++ b/transmission_openvpn/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## v5.3.2 (31-05-2025)
 
 - Update to latest version from haugene/docker-transmission-openvpn (changelog : https://github.com/haugene/docker-transmission-openvpn/releases)

--- a/transmission_openvpn/README.md
+++ b/transmission_openvpn/README.md
@@ -39,6 +39,8 @@ comparison to installing any other Hass.io add-on.
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Options : see https://github.com/haugene/docker-transmission-openvpn for documentation
 
 For setting a custom openvpn file (even if using AIRVPN), you should set OPENVPN_PROVIDER to "custom", then reference your ovpn file in your "OPENVPN_CONFIG". For example, if AIRVPN has provided to you an *.ovpn filed named AIRVPN.ovpn, you need to install an addon such as Filebrowser, go in the /config/addons_config/transmission/openvpn folder and put the AIRVPN.ovpn here. Then, in the addon option you need to write "AIRVPN" in the "OPENVPN_CONFIG" option
@@ -50,3 +52,5 @@ WEBPROXY_ENABLED : the webproxy is enabled by default on port 8118 but can be di
 Webui can be found at `<your-ip>:9091`.
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/transmission_openvpn/config.yaml
+++ b/transmission_openvpn/config.yaml
@@ -115,7 +115,7 @@ privileged:
   - NET_ADMIN
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   DEBUG: bool
   DNS_server: str?

--- a/ubooquity/CHANGELOG.md
+++ b/ubooquity/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 3.1.0 (23-08-2025)
 - Update to latest version from linuxserver/docker-ubooquity (changelog : https://github.com/linuxserver/docker-ubooquity/releases)

--- a/ubooquity/README.md
+++ b/ubooquity/README.md
@@ -49,6 +49,8 @@ comparison to installing any other Hass.io add-on.
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:PORT> or through the sidebar using Ingress.
 The default username/password is described in the startup log.
 Configurations can be done through the app webUI, except for the following options.
@@ -113,3 +115,5 @@ Create an issue on the [repository github][repository], or ask on the [home assi
 ![alt text](https://vaemendis.net/ubooquity/data/images/screenshots/books_library.jpg)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/ubooquity/config.yaml
+++ b/ubooquity/config.yaml
@@ -93,7 +93,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/unpackerr/CHANGELOG.md
+++ b/unpackerr/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## v0.14.5-2 (23-07-2025)
 - Minor bugs fixed
 

--- a/unpackerr/README.md
+++ b/unpackerr/README.md
@@ -104,7 +104,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom script execution and environment variable injection through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 In /addon_configs/db21ed7f_unpackerr/unpackerr.conf you can set all variables according to this list of environment variables : https://github.com/davidnewhall/unpackerr
 
@@ -113,3 +113,5 @@ In /addon_configs/db21ed7f_unpackerr/unpackerr.conf you can set all variables ac
 Create an issue on github
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/unpackerr/config.yaml
+++ b/unpackerr/config.yaml
@@ -88,7 +88,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/webtop/CHANGELOG.md
+++ b/webtop/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## 4.16-r0-ls95-4 (01-06-2025)
 - Minor bugs fixed
 ## 4.16-r0-ls94-4 (28-05-2025)

--- a/webtop/README.md
+++ b/webtop/README.md
@@ -86,7 +86,7 @@ This addon supports mounting both local drives and remote SMB shares:
 This addon supports custom script execution and environment variable injection:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ### Additional Resources
 
@@ -114,3 +114,5 @@ Create an issue on github
 ![illustration](https://www.linuxserver.io/user/pages/content/images/2021/05/menu.png)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/webtop/config.yaml
+++ b/webtop/config.yaml
@@ -119,7 +119,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   DNS_server: str?
   DRINODE: list(/dev/dri/card0|/dev/dri/card1|/dev/dri/card2|/dev/dri/renderD128|/dev/dri/renderD129|)?

--- a/webtop_kde/CHANGELOG.md
+++ b/webtop_kde/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "4.16-r0-ls94" (25-10-2025)
 - Minor bugs fixed
 

--- a/webtop_kde/README.md
+++ b/webtop_kde/README.md
@@ -27,6 +27,8 @@ This addon is based on the docker image https://github.com/linuxserver/docker-we
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found with ingress or at <http://homeassistant:PORT>. The port is by default disabled but can be enabled through the addon options.
 
 By default the image is based around the abc user and we recommend using this user as all of the init/config is based around it. The default password is also abc . If you want to change this password and require authentication when accessing the interface simply issue passwd inside a gui terminal in the webtop. Then when accessing the web interface use the path:
@@ -73,3 +75,5 @@ Create an issue on github
 ![illustration](https://www.linuxserver.io/user/pages/content/images/2021/05/menu.png)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/webtop_kde/config.yaml
+++ b/webtop_kde/config.yaml
@@ -120,7 +120,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   DNS_server: str?
   DRINODE: list(/dev/dri/card0|/dev/dri/card1|/dev/dri/card2|/dev/dri/renderD128|/dev/dri/renderD129|)?

--- a/webtrees/CHANGELOG.md
+++ b/webtrees/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## 2.2.4-2 (09-08-2025)
 - Minor bugs fixed
 

--- a/webtrees/README.md
+++ b/webtrees/README.md
@@ -28,6 +28,8 @@ This addon is based on the docker image https://github.com/NathanVaughn/webtrees
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:PORT>.
 
 The name and password are defined through the startup wizard.
@@ -107,3 +109,5 @@ Create an issue on github
 ## Illustration
 
 ![illustration](https://installatron.infomaniak.com/installatron//images/ss2_webtrees.jpg)
+
+

--- a/webtrees/config.yaml
+++ b/webtrees/config.yaml
@@ -100,7 +100,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   BASE_URL: url
   DATA_LOCATION: str

--- a/wger/CHANGELOG.md
+++ b/wger/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## 2.4-11 (19-09-2025)
 - Minor bugs fixed
 ## 2.4-10 (19-09-2025)

--- a/wger/README.md
+++ b/wger/README.md
@@ -27,6 +27,8 @@ _Thanks to everyone having starred my repo! To star it click on the image below,
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 - Start the addon. Wait a while and check the log for any errors. Initial start can take up to 15 minutes !
 - Open yourdomain.com:8000 (where ":8000" is the port configured in the addon).
 - Default
@@ -64,3 +66,5 @@ comparison to installing any other Hass.io add-on.
 If you have in issue with your installation, please be sure to checkout github.
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/wger/config.yaml
+++ b/wger/config.yaml
@@ -18,7 +18,7 @@ ports_description:
   80/tcp: Web interface
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   CONFIG_LOCATION: str
 slug: wger

--- a/whoogle/CHANGELOG.md
+++ b/whoogle/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 1.1.0 (11-10-2025)
 - Update to latest version from benbusby/whoogle-search (changelog : https://github.com/benbusby/whoogle-search/releases)

--- a/whoogle/README.md
+++ b/whoogle/README.md
@@ -27,6 +27,8 @@ This addon is based on the docker image https://hub.docker.com/r/benbusby/whoogl
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:PORT> or through the sidebar using Ingress.
 Configurations can be done through the app webUI, except for the following options.
 
@@ -104,3 +106,5 @@ Create an issue on github
 ![illustration](https://github.com/benbusby/whoogle-search/raw/main/docs/screenshot_desktop.jpg)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/whoogle/config.yaml
+++ b/whoogle/config.yaml
@@ -86,7 +86,7 @@ ports_description:
   5000/tcp: Web interface
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   HTTPS_ONLY: list(0|1)?
   TZ: str

--- a/zoneminder/CHANGELOG.md
+++ b/zoneminder/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 1.36.36 (11-10-2025)
 - Update to latest version from zoneminder-containers/zoneminder-base (changelog : https://github.com/zoneminder-containers/zoneminder-base/releases)

--- a/zoneminder/README.md
+++ b/zoneminder/README.md
@@ -28,6 +28,8 @@ This addon is based on the docker image https://github.com/ZoneMinder/zmdockerfi
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at <http://homeassistant:3778/zm>.
 
 ### Setup Steps
@@ -91,3 +93,5 @@ Create an issue on github
 ![viewmonitor-stream](https://user-images.githubusercontent.com/44178713/157933856-33ed3d44-6b91-4ce2-8a9b-daf9b618176c.png)
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/zoneminder/config.yaml
+++ b/zoneminder/config.yaml
@@ -89,7 +89,7 @@ ports_description:
   80/tcp: web interface
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   Images_location: str
 services:

--- a/zzz_archived_bitwarden/CHANGELOG.md
+++ b/zzz_archived_bitwarden/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 1.34.3 (01-08-2025)
 - Update to latest version from dani-garcia/bitwarden_rs (changelog : https://github.com/dani-garcia/bitwarden_rs/releases)

--- a/zzz_archived_bitwarden/README.md
+++ b/zzz_archived_bitwarden/README.md
@@ -1,5 +1,7 @@
 # Home assistant add-on: Vaultwarden (Bitwarden RS)
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 # ⚠️ It is recommended to use the official addon (https://github.com/hassio-addons/addon-bitwarden) instead of this fork. The only benefit of this fork is automated releases, now implemented in the offical one. ⚠️
 
 [![Donate][donation-badge]](https://www.buymeacoffee.com/alexbelgium)
@@ -27,3 +29,5 @@ _Thanks to everyone having starred my repo! To star it click on the image below,
 Created by Frenck, please see documentation here : https://github.com/hassio-addons/addon-bitwarden
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/zzz_archived_bitwarden/config.yaml
+++ b/zzz_archived_bitwarden/config.yaml
@@ -20,7 +20,7 @@ ports_description:
   7277/tcp: Bitwarden Vault
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   certfile: str
   keyfile: str

--- a/zzz_archived_code-server/CHANGELOG.md
+++ b/zzz_archived_code-server/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## "4.105.1" (25-10-2025)
 - Minor bugs fixed
 

--- a/zzz_archived_code-server/README.md
+++ b/zzz_archived_code-server/README.md
@@ -30,6 +30,8 @@ This addon is based on the [docker image](https://github.com/linuxserver/code-se
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at `<your-ip>:8443`.
 
 ```yaml
@@ -55,3 +57,5 @@ comparison to installing any other Hass.io add-on.
 1. Carefully configure the add-on to your preferences, see the official documentation for for that.
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/zzz_archived_code-server/config.yaml
+++ b/zzz_archived_code-server/config.yaml
@@ -90,7 +90,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PUID: int

--- a/zzz_archived_paperless_ngx/CHANGELOG.md
+++ b/zzz_archived_paperless_ngx/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 2.15.1 (12-04-2025)
 - Update to latest version from paperless-ngx/paperless-ngx (changelog : https://github.com/paperless-ngx/paperless-ngx/releases)

--- a/zzz_archived_paperless_ngx/README.md
+++ b/zzz_archived_paperless_ngx/README.md
@@ -42,6 +42,8 @@ Alternative quality addon : https://github.com/BenoitAnastay/home-assistant-addo
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Default username:password is admin:admin. Once logged in, you can change it from within the administration panel.
 
 Options can be configured through two ways :
@@ -90,3 +92,5 @@ Create an issue on github
 ---
 
 ![illustration](https://paperless-ngx.readthedocs.io/en/latest/_images/documents-smallcards.png)
+
+

--- a/zzz_archived_paperless_ngx/config.yaml
+++ b/zzz_archived_paperless_ngx/config.yaml
@@ -104,7 +104,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   CONFIG_LOCATION: str
   OCRLANG: str?

--- a/zzz_archived_papermerge/CHANGELOG.md
+++ b/zzz_archived_papermerge/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 - Feat : cifsdomain added
 
 ## v2.1.5-ls61 (19-02-2023)

--- a/zzz_archived_papermerge/README.md
+++ b/zzz_archived_papermerge/README.md
@@ -40,6 +40,8 @@ comparison to installing any other Hass.io add-on.
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 Webui can be found at `<your-ip>:8000`.
 
 Default name `admin` password `admin`
@@ -69,3 +71,5 @@ CONFIG_LOCATION: location of the papermerge.conf.py (see below)
   Full variables can be found here : https://papermerge.readthedocs.io/en/v2.0.1/settings.html.
 
 [repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/zzz_archived_papermerge/config.yaml
+++ b/zzz_archived_papermerge/config.yaml
@@ -91,7 +91,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   CONFIG_LOCATION: str
   PGID: int

--- a/zzz_archived_plex_meta_manager/CHANGELOG.md
+++ b/zzz_archived_plex_meta_manager/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 1.21.1 (27-04-2024)
 - Update to latest version from linuxserver/docker-plex-meta-manager (changelog : https://github.com/linuxserver/docker-plex-meta-manager/releases)

--- a/zzz_archived_plex_meta_manager/README.md
+++ b/zzz_archived_plex_meta_manager/README.md
@@ -47,6 +47,8 @@ The installation of this add-on is pretty straightforward and not different in c
 
 ## Configuration
 
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 There is a [walkthrough](https://github.com/meisnate12/Plex-Meta-Manager/wiki/Docker-Walkthrough#setting-up-the-initial-config-file) available to help get you up and running.
 For more information see the [official wiki](https://github.com/meisnate12/Plex-Meta-Manager/wiki).
 
@@ -80,3 +82,5 @@ Create an issue on github
 ---
 
 ![illustration](https://dausruddin.com/wp-content/uploads/2020/05/plex-meta-manager-v3-1024x515.png)
+
+

--- a/zzz_archived_plex_meta_manager/config.yaml
+++ b/zzz_archived_plex_meta_manager/config.yaml
@@ -85,7 +85,7 @@ privileged:
   - DAC_READ_SEARCH
 schema:
   env_vars:
-    - name: match(^[A-Z0-9_]+$)
+    - name: match(^[A-Za-z0-9_]+$)
       value: str?
   PGID: int
   PMM_CONFIG: str


### PR DESCRIPTION
## Summary
- embed the env_vars usage guidance directly in each add-on README where configuration and options are described
- document the new env_vars-based environment variable method in every affected changelog with a link to the wiki article

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690cbf9bd6508325bed7a45d7ede0453