### PR TITLE
Add env_vars option to epicgamesfree addon

### DIFF
--- a/epicgamesfree/CHANGELOG.md
+++ b/epicgamesfree/CHANGELOG.md
@@ -1,3 +1,6 @@
+## "debian-2025-11-09" (09-11-2025)
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.json
+
 ## "debian-2025-10-28" (01-11-2025)
 - Minor bugs fixed
 

--- a/epicgamesfree/README.md
+++ b/epicgamesfree/README.md
@@ -28,7 +28,7 @@ This addon is based on the docker image https://hub.docker.com/r/charlocharlie/e
 
 ## Configuration
 
-There are no addon options available through the Home Assistant interface. All configuration is done via JSON files.
+Addon options expose the `env_vars` field for passing extra environment variables; all other configuration is done via JSON files.
 
 ### Configuration Files
 
@@ -38,6 +38,8 @@ Configuration files are stored in `/config/addons_config/epicgamesfree/`:
 - **cookies.json**: Authentication cookies (optional)
 
 If these files don't exist, they will be created at first boot with default settings.
+
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ### Basic Configuration
 

--- a/epicgamesfree/config.yaml
+++ b/epicgamesfree/config.yaml
@@ -73,12 +73,18 @@ init: false
 map:
   - config:rw
 name: Epic Games Free
+options:
+  env_vars: []
 ports:
   3000/tcp: 3000
 ports_description:
   3000/tcp: web interface
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
 slug: epicgamesfree
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "debian-2025-10-28"
+version: "debian-2025-11-09"
 webui: "[PROTO:ssl]://[HOST]:[PORT:3000]"


### PR DESCRIPTION
## Summary
- add an `env_vars` add-on option and schema validation to Epic Games Free
- document how to use the new `env_vars` option alongside existing JSON configuration
- bump the add-on version and changelog for the new capability

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b8265202483259d8de5238f0b851f)