### PR TITLE
Adjust README stats count to include YAML-configured add-ons

### DIFF
--- a/.github/workflows/daily_README.yaml
+++ b/.github/workflows/daily_README.yaml
@@ -103,7 +103,8 @@ jobs:
           echo "Global stats..."
           STATS_DOWNLOADS="$(awk 'NR==2{print $1}' Stats)"
           sed -i "s|%%STATS_DOWNLOADS%%|$STATS_DOWNLOADS|g" README2.md && \
-          sed -i "s|%%STATS_ADDONS%%|$(find . -name "config.json" | wc -l)|g" README2.md && \
+          ADDONS_COUNT="$(find -- * -maxdepth 1 -type f \( -name "config.json" -o -name "config.yaml" \) -printf '%h\n' 2>/dev/null | sort -u | wc -l)" && \
+          sed -i "s|%%STATS_ADDONS%%|$ADDONS_COUNT|g" README2.md && \
           STATS_ONE="$(awk 'NR==3{print $(NF)}' Stats)" && \
           STATS_TWO="$(awk 'NR==4{print $(NF)}' Stats)" && \
           STATS_THREE="$(awk 'NR==5{print $(NF)}' Stats)"


### PR DESCRIPTION
## Summary
- update the README generation workflow to count add-ons that define config.yaml files in addition to config.json files when calculating the total add-on tally

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911c4d752808325938126b13e4919fb)