### PR TITLE
Fix changelog version quoting in builder workflow

### DIFF
--- a/.github/workflows/onpush_builder.yaml
+++ b/.github/workflows/onpush_builder.yaml
@@ -214,6 +214,9 @@ jobs:
           else
             exit 1
           fi
+          version="${version//"/}"
+          version="${version//'/}"
+          version="$(echo "$version" | xargs)"
           if [[ "$version" == *"test"* ]]; then exit 0; fi
           touch CHANGELOG.md
           if ! grep -q "$version" CHANGELOG.md; then


### PR DESCRIPTION
## Summary
- strip surrounding quote characters from detected add-on versions in the changelog update step

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_690ce10e49f483259609bbe564c5401b