### PR TITLE
feat: add wireguard vpn support to qbittorrent addon

### DIFF
--- a/qbittorrent/CHANGELOG.md
+++ b/qbittorrent/CHANGELOG.md
@@ -1,5 +1,9 @@
 - Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
+## 5.1.2-8 (13-11-2025)
+- FEAT : Added first-party WireGuard support alongside OpenVPN, including automatic interface binding and detailed troubleshooting logs.
+- FEAT : Exposed UDP port 51820 with validation to prevent misconfiguration when enabling WireGuard.
+
 ## 5.1.2-7 (17-08-2025)
 - Minor bugs fixed
 ## 5.1.2-6 (31-07-2025)

--- a/qbittorrent/README.md
+++ b/qbittorrent/README.md
@@ -34,6 +34,7 @@ This addons has several configurable options :
 - usage of ssl
 - ingress
 - optional openvpn support
+- optional wireguard support
 - allow setting specific DNS servers
 
 ## Configuration
@@ -70,6 +71,8 @@ Network disk is mounted to `/mnt/<share_name>`. You need to map the exposed port
 | `openvpn_username` | str | | OpenVPN username |
 | `openvpn_password` | str | | OpenVPN password |
 | `openvpn_alt_mode` | bool | `false` | Bind at container level instead of app level |
+| `wireguard_enabled` | bool | `false` | Enable WireGuard connection |
+| `wireguard_config` | str | `config.conf` | WireGuard config file name (in `/config/wireguard/`) |
 | `qbit_manage` | bool | `false` | Enable qBit Manage integration |
 | `run_duration` | str | | Run duration (e.g., `12h`, `5d`) |
 | `silent` | bool | `false` | Suppress debug messages |
@@ -93,7 +96,19 @@ networkdisks: "//192.168.1.100/downloads"
 cifsusername: "username"
 cifspassword: "password"
 openvpn_enabled: false
