### PR TITLE
Add env_vars options defaults for missing addons

### DIFF
--- a/cloudcommander/config.yaml
+++ b/cloudcommander/config.yaml
@@ -79,6 +79,8 @@ map:
   - backup:rw
   - addons:rw
 name: Cloudcommander
+options:
+  env_vars: []
 panel_admin: false
 panel_icon: mdi:file-search
 ports:

--- a/comixed/config.yaml
+++ b/comixed/config.yaml
@@ -64,6 +64,8 @@ map:
   - media:rw
   - share:rw
 name: Comixed
+options:
+  env_vars: []
 panel_admin: false
 panel_icon: mdi:book-open
 ports:

--- a/fireflyiii_fints_importer/config.yaml
+++ b/fireflyiii_fints_importer/config.yaml
@@ -75,6 +75,8 @@ map:
   - share:rw
   - ssl
 name: Firefly iii FinTS Importer
+options:
+  env_vars: []
 ports:
   8080/tcp: 3476
 ports_description:

--- a/immich_frame/config.yaml
+++ b/immich_frame/config.yaml
@@ -9,6 +9,8 @@ init: false
 map:
   - addon_config:rw
 name: Immich Frame
+options:
+  env_vars: []
 ports:
   8080/tcp: 8171
 ports_description:

--- a/immich_power_tools/config.yaml
+++ b/immich_power_tools/config.yaml
@@ -9,6 +9,8 @@ init: false
 map:
   - addon_config:rw
 name: Immich Power Tools
+options:
+  env_vars: []
 ports:
   3000/tcp: 8001
 ports_description:

--- a/linkwarden/config.yaml
+++ b/linkwarden/config.yaml
@@ -21,6 +21,8 @@ init: false
 map:
   - addon_config:rw
 name: Linkwarden
+options:
+  env_vars: []
 ports:
   3000/tcp: 3000
 ports_description:

--- a/netalertx/config.yaml
+++ b/netalertx/config.yaml
@@ -22,6 +22,8 @@ map:
   - share:rw
   - ssl
 name: NetAlertX
+options:
+  env_vars: []
 panel_icon: mdi:wifi-check
 ports:
   20211/tcp: 20211

--- a/netalertx_fa/config.yaml
+++ b/netalertx_fa/config.yaml
@@ -23,6 +23,8 @@ map:
   - share:rw
   - ssl
 name: NetAlertX Full Access
+options:
+  env_vars: []
 panel_icon: mdi:wifi-check
 ports:
   20211/tcp: 20211

--- a/portainer_agent/config.yaml
+++ b/portainer_agent/config.yaml
@@ -16,6 +16,8 @@ map:
   - share:rw
   - ssl
 name: Portainer Agent
+options:
+  env_vars: []
 ports:
   80/tcp: null
   9001/tcp: 9001


### PR DESCRIPTION
## Summary
- add empty `env_vars` defaults to the options section of add-ons that expose `env_vars` in their schema
- ensure the affected add-ons present the environment variable list in the Home Assistant UI

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dcb0115bc8325b395708abc551994)