### PR TITLE
Migrate config env exports into env_vars options

### DIFF
--- a/.templates/01-config_yaml.sh
+++ b/.templates/01-config_yaml.sh
@@ -226,7 +226,7 @@ while IFS= read -r line; do
     fi
 done < "/tempenv"
 
-if [[ ${#__env_var_new_keys[@]} -gt 0 ]]; then
+if [[ ${__env_var_new_keys+x} == x ]] && (( ${#__env_var_new_keys[@]} > 0 )); then
     __env_var_new_payload=""
     for key in "${__env_var_new_keys[@]}"; do
         __env_var_new_payload+="${__env_var_new_map["${key}"]}"$'\n'
@@ -275,7 +275,8 @@ JQ
     fi
 fi
 
-if [[ ${#__env_var_processed_order[@]} -gt 0 ]] && [ -f "${CONFIGSOURCE}" ] && [ -w "${CONFIGSOURCE}" ]; then
+if [[ ${__env_var_processed_order+x} == x ]] && (( ${#__env_var_processed_order[@]} > 0 )) \
+    && [ -f "${CONFIGSOURCE}" ] && [ -w "${CONFIGSOURCE}" ]; then
     tmp_config_file=$(mktemp)
     if [[ -n "${tmp_config_file}" ]]; then
         while IFS= read -r original_line || [ -n "${original_line}" ]; do


### PR DESCRIPTION
## Summary
- persist exported variables from config.yaml into the add-on env_vars option using bashio::addon.option
- comment migrated entries in config.yaml and note the move to env_vars

## Testing
- bash -n .templates/01-config_yaml.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dec890c4c8325a031903a961d4f9a)