+wireguard_enabled: false
+wireguard_config: config.conf
 ```
+
+### WireGuard configuration
+
+When `wireguard_enabled` is set to `true`, the add-on expects a standard `wg-quick` configuration file in `/config/wireguard/` (default `config.conf`).
+
+1. Copy your provider configuration file to `/config/wireguard/` using the Filebrowser add-on or another file manager.
+2. Expose and forward UDP port `51820` on your router towards the Home Assistant host.
+3. Start the add-on and review the logs; the add-on stores the last connection attempt in `/config/wireguard/wireguard-last-start.log` and `/config/wireguard/wireguard-last-error.log` for troubleshooting.
+
+The add-on automatically binds qBittorrent to the WireGuard interface to avoid traffic leaks.
 
 ### Mounting Drives
 

--- a/qbittorrent/config.yaml
+++ b/qbittorrent/config.yaml
@@ -92,6 +92,8 @@ options:
   qbit_manage: false
   ssl: false
   whitelist: localhost,127.0.0.1,172.30.0.0/16,192.168.0.0/16
+  wireguard_config: config.conf
+  wireguard_enabled: false
 panel_admin: false
 panel_icon: mdi:progress-download
 ports:
@@ -100,12 +102,14 @@ ports:
   6882/tcp: 6882
   6882/udp: 6882
   8080/tcp: 8081
+  51820/udp: 51820
 ports_description:
   59595/tcp: Peer port, do not change
   59595/udp: Peer port, do not change
   6882/tcp: Alternative peer port, do not change
   6882/udp: Alternative peer port, do not change
   8080/tcp: Web UI port (not required for Ingress)
+  51820/udp: WireGuard VPN port (required when WireGuard is enabled)
 privileged:
   - SYS_ADMIN
   - DAC_READ_SEARCH
@@ -138,7 +142,9 @@ schema:
   silent: bool?
   ssl: bool
   whitelist: str?
+  wireguard_config: str?
+  wireguard_enabled: bool?
 slug: qbittorrent
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: 5.1.2-7
+version: 5.1.2-8

--- a/qbittorrent/rootfs/etc/cont-init.d/93-openvpn.sh
+++ b/qbittorrent/rootfs/etc/cont-init.d/93-openvpn.sh
@@ -254,6 +254,10 @@ if bashio::config.true 'openvpn_enabled'; then
         sed -i "1a route-nopull" /config/openvpn/"$openvpn_config"
     fi
 
+elif bashio::config.true 'wireguard_enabled'; then
+
+    bashio::log.info "OpenVPN disabled. WireGuard configuration detected; skipping qBittorrent interface cleanup."
+
 else
 
     ##################

--- a/qbittorrent/rootfs/etc/cont-init.d/94-wireguard.sh
+++ b/qbittorrent/rootfs/etc/cont-init.d/94-wireguard.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -euo pipefail
+
+QBT_CONFIG_FILE="/config/qBittorrent/qBittorrent.conf"
+WIREGUARD_STATE_FILE="/run/wireguard/interface"
+
+mkdir -p "$(dirname "${WIREGUARD_STATE_FILE}")"
+
+if ! bashio::config.true 'wireguard_enabled'; then
+    # Ensure previous state is cleared when WireGuard is disabled
+    rm -f "${WIREGUARD_STATE_FILE}"
+    exit 0
+fi
+
+if bashio::config.true 'openvpn_enabled'; then
+    bashio::exit.nok "OpenVPN and WireGuard cannot be enabled at the same time. Disable one of them to continue."
+fi
+
+bashio::log.info "------------------------------"
+bashio::log.info "WireGuard enabled, configuring"
+bashio::log.info "------------------------------"
+
+# Store current public IP for comparison later on
+curl -s ipecho.net/plain > /currentip
+
+wireguard_config_name=$(bashio::config 'wireguard_config')
+wireguard_config_name=${wireguard_config_name:-config.conf}
+wireguard_config_path="/config/wireguard/${wireguard_config_name}"
+
+if [ ! -f "${wireguard_config_path}" ]; then
+    bashio::exit.nok "WireGuard configuration file '${wireguard_config_name}' was not found in /config/wireguard."
+fi
+
+wireguard_port=$(bashio::addon.port '51820/udp')
+if ! bashio::var.has_value "${wireguard_port}" || [[ "${wireguard_port}" == "null" ]]; then
+    bashio::exit.nok "WireGuard requires port 51820/udp to be exposed by the add-on. Please map it in the add-on configuration."
+fi
+
+# Try to bring WireGuard down in case it is still up from a previous run
+wg-quick down "${wireguard_config_path}" >/dev/null 2>&1 || true
+
+bashio::log.info "Starting WireGuard using ${wireguard_config_name}"
+
+wireguard_output="$(mktemp)"
+if ! wg-quick up "${wireguard_config_path}" >"${wireguard_output}" 2>&1; then
+    bashio::log.error "WireGuard failed to establish a tunnel."
+    while IFS= read -r line; do
+        bashio::log.error "WireGuard: ${line}"
+    done < "${wireguard_output}"
+    bashio::log.info "Troubleshooting tips:"
+    bashio::log.info "  1. Validate the WireGuard configuration contents inside /config/wireguard/${wireguard_config_name}."
+    bashio::log.info "  2. Ensure the 51820/udp port is forwarded from your router to the Home Assistant host."
+    bashio::log.info "  3. Confirm your DNS entries and endpoint address are reachable from the Home Assistant host."
+    bashio::log.info "  4. Inspect the complete WireGuard log at /config/wireguard/wireguard-last-error.log for provider-specific errors."
+    cat "${wireguard_output}" > /config/wireguard/wireguard-last-error.log
+    rm -f "${wireguard_output}"
+    bashio::exit.nok "WireGuard could not be started. Review the troubleshooting steps above."
+fi
+
+# Preserve log for later inspection
+cat "${wireguard_output}" > /config/wireguard/wireguard-last-start.log
+rm -f "${wireguard_output}"
+
+wireguard_interface=$(wg show interfaces 2>/dev/null | awk '{print $1}' | head -n 1)
+
+if [ -z "${wireguard_interface}" ]; then
+    bashio::exit.nok "WireGuard reported no active interfaces after startup."
+fi
+
+echo "${wireguard_interface}" > "${WIREGUARD_STATE_FILE}"
+
+bashio::log.info "WireGuard tunnel established on interface '${wireguard_interface}'."
+bashio::log.info "The add-on is listening on port ${wireguard_port}/udp for incoming WireGuard traffic."
+
+# Bind qBittorrent to the WireGuard interface to avoid traffic leaks
+if [ -f "${QBT_CONFIG_FILE}" ]; then
+    bashio::log.info "Binding qBittorrent to the WireGuard interface '${wireguard_interface}'."
+    sed -i '/Interface/d' "${QBT_CONFIG_FILE}"
+    sed -i "/\\[Preferences\\]/ i\\Connection\\\\Interface=${wireguard_interface}" "${QBT_CONFIG_FILE}"
+    sed -i "/\\[Preferences\\]/ i\\Connection\\\\InterfaceName=${wireguard_interface}" "${QBT_CONFIG_FILE}"
+    sed -i "/\\[BitTorrent\\]/a \\Session\\\\Interface=${wireguard_interface}" "${QBT_CONFIG_FILE}"
+    sed -i "/\\[BitTorrent\\]/a \\Session\\\\InterfaceName=${wireguard_interface}" "${QBT_CONFIG_FILE}"
+else
+    bashio::log.warning "qBittorrent configuration file not found. Please bind the WireGuard interface manually from the UI."
+fi
+
+bashio::log.info "WireGuard setup completed successfully."

--- a/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
+++ b/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
@@ -10,14 +10,6 @@ fi
 if bashio::config.true 'openvpn_enabled'; then
     exec /usr/sbin/openvpn --config /config/openvpn/config.ovpn --script-security 2 --up /etc/openvpn/up.sh --down /etc/openvpn/down.sh --pull-filter ignore "route-ipv6" --pull-filter ignore "ifconfig-ipv6" --pull-filter ignore "tun-ipv6" --pull-filter ignore "redirect-gateway ipv6" --pull-filter ignore "dhcp-option DNS6"
 else
-    ########################################################
-    # DRAFT : Start wireguard if needed
-    if bashio::config.true 'wireguard_enabled'; then
-        wg-quick up /config/wireguard/config.conf &
-        true
-    fi
-    ########################################################
-
     if bashio::config.true 'silent'; then
         exec \
             s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost ${WEBUI_PORT}" \

--- a/qbittorrent/rootfs/etc/services.d/nginx/run
+++ b/qbittorrent/rootfs/etc/services.d/nginx/run
@@ -8,15 +8,28 @@ bashio::net.wait_for 8080 localhost 900
 
 bashio::log.info "Starting NGinx..."
 
+# Determine which network interface to use for VPN checks
+vpn_interface="tun0"
+if bashio::config.true 'wireguard_enabled'; then
+    if [ -f /run/wireguard/interface ]; then
+        vpn_interface="$(cat /run/wireguard/interface)"
+    else
+        bashio::log.warning "WireGuard interface information is missing; falling back to 'wg0'."
+        vpn_interface="wg0"
+    fi
+fi
+
 # Check vpn is working
 if [ -f /currentip ]; then
     nginx || nginx -s reload &
     while true; do
         # Get vpn ip
-        if ! bashio::config.true 'wireguard_enabled' && bashio::config.true 'openvpn_alt_mode'; then
+        if bashio::config.true 'wireguard_enabled'; then
+            curl -s ipecho.net/plain --interface "${vpn_interface}" > /vpnip
+        elif bashio::config.true 'openvpn_alt_mode'; then
             curl -s ipecho.net/plain > /vpnip
         else
-            curl -s ipecho.net/plain --interface tun0 > /vpnip
+            curl -s ipecho.net/plain --interface "${vpn_interface}" > /vpnip
         fi
 
         # Verify ip has changed


### PR DESCRIPTION
## Summary
- add first-class WireGuard configuration handling, port validation, and startup troubleshooting
- ensure qBittorrent and health checks bind to the active WireGuard interface while keeping OpenVPN logic untouched
- document the new WireGuard workflow and expose the required UDP port in the add-on manifest

## Testing
- not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691633fc1f808325842c5555b5eff891)