### PR TITLE
feat(qbittorrent): add wireguard support

### DIFF
--- a/qbittorrent/CHANGELOG.md
+++ b/qbittorrent/CHANGELOG.md
@@ -1,5 +1,8 @@
 - Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
+## 5.1.2-8 (26-08-2025)
+- FEAT: Add first-class WireGuard support alongside OpenVPN, including automatic interface binding and tunnel health checks.
+
 ## 5.1.2-7 (17-08-2025)
 - Minor bugs fixed
 ## 5.1.2-6 (31-07-2025)

--- a/qbittorrent/README.md
+++ b/qbittorrent/README.md
@@ -33,7 +33,7 @@ This addons has several configurable options :
 - [alternative webUI](https://github.com/qbittorrent/qBittorrent/wiki/List-of-known-alternate-WebUIs)
 - usage of ssl
 - ingress
-- optional openvpn support
+- optional OpenVPN or WireGuard support
 - allow setting specific DNS servers
 
 ## Configuration
@@ -69,7 +69,9 @@ Network disk is mounted to `/mnt/<share_name>`. You need to map the exposed port
 | `openvpn_config` | str | | OpenVPN config file name (in `/config/openvpn/`) |
 | `openvpn_username` | str | | OpenVPN username |
 | `openvpn_password` | str | | OpenVPN password |
-| `openvpn_alt_mode` | bool | `false` | Bind at container level instead of app level |
+| `wireguard_enabled` | bool | `false` | Enable WireGuard connection |
+| `wireguard_config` | str | | WireGuard config file name (in `/config/wireguard/`) |
+| `openvpn_alt_mode` | bool | `false` | Bind VPN at container level instead of qBittorrent (also used for WireGuard) |
 | `qbit_manage` | bool | `false` | Enable qBit Manage integration |
 | `run_duration` | str | | Run duration (e.g., `12h`, `5d`) |
 | `silent` | bool | `false` | Suppress debug messages |
@@ -94,6 +96,17 @@ cifsusername: "username"
 cifspassword: "password"
 openvpn_enabled: false
 ```
+
+### WireGuard Configuration
+
+To use WireGuard instead of OpenVPN:
+
+1. Place your WireGuard `.conf` file(s) in `/addon_configs/<addon_host>/wireguard/` (exposed in Home Assistant as `/config/addon_configs/<slug>/wireguard`).
+1. Set `wireguard_enabled: true` in the add-on options.
+1. If you have multiple configuration files, set `wireguard_config` to the filename you want to use (for example `europe.conf`).
+1. (Optional) Enable `openvpn_alt_mode` to bind the entire container to WireGuard instead of only the qBittorrent process.
+
+The add-on automatically binds qBittorrent to the WireGuard interface (matching the configuration filename) and verifies that the tunnel replaces your public IP.
 
 ### Mounting Drives
 

--- a/qbittorrent/config.yaml
+++ b/qbittorrent/config.yaml
@@ -1,7 +1,7 @@
 arch:
   - aarch64
   - amd64
-description: Bittorrent client with optional vpn
+description: Bittorrent client with optional VPN (OpenVPN or WireGuard)
 devices:
   - /dev/net/tun
   - /dev/dri
@@ -89,8 +89,12 @@ options:
   certfile: fullchain.pem
   customUI: vuetorrent
   keyfile: privkey.pem
+  openvpn_alt_mode: false
+  openvpn_enabled: false
   qbit_manage: false
   ssl: false
+  wireguard_config: ""
+  wireguard_enabled: false
   whitelist: localhost,127.0.0.1,172.30.0.0/16,192.168.0.0/16
 panel_admin: false
 panel_icon: mdi:progress-download
@@ -133,6 +137,8 @@ schema:
   openvpn_enabled: bool?
   openvpn_password: str?
   openvpn_username: str?
+  wireguard_config: str?
+  wireguard_enabled: bool?
   qbit_manage: bool?
   run_duration: str?
   silent: bool?
@@ -141,4 +147,4 @@ schema:
 slug: qbittorrent
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: 5.1.2-7
+version: 5.1.2-8

--- a/qbittorrent/rootfs/etc/cont-init.d/93-openvpn.sh
+++ b/qbittorrent/rootfs/etc/cont-init.d/93-openvpn.sh
@@ -260,10 +260,15 @@ else
     # REMOVE OPENVPN #
     ##################
 
-    # Ensure no redirection by removing the direction tag
-    if [ -f "$QBT_CONFIG_FILE" ]; then
+    # Ensure no redirection by removing the direction tag when no VPN is active
+    if [ -f "$QBT_CONFIG_FILE" ] && ! bashio::config.true 'wireguard_enabled'; then
         sed -i '/Interface/d' "$QBT_CONFIG_FILE"
     fi
-    bashio::log.info "Direct connection without VPN enabled"
+
+    if bashio::config.true 'wireguard_enabled'; then
+        bashio::log.info "WireGuard will manage VPN connectivity."
+    else
+        bashio::log.info "Direct connection without VPN enabled"
+    fi
 
 fi

--- a/qbittorrent/rootfs/etc/cont-init.d/94-wireguard.sh
+++ b/qbittorrent/rootfs/etc/cont-init.d/94-wireguard.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+
+QBT_CONFIG_FILE="/config/qBittorrent/qBittorrent.conf"
+ENV_DIR="/var/run/s6/container_environment"
+WIREGUARD_DIR="/config/wireguard"
+
+# Clean previous environment values when WireGuard is disabled
+if ! bashio::config.true 'wireguard_enabled'; then
+    rm -f "${ENV_DIR}/WIREGUARD_CONFIG" "${ENV_DIR}/WIREGUARD_INTERFACE" 2>/dev/null || true
+    exit 0
+fi
+
+if bashio::config.true 'openvpn_enabled'; then
+    bashio::exit.nok "Both OpenVPN and WireGuard are enabled. Please enable only one VPN protocol."
+fi
+
+bashio::log.info "-----------------------------"
+bashio::log.info "WireGuard enabled, configuring"
+bashio::log.info "-----------------------------"
+
+# Capture current public IP for later comparison
+curl -s ipecho.net/plain > /currentip || true
+
+# Resolve WireGuard configuration file
+if bashio::config.has_value 'wireguard_config'; then
+    wireguard_config=$(bashio::config 'wireguard_config')
+    if [[ "${wireguard_config}" != /* ]]; then
+        wireguard_config="${WIREGUARD_DIR}/${wireguard_config}"
+    fi
+    if [ ! -f "${wireguard_config}" ]; then
+        bashio::exit.nok "WireGuard configuration file ${wireguard_config} not found."
+    fi
+else
+    mapfile -t WG_CONFIGS < <(find "${WIREGUARD_DIR}" -maxdepth 1 -type f -name '*.conf' -print)
+    if [ "${#WG_CONFIGS[@]}" -eq 0 ]; then
+        bashio::exit.nok "WireGuard is enabled, but no .conf files were found in ${WIREGUARD_DIR}."
+    elif [ "${#WG_CONFIGS[@]}" -gt 1 ]; then
+        bashio::log.error "Multiple WireGuard configuration files detected:"
+        printf '%s\n' "${WG_CONFIGS[@]}"
+        bashio::exit.nok "Please set the wireguard_config option to select the desired configuration."
+    fi
+    wireguard_config="${WG_CONFIGS[0]}"
+fi
+
+if [[ "${wireguard_config}" != *.conf ]]; then
+    bashio::exit.nok "WireGuard configuration ${wireguard_config} must use the .conf extension."
+fi
+
+dos2unix "${wireguard_config}" >/dev/null 2>&1 || true
+chmod 600 "${wireguard_config}" || true
+
+wireguard_interface="$(basename "${wireguard_config}")"
+wireguard_interface="${wireguard_interface%.*}"
+wireguard_interface="${wireguard_interface:-wg0}"
+
+mkdir -p "${ENV_DIR}"
+printf '%s' "${wireguard_config}" > "${ENV_DIR}/WIREGUARD_CONFIG"
+printf '%s' "${wireguard_interface}" > "${ENV_DIR}/WIREGUARD_INTERFACE"
+export WIREGUARD_CONFIG="${wireguard_config}"
+export WIREGUARD_INTERFACE="${wireguard_interface}"
+
+if bashio::config.true 'openvpn_alt_mode'; then
+    if [ -f "${QBT_CONFIG_FILE}" ]; then
+        sed -i '/Interface/d' "${QBT_CONFIG_FILE}"
+    fi
+    bashio::log.info "Using container-level binding for WireGuard (openvpn_alt_mode enabled)."
+    exit 0
+fi
+
+if [ ! -f "${QBT_CONFIG_FILE}" ]; then
+    bashio::log.warning "qBittorrent config file not found; WireGuard interface binding will need to be configured after the application generates it."
+    exit 0
+fi
+
+bashio::log.info "Binding qBittorrent to WireGuard interface ${wireguard_interface}."
+sed -i '/Interface/d' "${QBT_CONFIG_FILE}"
+sed -i "/\\[Preferences\\]/ i\\Connection\\\\Interface=${wireguard_interface}" "${QBT_CONFIG_FILE}"
+sed -i "/\\[Preferences\\]/ i\\Connection\\\\InterfaceName=${wireguard_interface}" "${QBT_CONFIG_FILE}"
+sed -i "/\\[BitTorrent\\]/a \\Session\\\\Interface=${wireguard_interface}" "${QBT_CONFIG_FILE}"
+sed -i "/\\[BitTorrent\\]/a \\Session\\\\InterfaceName=${wireguard_interface}" "${QBT_CONFIG_FILE}"

--- a/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
+++ b/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
@@ -10,13 +10,26 @@ fi
 if bashio::config.true 'openvpn_enabled'; then
     exec /usr/sbin/openvpn --config /config/openvpn/config.ovpn --script-security 2 --up /etc/openvpn/up.sh --down /etc/openvpn/down.sh --pull-filter ignore "route-ipv6" --pull-filter ignore "ifconfig-ipv6" --pull-filter ignore "tun-ipv6" --pull-filter ignore "redirect-gateway ipv6" --pull-filter ignore "dhcp-option DNS6"
 else
-    ########################################################
-    # DRAFT : Start wireguard if needed
     if bashio::config.true 'wireguard_enabled'; then
-        wg-quick up /config/wireguard/config.conf &
-        true
+        wireguard_interface="${WIREGUARD_INTERFACE:-}"
+        if [ -z "${wireguard_interface}" ] && [ -f /var/run/s6/container_environment/WIREGUARD_INTERFACE ]; then
+            wireguard_interface="$(cat /var/run/s6/container_environment/WIREGUARD_INTERFACE)"
+        fi
+        wireguard_interface="${wireguard_interface:-wg0}"
+
+        bashio::log.info "Waiting for WireGuard interface ${wireguard_interface} to become available."
+        for _ in $(seq 1 60); do
+            if ip link show "${wireguard_interface}" >/dev/null 2>&1; then
+                break
+            fi
+            sleep 1
+        done
+
+        if ! ip link show "${wireguard_interface}" >/dev/null 2>&1; then
+            bashio::log.fatal "WireGuard interface ${wireguard_interface} is not available."
+            exit 1
+        fi
     fi
-    ########################################################
 
     if bashio::config.true 'silent'; then
         exec \

--- a/qbittorrent/rootfs/etc/services.d/nginx/run
+++ b/qbittorrent/rootfs/etc/services.d/nginx/run
@@ -13,10 +13,42 @@ if [ -f /currentip ]; then
     nginx || nginx -s reload &
     while true; do
         # Get vpn ip
-        if ! bashio::config.true 'wireguard_enabled' && bashio::config.true 'openvpn_alt_mode'; then
-            curl -s ipecho.net/plain > /vpnip
+        vpn_interface="tun0"
+        use_interface=true
+
+        if bashio::config.true 'wireguard_enabled'; then
+            vpn_interface="${WIREGUARD_INTERFACE:-}"
+            if [ -z "${vpn_interface}" ] && [ -f /var/run/s6/container_environment/WIREGUARD_INTERFACE ]; then
+                vpn_interface="$(cat /var/run/s6/container_environment/WIREGUARD_INTERFACE)"
+            fi
+            vpn_interface="${vpn_interface:-wg0}"
+
+            if bashio::config.true 'openvpn_alt_mode'; then
+                use_interface=false
+            fi
         else
-            curl -s ipecho.net/plain --interface tun0 > /vpnip
+            if bashio::config.true 'openvpn_alt_mode'; then
+                use_interface=false
+            fi
+        fi
+
+        if ${use_interface}; then
+            if ! ip link show "${vpn_interface}" >/dev/null 2>&1; then
+                bashio::log.warning "VPN interface ${vpn_interface} is not ready yet. Retrying in 5 seconds."
+                sleep 5
+                continue
+            fi
+            if ! curl -s ipecho.net/plain --interface "${vpn_interface}" > /vpnip; then
+                bashio::log.warning "Unable to query public IP via interface ${vpn_interface}. Retrying in 5 seconds."
+                sleep 5
+                continue
+            fi
+        else
+            if ! curl -s ipecho.net/plain > /vpnip; then
+                bashio::log.warning "Unable to query public IP. Retrying in 5 seconds."
+                sleep 5
+                continue
+            fi
         fi
 
         # Verify ip has changed

--- a/qbittorrent/rootfs/etc/services.d/wireguard/finish
+++ b/qbittorrent/rootfs/etc/services.d/wireguard/finish
@@ -1,0 +1,17 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set +e
+
+if ! bashio::config.true 'wireguard_enabled'; then
+    exit 0
+fi
+
+wireguard_config="${WIREGUARD_CONFIG:-}"
+
+if [ -z "${wireguard_config}" ] && [ -f /var/run/s6/container_environment/WIREGUARD_CONFIG ]; then
+    wireguard_config="$(cat /var/run/s6/container_environment/WIREGUARD_CONFIG)"
+fi
+
+if [ -n "${wireguard_config}" ]; then
+    wg-quick down "${wireguard_config}" >/dev/null 2>&1 || true
+fi

--- a/qbittorrent/rootfs/etc/services.d/wireguard/run
+++ b/qbittorrent/rootfs/etc/services.d/wireguard/run
@@ -1,0 +1,44 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+
+if ! bashio::config.true 'wireguard_enabled'; then
+    exit 0
+fi
+
+wireguard_config="${WIREGUARD_CONFIG:-}"
+wireguard_interface="${WIREGUARD_INTERFACE:-}"
+
+if [ -z "${wireguard_config}" ] && [ -f /var/run/s6/container_environment/WIREGUARD_CONFIG ]; then
+    wireguard_config="$(cat /var/run/s6/container_environment/WIREGUARD_CONFIG)"
+fi
+
+if [ -z "${wireguard_interface}" ] && [ -f /var/run/s6/container_environment/WIREGUARD_INTERFACE ]; then
+    wireguard_interface="$(cat /var/run/s6/container_environment/WIREGUARD_INTERFACE)"
+fi
+
+wireguard_interface="${wireguard_interface:-wg0}"
+
+if [ -z "${wireguard_config}" ]; then
+    bashio::exit.nok "WireGuard service started without a configuration file."
+fi
+
+bashio::log.info "Starting WireGuard interface ${wireguard_interface} using ${wireguard_config}."
+
+# Ensure we start from a clean state
+wg-quick down "${wireguard_config}" >/dev/null 2>&1 || true
+
+if ! wg-quick up "${wireguard_config}"; then
+    bashio::exit.nok "Failed to start WireGuard interface ${wireguard_interface}."
+fi
+
+bashio::log.info "WireGuard interface ${wireguard_interface} is up."
+
+# Keep the service alive while WireGuard is active
+while true; do
+    sleep 60
+    if ! ip link show "${wireguard_interface}" >/dev/null 2>&1; then
+        bashio::log.warning "WireGuard interface ${wireguard_interface} is no longer available. Attempting to restore."
+        wg-quick up "${wireguard_config}" || bashio::log.warning "Automatic WireGuard restart failed."
+    fi
+done


### PR DESCRIPTION
## Summary
- add WireGuard configuration handling and lifecycle management to the qBittorrent add-on
- update startup and monitoring scripts to work with either OpenVPN or WireGuard tunnels
- document the new WireGuard options and bump the add-on version

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915b1faf9508325802abe299576d685)