### PR TITLE
Fix Navidrome local disk mounting failure

### DIFF
--- a/navidrome/CHANGELOG.md
+++ b/navidrome/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.58.0-1 (15-11-2025)
+- Allow mounting local disks by adding the required Linux capabilities to the add-on.
 - Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 0.58.0 (01-08-2025)

--- a/navidrome/config.yaml
+++ b/navidrome/config.yaml
@@ -25,6 +25,9 @@ ports:
   4533/tcp: 4533
 ports_description:
   4533/tcp: Web interface
+privileged:
+  - SYS_ADMIN
+  - DAC_READ_SEARCH
 schema:
   env_vars:
     - name: match(^[A-Za-z0-9_]+$)
@@ -54,5 +57,5 @@ schema:
 slug: navidrome
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/navidrome
-version: 0.58.0
+version: 0.58.0-1
 webui: "[PROTO:ssl]://[HOST]:[PORT:4533]"


### PR DESCRIPTION
## Summary
- add the SYS_ADMIN and DAC_READ_SEARCH privileges to the Navidrome add-on so local disks can be mounted
- bump the add-on version to 0.58.0-1 and document the change in the changelog

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917584761788325a300b93e9ef8970d)