### PR TITLE
Remove deprecated codenotary metadata

### DIFF
--- a/addons_updater/build.json
+++ b/addons_updater/build.json
@@ -3,8 +3,5 @@
     "aarch64": "ghcr.io/hassio-addons/base-python/aarch64:stable",
     "amd64": "ghcr.io/hassio-addons/base-python/amd64:stable",
     "armv7": "ghcr.io/hassio-addons/base-python/armv7:stable"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/addons_updater/config.json
+++ b/addons_updater/config.json
@@ -5,7 +5,6 @@
     "armv7"
   ],
   "boot": "manual",
-  "codenotary": "alexandrep.github@gmail.com",
   "description": "Automatic addons update by aligning version tag with upstream releases",
   "environment": {
     "GIT_DISCOVERY_ACROSS_FILESYSTEM": "1"

--- a/arpspoof/build.json
+++ b/arpspoof/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "techblog/arpspoof-docker:latest",
     "amd64": "techblog/arpspoof-docker:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/arpspoof/config.yaml
+++ b/arpspoof/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: block internet connection for local network devices
 devices:
   - /dev/dri

--- a/autobrr/build.json
+++ b/autobrr/build.json
@@ -3,8 +3,5 @@
     "aarch64": "ghcr.io/autobrr/autobrr:latest",
     "amd64": "ghcr.io/autobrr/autobrr:latest",
     "armv7": "ghcr.io/autobrr/autobrr:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/autobrr/config.yaml
+++ b/autobrr/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: Automation for downloads
 devices:
   - /dev/dri

--- a/baikal/build.json
+++ b/baikal/build.json
@@ -3,8 +3,5 @@
     "aarch64": "ghcr.io/mralucarddante/baikal-docker-hass:latest",
     "amd64": "ghcr.io/mralucarddante/baikal-docker-hass:latest",
     "armv7": "ghcr.io/mralucarddante/baikal-docker-hass:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/baikal/config.yaml
+++ b/baikal/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: Calendar+Contacts server
 devices:
   - /dev/dri

--- a/battybirdnet-pi/build.yaml
+++ b/battybirdnet-pi/build.yaml
@@ -2,5 +2,3 @@
 build_from:
   aarch64: ghcr.io/linuxserver/baseimage-debian:arm64v8-bookworm
   amd64: ghcr.io/linuxserver/baseimage-debian:amd64-bookworm
-codenotary:
-  signer: alexandrep.github@gmail.com

--- a/battybirdnet-pi/config.yaml
+++ b/battybirdnet-pi/config.yaml
@@ -3,7 +3,6 @@ arch:
   - amd64
 audio: true
 backup: cold
-codenotary: alexandrep.github@gmail.com
 description:
   A realtime acoustic bat & bird classification system for the Raspberry
   Pi 4/5 built on BattyBirdNET-Analyzer

--- a/bazarr/build.json
+++ b/bazarr/build.json
@@ -3,8 +3,5 @@
     "aarch64": "lscr.io/linuxserver/bazarr:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/bazarr:amd64-latest",
     "armv7": "lscr.io/linuxserver/bazarr:arm32v7-1.2.2"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/bazarr/config.yaml
+++ b/bazarr/config.yaml
@@ -6,7 +6,6 @@ backup_exclude:
   - "**/Backups/*"
   - "**/logs/*"
   - "**/MediaCover/*"
-codenotary: alexandrep.github@gmail.com
 description: Companion application to Sonarr and Radarr to download subtitles
 devices:
   - /dev/dri

--- a/binance-trading-bot/build.json
+++ b/binance-trading-bot/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "chrisleekr/binance-trading-bot:latest",
     "amd64": "chrisleekr/binance-trading-bot:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/binance-trading-bot/config.yaml
+++ b/binance-trading-bot/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description:
   Automated Binance trading bot - Trade multiple cryptocurrencies. Buy
   low/sell high with Grid Trading. Integrated with TradingView technical analysis

--- a/birdnet-go/build.yaml
+++ b/birdnet-go/build.yaml
@@ -2,5 +2,3 @@
 build_from:
   aarch64: ghcr.io/tphakala/birdnet-go:nightly
   amd64: ghcr.io/tphakala/birdnet-go:nightly
-codenotary:
-  signer: alexandrep.github@gmail.com

--- a/birdnet-go/config.yaml
+++ b/birdnet-go/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
 audio: true
-codenotary: alexandrep.github@gmail.com
 description: Realtime BirdNET soundscape analyzer
 devices:
   - /dev/dri

--- a/birdnet-pi/build.yaml
+++ b/birdnet-pi/build.yaml
@@ -2,5 +2,3 @@
 build_from:
   aarch64: ghcr.io/linuxserver/baseimage-debian:arm64v8-bookworm
   amd64: ghcr.io/linuxserver/baseimage-debian:amd64-bookworm
-codenotary:
-  signer: alexandrep.github@gmail.com

--- a/birdnet-pi/config.yaml
+++ b/birdnet-pi/config.yaml
@@ -3,7 +3,6 @@ arch:
   - amd64
 audio: true
 backup: cold
-codenotary: alexandrep.github@gmail.com
 description: Realtime acoustic bird classification system
 devices:
   - /dev/dri

--- a/booksonic_air/build.json
+++ b/booksonic_air/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "lscr.io/linuxserver/booksonic-air:arm64v8-",
     "amd64": "lscr.io/linuxserver/booksonic-air:amd64-"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/booksonic_air/config.yaml
+++ b/booksonic_air/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: platform for accessing the audiobooks you own wherever you are
 devices:
   - /dev/dri

--- a/browserless_chrome/build.json
+++ b/browserless_chrome/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "ghcr.io/browserless/chromium:latest",
     "amd64": "ghcr.io/browserless/chromium:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/browserless_chrome/config.yaml
+++ b/browserless_chrome/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Chromium as a service container
 devices:
   - /dev/dri

--- a/calibre/build.json
+++ b/calibre/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "lscr.io/linuxserver/calibre:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/calibre:amd64-latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/calibre_web/build.json
+++ b/calibre_web/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "lscr.io/linuxserver/calibre-web:arm64v8-",
     "amd64": "lscr.io/linuxserver/calibre-web:amd64-"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/calibre_web/config.yaml
+++ b/calibre_web/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Browsing, reading and downloading eBooks using an existing Calibre database
 devices:
   - /dev/dri

--- a/changedetection.io/build.json
+++ b/changedetection.io/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "lscr.io/linuxserver/changedetection.io:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/changedetection.io:amd64-latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/changedetection.io/config.yaml
+++ b/changedetection.io/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: web page monitoring, notification and change detection
 environment:
   LC_ALL: en_US.UTF-8

--- a/cloudcommander/build.json
+++ b/cloudcommander/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "coderaiser/cloudcmd:latest",
     "amd64": "coderaiser/cloudcmd:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/cloudcommander/config.yaml
+++ b/cloudcommander/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Cloud Commander a file manager for the web with console and editor
 devices:
   - /dev/dri

--- a/codex/build.json
+++ b/codex/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "ajslater/codex:latest",
     "amd64": "ajslater/codex:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/codex/config.yaml
+++ b/codex/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Web based comic archive browser and reader
 devices:
   - /dev/dri

--- a/collabora/build.json
+++ b/collabora/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "collabora/code:latest-arm64",
     "amd64": "collabora/code:latest-amd64"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/collabora/config.yaml
+++ b/collabora/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Collabora Online office suite
 environment:
   PGID: "0"

--- a/comixed/build.json
+++ b/comixed/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "comixed/comixed:latest",
     "amd64": "comixed/comixed:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/comixed/config.yaml
+++ b/comixed/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: managing digital comics
 devices:
   - /dev/dri

--- a/elasticsearch/config.yaml
+++ b/elasticsearch/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Free and Open, Distributed, RESTful Search Engine
 devices:
   - /dev/dri

--- a/emby/build.json
+++ b/emby/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "lscr.io/linuxserver/emby:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/emby:amd64-latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/emby/config.yaml
+++ b/emby/config.yaml
@@ -5,7 +5,6 @@ backup_exclude:
   - "*/cache/"
   - "*/transcoding-temp/"
   - "*/logs/*"
-codenotary: alexandrep.github@gmail.com
 description:
   A free Software Media System that puts you in control of managing and
   streaming your media

--- a/emby_beta/build.json
+++ b/emby_beta/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "ghcr.io/linuxserver/emby:arm64v8-beta",
     "amd64": "ghcr.io/linuxserver/emby:amd64-beta"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/emby_beta/config.yaml
+++ b/emby_beta/config.yaml
@@ -5,7 +5,6 @@ backup_exclude:
   - "*/cache/"
   - "*/transcoding-temp/"
   - "*/logs/*"
-codenotary: alexandrep.github@gmail.com
 description:
   A free Software Media System that puts you in control of managing and
   streaming your media (beta version)

--- a/enedisgateway2mqtt/build.json
+++ b/enedisgateway2mqtt/build.json
@@ -3,8 +3,5 @@
     "aarch64": "m4dm4rtig4n/myelectricaldata:latest",
     "amd64": "m4dm4rtig4n/myelectricaldata:latest",
     "armv7": "m4dm4rtig4n/myelectricaldata:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/enedisgateway2mqtt/config.yaml
+++ b/enedisgateway2mqtt/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: Use Enedis Gateway API to send data in your MQTT Broker (latest channel)
 devices:
   - /dev/dri

--- a/enedisgateway2mqtt_dev/build.json
+++ b/enedisgateway2mqtt_dev/build.json
@@ -3,8 +3,5 @@
     "aarch64": "m4dm4rtig4n/myelectricaldata:latest-dev",
     "amd64": "m4dm4rtig4n/myelectricaldata:latest-dev",
     "armv7": "m4dm4rtig4n/myelectricaldata:latest-dev"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/enedisgateway2mqtt_dev/config.yaml
+++ b/enedisgateway2mqtt_dev/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: Use Enedis Gateway API to send data in your MQTT Broker (dev channel)
 devices:
   - /dev/dri

--- a/ente/build.json
+++ b/ente/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "ghcr.io/ente-io/server:latest",
     "amd64": "ghcr.io/ente-io/server:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/epicgamesfree/build.json
+++ b/epicgamesfree/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "charlocharlie/epicgames-freegames:latest",
     "amd64": "charlocharlie/epicgames-freegames:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/epicgamesfree/config.yaml
+++ b/epicgamesfree/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description:
   Automatically login and redeem promotional free games from Epic Games
   Store

--- a/filebrowser/build.json
+++ b/filebrowser/build.json
@@ -3,8 +3,5 @@
     "aarch64": "filebrowser/filebrowser:s6",
     "amd64": "filebrowser/filebrowser:s6",
     "armv7": "filebrowser/filebrowser:v2.32.0"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/filebrowser/config.yaml
+++ b/filebrowser/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description:
   filebrowser provides a file managing interface within a specified directory
   and it can be used to upload, delete, preview, rename and edit your files

--- a/fireflyiii/config.yaml
+++ b/fireflyiii/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: A free and open source personal finance manager
 devices:
   - /dev/dri

--- a/fireflyiii_data_importer/build.json
+++ b/fireflyiii_data_importer/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "fireflyiii/data-importer:latest",
     "amd64": "fireflyiii/data-importer:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/fireflyiii_data_importer/config.yaml
+++ b/fireflyiii_data_importer/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Data importer for Firefly III (separate addon)
 devices:
   - /dev/dri

--- a/fireflyiii_fints_importer/build.json
+++ b/fireflyiii_fints_importer/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "benkl/firefly-iii-fints-importer:latest",
     "amd64": "benkl/firefly-iii-fints-importer:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/fireflyiii_fints_importer/config.yaml
+++ b/fireflyiii_fints_importer/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - amd64
   - aarch64
-codenotary: alexandrep.github@gmail.com
 description:
   Import financial transactions from your FinTS enabled bank into Firefly
   III

--- a/flaresolverr/config.yaml
+++ b/flaresolverr/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: Proxy server to bypass Cloudflare protection
 devices:
   - /dev/dri

--- a/flexget/config.yaml
+++ b/flexget/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: FlexGet is a multipurpose automation tool for all of your media
 devices:
   - /dev/dri

--- a/free_games_claimer/build.json
+++ b/free_games_claimer/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "ghcr.io/vogler/free-games-claimer:latest",
     "amd64": "ghcr.io/vogler/free-games-claimer:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/free_games_claimer/config.yaml
+++ b/free_games_claimer/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description:
   automatically claims free games on the Epic Games Store, Amazon Prime
   Gaming and GOG

--- a/gazpar2mqtt/config.yaml
+++ b/gazpar2mqtt/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: fetch GRDF data and publish data to a mqtt broker
 devices:
   - /dev/dri

--- a/gitea/build.json
+++ b/gitea/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "gitea/gitea:latest",
     "amd64": "gitea/gitea:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/gitea/config.yaml
+++ b/gitea/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Gitea for Home Assistant
 devices:
   - /dev/dri

--- a/grampsweb/build.yaml
+++ b/grampsweb/build.yaml
@@ -2,5 +2,3 @@
 build_from:
   aarch64: ghcr.io/gramps-project/grampsweb:latest
   amd64: ghcr.io/gramps-project/grampsweb:latest
-codenotary:
-  signer: alexandrep.github@gmail.com

--- a/grampsweb/config.yaml
+++ b/grampsweb/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Open Source Online Genealogy System
 devices:
   - /dev/dri

--- a/grav/build.json
+++ b/grav/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "lscr.io/linuxserver/grav:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/grav:amd64-latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/grav/config.yaml
+++ b/grav/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Fast, Simple, and Flexible, file-based Web-platform
 devices:
   - /dev/dri

--- a/immich/build.json
+++ b/immich/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "ghcr.io/imagegenius/immich:arm64v8-latest",
     "amd64": "ghcr.io/imagegenius/immich:amd64-latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/immich/config.yaml
+++ b/immich/config.yaml
@@ -3,7 +3,6 @@ arch:
   - amd64
 backup_exclude:
   - "**/machine-learning/*"
-codenotary: alexandrep.github@gmail.com
 description:
   Self-hosted photo and video backup solution directly from your mobile
   phone

--- a/immich_cuda/build.json
+++ b/immich_cuda/build.json
@@ -1,8 +1,5 @@
 {
   "build_from": {
     "amd64": "ghcr.io/imagegenius/immich:cuda"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/immich_cuda/config.yaml
+++ b/immich_cuda/config.yaml
@@ -2,7 +2,6 @@ arch:
   - amd64
 backup_exclude:
   - "**/machine-learning/*"
-codenotary: alexandrep.github@gmail.com
 description:
   Self-hosted photo and video backup solution directly from your mobile
   phone

--- a/immich_frame/build.json
+++ b/immich_frame/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "ghcr.io/immichframe/immichframe:latest",
     "amd64": "ghcr.io/immichframe/immichframe:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/immich_frame/config.yaml
+++ b/immich_frame/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Display your immich gallery as a digital photo frame
 hassio_api: true
 image: ghcr.io/alexbelgium/immich_frame-{arch}

--- a/immich_noml/build.json
+++ b/immich_noml/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "ghcr.io/imagegenius/immich:noml",
     "amd64": "ghcr.io/imagegenius/immich:noml"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/immich_noml/config.yaml
+++ b/immich_noml/config.yaml
@@ -3,7 +3,6 @@ arch:
   - amd64
 backup_exclude:
   - "**/machine-learning/*"
-codenotary: alexandrep.github@gmail.com
 description:
   Self-hosted photo and video backup solution directly from your mobile
   phone

--- a/immich_openvino/build.json
+++ b/immich_openvino/build.json
@@ -1,8 +1,5 @@
 {
   "build_from": {
     "amd64": "ghcr.io/imagegenius/immich:openvino"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/immich_openvino/config.yaml
+++ b/immich_openvino/config.yaml
@@ -2,7 +2,6 @@ arch:
   - amd64
 backup_exclude:
   - "**/machine-learning/*"
-codenotary: alexandrep.github@gmail.com
 description:
   Self-hosted photo and video backup solution directly from your mobile
   phone

--- a/immich_power_tools/build.json
+++ b/immich_power_tools/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "ghcr.io/varun-raj/immich-power-tools:latest",
     "amd64": "ghcr.io/varun-raj/immich-power-tools:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/immich_power_tools/config.yaml
+++ b/immich_power_tools/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Power tools for organizing your immich library
 hassio_api: true
 image: ghcr.io/alexbelgium/immich_power_tools-{arch}

--- a/inadyn/build.json
+++ b/inadyn/build.json
@@ -3,8 +3,5 @@
     "aarch64": "troglobit/inadyn:latest",
     "amd64": "troglobit/inadyn:latest",
     "armv7": "troglobit/inadyn:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/inadyn/config.yaml
+++ b/inadyn/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description:
   Inadyn is a small and simple Dynamic DNS, DDNS, client with HTTPS support.
   A large number of dynamic dns providers are supported (https://github.com/troglobit/inadyn#supported-providers).

--- a/jackett/build.json
+++ b/jackett/build.json
@@ -3,8 +3,5 @@
     "aarch64": "lscr.io/linuxserver/jackett:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/jackett:amd64-latest",
     "armv7": "lscr.io/linuxserver/jackett:arm32v7-version-v0.21.334"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/jackett/config.yaml
+++ b/jackett/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description:
   Translates queries from apps (Sonarr, Sickrage, CouchPotato, Mylar, etc)
   into tracker-site-specific http queries, parses the html response, then sends results

--- a/jellyfin/build.json
+++ b/jellyfin/build.json
@@ -3,8 +3,5 @@
     "aarch64": "lscr.io/linuxserver/jellyfin:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/jellyfin:amd64-latest",
     "armv7": "lscr.io/linuxserver/jellyfin:arm32v7-10.8.10"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/jellyfin/config.yaml
+++ b/jellyfin/config.yaml
@@ -8,7 +8,6 @@ backup_exclude:
   - "**/transcode/"
 breaking_versions:
   - 10.10.6*
-codenotary: alexandrep.github@gmail.com
 description:
   A Free Software Media System that puts you in control of managing and
   streaming your media

--- a/jellyseerr/build.json
+++ b/jellyseerr/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "fallenbagel/jellyseerr:latest",
     "amd64": "fallenbagel/jellyseerr:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/jellyseerr/config.yaml
+++ b/jellyseerr/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Fork of overseerr for jellyfin support
 devices:
   - /dev/dri

--- a/joal/config.yaml
+++ b/joal/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: An open source command line RatioMaster with WebUI
 hassio_api: true
 image: ghcr.io/alexbelgium/joal-{arch}

--- a/joplin/config.yaml
+++ b/joplin/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Self-hosted open source note-taking application
 devices:
   - /dev/dri

--- a/kometa/build.json
+++ b/kometa/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "lscr.io/linuxserver/kometa:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/kometa:amd64-latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/kometa/config.yaml
+++ b/kometa/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description:
   Python script to update metadata information for movies, shows, and collections
   as well as automatically build collections

--- a/librespeed/build.json
+++ b/librespeed/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "lscr.io/linuxserver/librespeed:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/librespeed:amd64-latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/librespeed/config.yaml
+++ b/librespeed/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description:
   A very lightweight speed test implemented in Javascript, using XMLHttpRequest
   and Web Workers

--- a/lidarr/build.json
+++ b/lidarr/build.json
@@ -3,8 +3,5 @@
     "aarch64": "lscr.io/linuxserver/lidarr:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/lidarr:amd64-latest",
     "armv7": "lscr.io/linuxserver/lidarr:arm32v7-1.1.4"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/lidarr/config.yaml
+++ b/lidarr/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: Music collection manager for Usenet and BitTorrent users
 devices:
   - /dev/dri

--- a/linkwarden/build.yaml
+++ b/linkwarden/build.yaml
@@ -2,5 +2,3 @@
 build_from:
   aarch64: ghcr.io/linkwarden/linkwarden:latest
   amd64: ghcr.io/linkwarden/linkwarden:latest
-codenotary:
-  signer: alexandrep.github@gmail.com

--- a/linkwarden/config.yaml
+++ b/linkwarden/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description:
   collaborative bookmark manager to collect, organize, and preserve webpages
   and articles

--- a/mealie/build.json
+++ b/mealie/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "hkotel/mealie:latest",
     "amd64": "hkotel/mealie:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/mealie/config.yaml
+++ b/mealie/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Mealie is a self hosted recipe manager and meal planner built in Vue
 devices:
   - /dev/dri

--- a/monica/build.yaml
+++ b/monica/build.yaml
@@ -2,5 +2,3 @@
 build_from:
   aarch64: monica:5.0-apache
   amd64: monica:5.0-apache
-codenotary:
-  signer: alexandrep.github@gmail.com

--- a/monica/config.yaml
+++ b/monica/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Personal Relationship Manager
 devices:
   - /dev/dri

--- a/mylar3/build.json
+++ b/mylar3/build.json
@@ -3,8 +3,5 @@
     "aarch64": "lscr.io/linuxserver/mylar3:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/mylar3:amd64-latest",
     "armv7": "lscr.io/linuxserver/mylar3:arm32v7-v0.7.2-ls91"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/mylar3/config.yaml
+++ b/mylar3/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: Automated comic book downloader for use with NZB and torrents
 devices:
   - /dev/dri

--- a/navidrome/build.json
+++ b/navidrome/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "deluan/navidrome:latest",
     "amd64": "deluan/navidrome:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/navidrome/config.yaml
+++ b/navidrome/config.yaml
@@ -3,7 +3,6 @@ arch:
   - aarch64
 backup_exclude:
   - "**/cache/**"
-codenotary: alexandrep.github@gmail.com
 description: Navidrome for Home Assistant
 image: ghcr.io/alexbelgium/navidrome-{arch}
 init: false

--- a/netalertx/build.json
+++ b/netalertx/build.json
@@ -3,8 +3,5 @@
     "aarch64": "ghcr.io/jokob-sk/netalertx:latest",
     "amd64": "ghcr.io/jokob-sk/netalertx:latest",
     "armv7": "ghcr.io/jokob-sk/netalertx:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/netalertx/config.yaml
+++ b/netalertx/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: "\U0001F5A7\U0001F50D WIFI / LAN scanner, intruder, and presence detector"
 environment:
   PGID: "102"

--- a/netalertx_fa/config.yaml
+++ b/netalertx_fa/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: "\U0001F5A7\U0001F50D WIFI / LAN scanner, intruder, and presence detector"
 environment:
   PGID: "102"

--- a/nextcloud/build.json
+++ b/nextcloud/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "lscr.io/linuxserver/nextcloud:arm64v8-",
     "amd64": "lscr.io/linuxserver/nextcloud:amd64-"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/nextcloud/config.yaml
+++ b/nextcloud/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Nextcloud for Homeassistant
 devices:
   - /dev/dri

--- a/nzbget/build.json
+++ b/nzbget/build.json
@@ -3,8 +3,5 @@
     "aarch64": "lscr.io/linuxserver/nzbget:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/nzbget:amd64-latest",
     "armv7": "lscr.io/linuxserver/nzbget:arm32v7-v21.1-ls131"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/nzbget/config.yaml
+++ b/nzbget/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: usenet downloader
 devices:
   - /dev/dri

--- a/omada/build.json
+++ b/omada/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "mbentley/omada-controller:latest-arm64",
     "amd64": "mbentley/omada-controller:latest-amd64"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/omada/config.yaml
+++ b/omada/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: TP-Link Omada Controller
 devices:
   - /dev/dri

--- a/omada_v3/build.json
+++ b/omada_v3/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "mbentley/omada-controller:3.2-arm64",
     "amd64": "mbentley/omada-controller:3.2-amd64"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/omada_v3/config.yaml
+++ b/omada_v3/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: TP-Link Omada Controller
 devices:
   - /dev/dri

--- a/ombi/build.json
+++ b/ombi/build.json
@@ -3,8 +3,5 @@
     "aarch64": "lscr.io/linuxserver/ombi:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/ombi:amd64-latest",
     "armv7": "lscr.io/linuxserver/ombi:arm32v7-development-v4.38.2-ls361"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/ombi/config.yaml
+++ b/ombi/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: Self-hosted Plex Request and user management system
 devices:
   - /dev/dri

--- a/omni-tools/build.json
+++ b/omni-tools/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "iib0011/omni-tools:latest",
     "amd64": "iib0011/omni-tools:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/omni-tools/config.yaml
+++ b/omni-tools/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description:
   Self-hosted collection of powerful web-based tools for everyday tasks.
   No ads, no tracking, just fast, accessible utilities right from your browser

--- a/openproject/build.json
+++ b/openproject/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "openproject/openproject:16",
     "amd64": "openproject/openproject:16"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/openproject/config.yaml
+++ b/openproject/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - amd64
   - aarch64
-codenotary: alexandrep.github@gmail.com
 description: Openproject for Home Assistant
 environment:
   APP_DATA_PATH: /data/assets

--- a/organizr/build.json
+++ b/organizr/build.json
@@ -3,8 +3,5 @@
     "aarch64": "organizr/organizr:linux-arm64",
     "amd64": "organizr/organizr:linux-amd64",
     "armv7": "organizr/organizr:linux-arm-v7"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/organizr/config.yaml
+++ b/organizr/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: An HTPC/Homelab services organizer that is written in PHP
 devices:
   - /dev/dri

--- a/overseerr/build.json
+++ b/overseerr/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "lscr.io/linuxserver/overseerr:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/overseerr:amd64-latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/overseerr/config.yaml
+++ b/overseerr/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description:
   Request management and media discovery tool built to work with your existing
   Plex ecosystem

--- a/photoprism/build.json
+++ b/photoprism/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "photoprism/photoprism:latest",
     "amd64": "photoprism/photoprism:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/photoprism/config.yaml
+++ b/photoprism/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description:
   A server-based application for browsing, organizing and sharing your
   personal photo collection

--- a/piwigo/build.json
+++ b/piwigo/build.json
@@ -3,8 +3,5 @@
     "aarch64": "lscr.io/linuxserver/piwigo:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/piwigo:amd64-latest",
     "armv7": "lscr.io/linuxserver/piwigo:arm32v7-13.7.0"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/piwigo/config.yaml
+++ b/piwigo/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: Piwigo is a photo gallery software for the web
 devices:
   - /dev/dri

--- a/plex/build.json
+++ b/plex/build.json
@@ -3,8 +3,5 @@
     "aarch64": "lscr.io/linuxserver/plex:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/plex:amd64-latest",
     "armv7": "lscr.io/linuxserver/plex:arm32v7-1.32.4"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/plex/config.yaml
+++ b/plex/config.yaml
@@ -8,7 +8,6 @@ backup_exclude:
   - "**/Logs/**"
   - "**/Crash Reports/**"
   - "**/Diagnostics/**"
-codenotary: alexandrep.github@gmail.com
 description:
   Plex organizes video, music and photos from personal media libraries
   and streams them to smart TVs, streaming boxes and mobile devices

--- a/portainer/build.json
+++ b/portainer/build.json
@@ -3,8 +3,5 @@
     "aarch64": "ghcr.io/hassio-addons/base/aarch64:16.0.0",
     "amd64": "ghcr.io/hassio-addons/base/amd64:16.0.0",
     "armv7": "ghcr.io/hassio-addons/base/armv7:16.0.0"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/portainer/config.yaml
+++ b/portainer/config.yaml
@@ -5,7 +5,6 @@ arch:
 backup_exclude:
   - backups
   - docker_config/cli-plugins
-codenotary: alexandrep.github@gmail.com
 description: Manage your Docker environment with ease
 docker_api: true
 hassio_api: true

--- a/portainer_agent/build.json
+++ b/portainer_agent/build.json
@@ -3,8 +3,5 @@
     "aarch64": "ghcr.io/hassio-addons/base/aarch64:11.1.0",
     "amd64": "ghcr.io/hassio-addons/base/amd64:11.1.0",
     "armv7": "ghcr.io/hassio-addons/base/armv7:11.1.0"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/portainer_agent/config.yaml
+++ b/portainer_agent/config.yaml
@@ -4,7 +4,6 @@ arch:
   - armv7
 backup_exclude:
   - backups
-codenotary: alexandrep.github@gmail.com
 description: An agent used to manage all the resources in a Swarm cluster
 docker_api: true
 full_access: true

--- a/postgres_15/build.json
+++ b/postgres_15/build.json
@@ -3,8 +3,5 @@
     "aarch64": "ghcr.io/immich-app/postgres:15-vectorchord0.4.3-pgvectors0.3.0",
     "amd64": "ghcr.io/immich-app/postgres:15-vectorchord0.4.3-pgvectors0.3.0",
     "armv7": "postgres:15-alpine"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/postgres_15/config.yaml
+++ b/postgres_15/config.yaml
@@ -3,7 +3,6 @@ arch:
   - amd64
   - armv7
 backup: cold
-codenotary: alexandrep.github@gmail.com
 description: Postgres 15 with VectorChord support
 environment:
   CONFIG_LOCATION: /config/postgresql.conf

--- a/postgres_17/build.json
+++ b/postgres_17/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "ghcr.io/immich-app/postgres:17-vectorchord0.4.3-pgvectors0.3.0",
     "amd64": "ghcr.io/immich-app/postgres:17-vectorchord0.4.3-pgvectors0.3.0"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/postgres_17/config.yaml
+++ b/postgres_17/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
 backup: cold
-codenotary: alexandrep.github@gmail.com
 description: Postgres 17 with VectorChord support
 environment:
   CONFIG_LOCATION: /config/postgresql.conf

--- a/prowlarr/build.json
+++ b/prowlarr/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "lscr.io/linuxserver/prowlarr:arm64v8-nightly",
     "amd64": "lscr.io/linuxserver/prowlarr:amd64-nightly"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/prowlarr/config.yaml
+++ b/prowlarr/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description:
   Torrent Trackers and Usenet indexers offering complete management ofSonarr,
   Radarr, Lidarr, and Readarr indexers with no per app setup required

--- a/qbittorrent/build.json
+++ b/qbittorrent/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "lscr.io/linuxserver/qbittorrent:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/qbittorrent:amd64-latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/qbittorrent/config.yaml
+++ b/qbittorrent/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Bittorrent client with optional vpn
 devices:
   - /dev/net/tun

--- a/radarr/build.json
+++ b/radarr/build.json
@@ -3,8 +3,5 @@
     "aarch64": "lscr.io/linuxserver/radarr:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/radarr:amd64-latest",
     "armv7": "lscr.io/linuxserver/radarr:arm32v7-4.5.2"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/radarr/config.yaml
+++ b/radarr/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: A fork of Sonarr to work with movies like Couchpotato
 devices:
   - /dev/dri

--- a/readarr/build.json
+++ b/readarr/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "linuxserver/readarr:arm64v8-develop",
     "amd64": "linuxserver/readarr:amd64-develop"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/readarr/config.yaml
+++ b/readarr/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Book manager and automation
 devices:
   - /dev/dri

--- a/requestrr/build.json
+++ b/requestrr/build.json
@@ -3,8 +3,5 @@
     "aarch64": "thomst08/requestrr:arm64-latest",
     "amd64": "thomst08/requestrr:linux-latest",
     "armv7": "thomst08/requestrr:arm-latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/requestrr/config.yaml
+++ b/requestrr/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description:
   Chatbot used to simplify using services like Sonarr/Radarr/Ombi via the
   use of chat

--- a/resiliosync/build.json
+++ b/resiliosync/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "lscr.io/linuxserver/resilio-sync:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/resilio-sync:amd64-latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/resiliosync/config.yaml
+++ b/resiliosync/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Self-hosted file share and collaboration platform on the web
 devices:
   - /dev/dri

--- a/sabnzbd/build.json
+++ b/sabnzbd/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "lscr.io/linuxserver/sabnzbd:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/sabnzbd:amd64-latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/sabnzbd/config.yaml
+++ b/sabnzbd/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description:
   Makes Usenet as simple and streamlined as possible by automating everything
   we can

--- a/scrutiny/build.json
+++ b/scrutiny/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "ghcr.io/analogj/scrutiny:master-omnibus",
     "amd64": "ghcr.io/analogj/scrutiny:master-omnibus"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/scrutiny/config.yaml
+++ b/scrutiny/config.yaml
@@ -2,7 +2,6 @@ apparmor: "true"
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Scrutiny webUI for smartd S.M.A.R.T monitoring
 devices:
   - /dev/dri

--- a/scrutiny_fa/config.yaml
+++ b/scrutiny_fa/config.yaml
@@ -2,7 +2,6 @@ apparmor: "true"
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Scrutiny WebUI for smartd S.M.A.R.T monitoring (Full Access)
 environment:
   COLLECTOR_API_ENDPOINT: http://localhost:8080

--- a/seafile/build.json
+++ b/seafile/build.json
@@ -3,8 +3,5 @@
     "aarch64": "franchetti/seafile-arm:latest",
     "amd64": "franchetti/seafile-arm:latest",
     "armv7": "franchetti/seafile-arm:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/seafile/config.yaml
+++ b/seafile/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description:
   High performance file syncing and sharing, with also Markdown WYSIWYG
   editing, Wiki, file label and other knowledge management features

--- a/signalk/build.json
+++ b/signalk/build.json
@@ -3,8 +3,5 @@
     "aarch64": "ghcr.io/signalk/signalk-server:latest",
     "amd64": "ghcr.io/signalk/signalk-server:latest",
     "armv7": "ghcr.io/signalk/signalk-server:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/signalk/config.yaml
+++ b/signalk/config.yaml
@@ -3,7 +3,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: An implementation of a Signal K central server for boats
 devices:
   - /dev/can0

--- a/sonarr/build.json
+++ b/sonarr/build.json
@@ -3,8 +3,5 @@
     "aarch64": "lscr.io/linuxserver/sonarr:arm64v8-develop",
     "amd64": "lscr.io/linuxserver/sonarr:amd64-develop",
     "armv7": "lscr.io/linuxserver/sonarr:arm32v7-3.0.9.1549-ls173"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/sonarr/config.yaml
+++ b/sonarr/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description:
   Can monitor multiple RSS feeds for new episodes of your favorite shows
   and will grab, sort and rename them

--- a/sponsorblockcast/build.json
+++ b/sponsorblockcast/build.json
@@ -3,8 +3,5 @@
     "aarch64": "ghcr.io/gabe565/castsponsorskip:latest",
     "amd64": "ghcr.io/gabe565/castsponsorskip:latest",
     "armv7": "ghcr.io/gabe565/castsponsorskip:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/sponsorblockcast/config.yaml
+++ b/sponsorblockcast/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: Skip YouTube ads and sponsorships on all local Google Cast devices
 environment: {}
 host_network: true

--- a/spotweb/build.yaml
+++ b/spotweb/build.yaml
@@ -4,5 +4,3 @@ build_from:
   amd64: ghcr.io/hassio-addons/base/amd64:stable
   armv7: ghcr.io/hassio-addons/base/armv7:stable
   i386: ghcr.io/hassio-addons/base/i386:stable
-codenotary:
-  signer: alexandrep.github@gmail.com

--- a/spotweb/config.yaml
+++ b/spotweb/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: Spotweb is a decentralized usenet community based on the Spotnet protocol
 hassio_api: true
 image: ghcr.io/alexbelgium/spotweb-{arch}

--- a/tandoor_recipes/build.json
+++ b/tandoor_recipes/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "vabene1111/recipes:latest",
     "amd64": "vabene1111/recipes:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/tandoor_recipes/config.yaml
+++ b/tandoor_recipes/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: recipe manager
 devices:
   - /dev/dri

--- a/tdarr/build.json
+++ b/tdarr/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "ghcr.io/haveagitgat/tdarr:latest",
     "amd64": "ghcr.io/haveagitgat/tdarr:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/tdarr/config.yaml
+++ b/tdarr/config.yaml
@@ -7,7 +7,6 @@ backup_exclude:
   - "*/logs/"
   - "*/transcoding-temp/"
   - "*/metadata/"
-codenotary: alexandrep.github@gmail.com
 description: Distributed transcode automation using FFmpeg/HandBrake
 devices:
   - /dev/dri

--- a/teamspeak/build.json
+++ b/teamspeak/build.json
@@ -3,8 +3,5 @@
     "aarch64": "ertagh/teamspeak3-server:latest-predownloaded",
     "amd64": "ertagh/teamspeak3-server:x64-latest-predownloaded",
     "armv7": "ertagh/teamspeak3-server:latest-predownloaded"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/teamspeak/config.yaml
+++ b/teamspeak/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: voice communication for online gaming, education and training
 environment:
   DIST_UPDATE: "0"

--- a/tor/build.json
+++ b/tor/build.json
@@ -3,9 +3,5 @@
     "aarch64": "ghcr.io/hassio-addons/base:17.2.0",
     "amd64": "ghcr.io/hassio-addons/base:17.2.0",
     "armv7": "ghcr.io/hassio-addons/base:17.2.0"
-  },
-  "codenotary": {
-    "base_image": "codenotary@frenck.dev",
-    "signer": "codenotary@frenck.dev"
   }
 }

--- a/tor/config.yaml
+++ b/tor/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: Protect your privacy and access Home Assistant via Tor
 image: ghcr.io/alexbelgium/tor-{arch}
 init: false

--- a/transmission/build.json
+++ b/transmission/build.json
@@ -3,8 +3,5 @@
     "aarch64": "lscr.io/linuxserver/transmission:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/transmission:amd64-latest",
     "armv7": "lscr.io/linuxserver/transmission:arm32v7-4.0.3"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/transmission/config.yaml
+++ b/transmission/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: Bittorrent client based on linuxserver image
 devices:
   - /dev/dri

--- a/transmission_openvpn/build.json
+++ b/transmission_openvpn/build.json
@@ -3,8 +3,5 @@
     "aarch64": "haugene/transmission-openvpn:latest",
     "amd64": "haugene/transmission-openvpn:latest",
     "armv7": "haugene/transmission-openvpn:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/transmission_openvpn/config.yaml
+++ b/transmission_openvpn/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description:
   Docker container running Transmission torrent client with WebUI over
   an OpenVPN tunnel

--- a/ubooquity/build.json
+++ b/ubooquity/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "lscr.io/linuxserver/ubooquity:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/ubooquity:amd64-latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/ubooquity/config.yaml
+++ b/ubooquity/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Free, lightweight, and easy-to-use home server for your comics and ebooks
 devices:
   - /dev/dri

--- a/unpackerr/build.json
+++ b/unpackerr/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "ghcr.io/hotio/unpackerr:latest",
     "amd64": "ghcr.io/hotio/unpackerr:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/unpackerr/config.yaml
+++ b/unpackerr/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Unpacks RARd files for Sonarr, Lidarr and Radarr
 devices:
   - /dev/dri

--- a/webtop/build.json
+++ b/webtop/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "linuxserver/webtop:arm64v8-ubuntu-xfce-33543f91-ls159",
     "amd64": "linuxserver/webtop:amd64-ubuntu-xfce-33543f91-ls159"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/webtop/config.yaml
+++ b/webtop/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
 audio: true
-codenotary: alexandrep.github@gmail.com
 description: Full linux desktop environment accessible via any modern web browser
 devices:
   - /dev/dri

--- a/webtop_kde/build.json
+++ b/webtop_kde/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "ghcr.io/linuxserver/webtop:arm64v8-ubuntu-kde",
     "amd64": "ghcr.io/linuxserver/webtop:amd64-ubuntu-kde"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/webtop_kde/config.yaml
+++ b/webtop_kde/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
 audio: true
-codenotary: alexandrep.github@gmail.com
 description: Full linux desktop environment accessible via any modern web browser
 devices:
   - /dev/dri

--- a/webtrees/config.yaml
+++ b/webtrees/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: web's leading on-line collaborative genealogy application
 devices:
   - /dev/dri

--- a/wger/build.json
+++ b/wger/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "wger/server:latest",
     "amd64": "wger/server:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/wger/config.yaml
+++ b/wger/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - amd64
   - aarch64
-codenotary: alexandrep.github@gmail.com
 description: manage your personal workouts, weight and diet plans
 image: ghcr.io/alexbelgium/wger-{arch}
 map:

--- a/whatsapper/build.json
+++ b/whatsapper/build.json
@@ -1,8 +1,5 @@
 {
   "build_from": {
     "amd64": "baldarn/whatsapper:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/whatsapper/config.yaml
+++ b/whatsapper/config.yaml
@@ -1,6 +1,5 @@
 arch:
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Whatsapper for Home Assistant
 image: ghcr.io/alexbelgium/whatsapper-{arch}
 map:

--- a/whoogle/build.json
+++ b/whoogle/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "ghcr.io/benbusby/whoogle-search:latest",
     "amd64": "ghcr.io/benbusby/whoogle-search:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/whoogle/config.yaml
+++ b/whoogle/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Self-hosted, ad-free, privacy-respecting metasearch engine
 devices:
   - /dev/dri

--- a/xteve/build.json
+++ b/xteve/build.json
@@ -3,8 +3,5 @@
     "aarch64": "senexcrenshaw/xteve:latest",
     "amd64": "senexcrenshaw/xteve:latest",
     "armv7": "senexcrenshaw/xteve:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/xteve/config.yaml
+++ b/xteve/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: M3U Proxy for Plex DVR and Emby Live TV
 environment:
   XTEVE_CONF: /data/conf

--- a/zoneminder/config.yaml
+++ b/zoneminder/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description:
   A full-featured, open source, state-of-the-art video surveillance software
   system

--- a/zzz_archived_bitwarden/build.yaml
+++ b/zzz_archived_bitwarden/build.yaml
@@ -3,5 +3,3 @@ build_from:
   aarch64: ghcr.io/hassio-addons/debian-base/aarch64:7.1.0
   amd64: ghcr.io/hassio-addons/debian-base/amd64:7.1.0
   armv7: ghcr.io/hassio-addons/debian-base/armv7:7.1.0
-codenotary:
-  signer: alexandrep.github@gmail.com

--- a/zzz_archived_bitwarden/config.yaml
+++ b/zzz_archived_bitwarden/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: Deprecated - please use community version
 image: ghcr.io/alexbelgium/vaultwarden-{arch}
 init: false

--- a/zzz_archived_code-server/build.json
+++ b/zzz_archived_code-server/build.json
@@ -3,8 +3,5 @@
     "aarch64": "lscr.io/linuxserver/code-server:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/code-server:amd64-latest",
     "armv7": "lscr.io/linuxserver/code-server:arm32v7-4.14.1"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/zzz_archived_code-server/config.yaml
+++ b/zzz_archived_code-server/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description:
   "Deprecated : Code-server is VS Code running on a remote server, accessible
   through the browser"

--- a/zzz_archived_paperless_ngx/build.json
+++ b/zzz_archived_paperless_ngx/build.json
@@ -2,8 +2,5 @@
   "build_from": {
     "aarch64": "ghcr.io/paperless-ngx/paperless-ngx:latest",
     "amd64": "ghcr.io/paperless-ngx/paperless-ngx:latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/zzz_archived_paperless_ngx/config.yaml
+++ b/zzz_archived_paperless_ngx/config.yaml
@@ -1,7 +1,6 @@
 arch:
   - aarch64
   - amd64
-codenotary: alexandrep.github@gmail.com
 description: Scan, index and archive all your physical documents
 devices:
   - /dev/dri

--- a/zzz_archived_papermerge/build.json
+++ b/zzz_archived_papermerge/build.json
@@ -3,8 +3,5 @@
     "aarch64": "lscr.io/linuxserver/papermerge:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/papermerge:amd64-latest",
     "armv7": "lscr.io/linuxserver/papermerge:arm32v7-latest"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/zzz_archived_papermerge/config.yaml
+++ b/zzz_archived_papermerge/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description: Open source document management system (DMS)
 devices:
   - /dev/dri

--- a/zzz_archived_plex_meta_manager/build.json
+++ b/zzz_archived_plex_meta_manager/build.json
@@ -3,8 +3,5 @@
     "aarch64": "lscr.io/linuxserver/plex-meta-manager:arm64v8-latest",
     "amd64": "lscr.io/linuxserver/plex-meta-manager:amd64-latest",
     "armv7": "lscr.io/linuxserver/plex-meta-manager:arm32v7-1.19.0"
-  },
-  "codenotary": {
-    "signer": "alexandrep.github@gmail.com"
   }
 }

--- a/zzz_archived_plex_meta_manager/config.yaml
+++ b/zzz_archived_plex_meta_manager/config.yaml
@@ -2,7 +2,6 @@ arch:
   - aarch64
   - amd64
   - armv7
-codenotary: alexandrep.github@gmail.com
 description:
   Python script to update metadata information for movies, shows, and collections
   as well as automatically build collections


### PR DESCRIPTION
## Summary
- remove deprecated `codenotary` entries from add-on build definitions
- drop matching `codenotary` metadata from add-on configuration files
- clean up repository updater configuration by deleting obsolete `codenotary` key

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690df60818888325b7ef643d9b6994d0)