### PR TITLE
Add env vars support to remaining add-ons

### DIFF
--- a/addons_updater/CHANGELOG.md
+++ b/addons_updater/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.19.12 (18-11-2025)
+
+- Added support for configuring extra environment variables through the `env_vars` option.
+
 ## 3.19.11
 
 - Avoid blank config.json when using config.yaml

--- a/addons_updater/README.md
+++ b/addons_updater/README.md
@@ -92,6 +92,6 @@ verbose: "false"
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **Environment variables**: Use the add-on `env_vars` option and see [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon) for details.
 
 [repository]: https://github.com/alexbelgium/hassio-addons

--- a/addons_updater/config.yaml
+++ b/addons_updater/config.yaml
@@ -12,10 +12,14 @@ map:
   - addon_config:rw
 name: Repository Updater
 options:
+  env_vars: []
   gitapi: gitapi
   gituser: gituser
   repository: alexbelgium/hassio-addons
 schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
   dry_run: bool?
   gitapi: str
   gitmail: str?
@@ -25,4 +29,4 @@ schema:
 slug: updater
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/addons_updater
-version: "3.19.11"
+version: "3.19.12"

--- a/baikal/CHANGELOG.md
+++ b/baikal/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.10.1-hafix3 (18-11-2025)
+- Added support for configuring extra environment variables via the `env_vars` option alongside config.yaml.
+
 ## 0.10.1-hafix2 (01-08-2025)
 - Minor bugs fixed
 

--- a/baikal/README.md
+++ b/baikal/README.md
@@ -61,6 +61,10 @@ The installation of this add-on is pretty straightforward and not different in c
 1. Check the logs of the add-on to see if everything went well.
 1. Open the webUI and adapt the software options
 
+### Environment variables
+
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## Support
 
 Create an issue on github

--- a/baikal/config.yaml
+++ b/baikal/config.yaml
@@ -72,12 +72,18 @@ map:
   - share:rw
   - ssl:ro
 name: Baikal
+options:
+  env_vars: []
 ports:
   80/tcp: 8013
 ports_description:
   80/tcp: Web UI port
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
 slug: baikal
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: 0.10.1-hafix2
+version: 0.10.1-hafix3
 webui: "[PROTO:ssl]://[HOST]:[PORT:80]"

--- a/elasticsearch/CHANGELOG.md
+++ b/elasticsearch/CHANGELOG.md
@@ -1,3 +1,6 @@
+- 8.14.3-1 (18-11-2025)
+  - Added `env_vars` option to support custom environment variables from the add-on configuration.
+
 - BREAKING CHANGE : upgrade to v8.14.3. You'll need to rebuild your indexes
 
 ## v7

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -80,6 +80,10 @@ Connect other applications to Elasticsearch using:
 - **Nextcloud**: Configure Full Text Search app to use this Elasticsearch instance
 - **Home Assistant**: Use with the Elasticsearch component for event publishing
 
+### Environment variables
+
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## Integration with HA
 
 Component : https://community.home-assistant.io/t/elasticsearch-component-publish-home-assistant-events-to-elasticsearch/66877

--- a/elasticsearch/config.yaml
+++ b/elasticsearch/config.yaml
@@ -74,14 +74,20 @@ image: ghcr.io/alexbelgium/elasticsearch-{arch}
 map:
   - config:rw
 name: Elasticsearch server
+options:
+  env_vars: []
 ports:
   9200/tcp: 9200
   9300/tcp: 9300
 ports_description:
   9200/tcp: API calls over HTTP
   9300/tcp: custom binary protoco
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
 slug: elasticsearch
 startup: services
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/elasticsearch
-version: 8.14.3
+version: 8.14.3-1

--- a/flaresolverr/CHANGELOG.md
+++ b/flaresolverr/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 3.4.5-1 (18-11-2025)
+- Added `env_vars` option to allow custom environment variables from the add-on configuration.
+
 ## 3.4.5 (15-11-2025)
 - Update to latest version from FlareSolverr/FlareSolverr (changelog : https://github.com/FlareSolverr/FlareSolverr/releases)
 

--- a/flaresolverr/README.md
+++ b/flaresolverr/README.md
@@ -81,6 +81,10 @@ No configuration options are available - FlareSolverr works automatically with d
 - **CPU**: Moderate usage during challenge solving
 - **Network**: Requires internet access to function
 
+### Environment variables
+
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## Support
 
 Create an issue on github

--- a/flaresolverr/config.yaml
+++ b/flaresolverr/config.yaml
@@ -67,12 +67,18 @@ devices:
   - /dev/nvme2
 image: ghcr.io/alexbelgium/flaresolverr-{arch}
 name: FlareSolverr
+options:
+  env_vars: []
 ports:
   8191/tcp: 8191
 ports_description:
   8191/tcp: Web interface
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
 slug: flaresolverr
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "3.4.5"
+version: "3.4.5-1"
 webui: "[PROTO:ssl]://[HOST]:[PORT:8191]"

--- a/omada/CHANGELOG.md
+++ b/omada/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 5.14.26.1-2024-08-29-1 (18-11-2025)
+- Added `env_vars` option to allow passing custom environment variables from the add-on configuration.
+
 ## 5.14.26.1-2024-08-29 (2024-08-29)
 - Update to latest version from mbentley/omada-controller
 

--- a/omada/README.md
+++ b/omada/README.md
@@ -72,7 +72,7 @@ Webui can be found at `<your-ip>:8088` (HTTP) or `<your-ip>:8043` (HTTPS).
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
-- **Environment variables**: See [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon)
+- **Environment variables**: Use the add-on `env_vars` option and see [Add Environment Variables to your Addon](https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon) for details.
 
 ## Support
 

--- a/omada/config.yaml
+++ b/omada/config.yaml
@@ -75,6 +75,8 @@ map:
   - addon_config:rw
   - ssl:ro
 name: Omada
+options:
+  env_vars: []
 ports:
   29810/udp: 29810
   29811/tcp: 29811
@@ -99,8 +101,12 @@ ports_description:
   8088/tcp: web interface http
   8843/tcp: portal https
   8888/tcp: portal http
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
 slug: omada
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: 5.14.26.1-2024-08-17
+version: 5.14.26.1-2024-08-29-1
 webui: http://[HOST]:[PORT:8088]

--- a/omada_v3/CHANGELOG.md
+++ b/omada_v3/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 5.3-amd64-2025-11-09-1 (18-11-2025)
+- Added `env_vars` option to allow passing custom environment variables from the add-on configuration.
+
 ## 5.3-amd64-2025-11-09 (2025-11-09)
 - Update to latest version from mbentley/omada-controller
 ## 5.3-2025-05-30 (31-05-2025)

--- a/omada_v3/README.md
+++ b/omada_v3/README.md
@@ -52,6 +52,10 @@ This addon provided the legacy TP-Link Omada Controller v3.x for managing older 
 3. **Import configuration** and reconnect devices
 4. **Verify functionality** before removing this legacy addon
 
+### Environment variables
+
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## Legacy Support
 
 This addon is maintained for compatibility only. No new features will be added.

--- a/omada_v3/config.yaml
+++ b/omada_v3/config.yaml
@@ -80,6 +80,8 @@ map:
   - config:rw
   - ssl:ro
 name: Omada v3.2
+options:
+  env_vars: []
 ports:
   29810/udp: 29810
   29811/tcp: 29811
@@ -100,8 +102,12 @@ ports_description:
   8088/tcp: web interface http
   8843/tcp: portal https
   8888/tcp: portal http
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
 slug: omada_v3
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "5.3-amd64-2025-11-09"
+version: "5.3-amd64-2025-11-09-1"
 webui: http://[HOST]:[PORT:8088]

--- a/omni-tools/CHANGELOG.md
+++ b/omni-tools/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 0.6.1 (18-11-2025)
+- Added `env_vars` option to allow passing custom environment variables from the add-on configuration.
+
 ## 0.6.0 (04-10-2025)
 - Update to latest version from iib0011/omni-tools (changelog : https://github.com/iib0011/omni-tools/releases)
 ## v0.5.0 (30-07-2025)

--- a/omni-tools/README.md
+++ b/omni-tools/README.md
@@ -50,6 +50,10 @@ Timezone setting for the application.
 
 All processing is done locally in your browser for maximum privacy and security.
 
+### Environment variables
+
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## Support
 
 Got questions?

--- a/omni-tools/config.yaml
+++ b/omni-tools/config.yaml
@@ -8,11 +8,17 @@ image: ghcr.io/alexbelgium/omni-tools-{arch}
 map:
   - addon_config:rw
 name: Omni Tools
+options:
+  env_vars: []
 ports:
   80/tcp: 8188
 ports_description:
   80/tcp: Web UI port
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
 slug: omni-tools
 url: https://github.com/alexbelgium/hassio-addons
-version: 0.6.0
+version: 0.6.1
 webui: "[PROTO:ssl]://[HOST]:[PORT:80]"

--- a/signalk/CHANGELOG.md
+++ b/signalk/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 2.18.0-1 (18-11-2025)
+- Added `env_vars` option to allow custom environment variables from the add-on configuration.
+
 ## 2.18.0 (08-11-2025)
 - Update to latest version from SignalK/signalk-server (changelog : https://github.com/SignalK/signalk-server/releases)
 ## "2.17.2" (18-10-2025)

--- a/signalk/README.md
+++ b/signalk/README.md
@@ -41,6 +41,10 @@ The installation of this add-on is pretty straightforward and not different in c
 1. Check the logs of the add-on to see if everything went well.
 1. Open the webUI and adapt the software options
 
+### Environment variables
+
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## Support
 
 Create an issue on github

--- a/signalk/config.yaml
+++ b/signalk/config.yaml
@@ -21,6 +21,8 @@ image: ghcr.io/alexbelgium/signalk-{arch}
 map:
   - addon_config:rw
 name: Signalk Server
+options:
+  env_vars: []
 ports:
   10110/tcp: 10110
   1458/udp: null
@@ -37,6 +39,10 @@ ports_description:
   3000/tcp: web interface
   3443/tcp: ssl web interface
   8375/tcp: TCPSTREAM port
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
 privileged:
   - SYS_ADMIN
   - SYS_RAWIO
@@ -45,5 +51,5 @@ uart: true
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "2.18.0"
+version: "2.18.0-1"
 webui: http://[HOST]:[PORT:3000]

--- a/teamspeak/CHANGELOG.md
+++ b/teamspeak/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.13.6-9 (18-11-2025)
+- Added `env_vars` option to allow passing custom environment variables from the add-on configuration.
+
 - WARNING : update to supervisor 2022.11 before installing
 - Allow persistence on arm devices
 - Add codenotary sign

--- a/teamspeak/README.md
+++ b/teamspeak/README.md
@@ -62,6 +62,10 @@ Connect using the TeamSpeak client at `homeassistant.local:9987`.
 
 **Important**: Configure your router to forward these ports for external access.
 
+### Environment variables
+
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## Support
 
 If you have in issue with your installation, please be sure to checkout github.

--- a/teamspeak/config.yaml
+++ b/teamspeak/config.yaml
@@ -15,6 +15,8 @@ init: false
 map:
   - share:rw
 name: Teamspeak server
+options:
+  env_vars: []
 ports:
   10011/tcp: 10011
   30033/tcp: 30033
@@ -25,7 +27,11 @@ ports_description:
   30033/tcp: Filetransfer
   41144/tcp: TSDNS
   9987/udp: Voice
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
 slug: teamspeak
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: 3.13.6-8
+version: 3.13.6-9

--- a/whatsapper/CHANGELOG.md
+++ b/whatsapper/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.5 (18-11-2025)
+- Added `env_vars` option to allow passing custom environment variables from the add-on configuration.
+
 ## 1.0.4 (15-09-2025)
 - Update to latest version from baldarn/whatsapper (changelog : https://github.com/baldarn/whatsapper/releases)
 

--- a/whatsapper/README.md
+++ b/whatsapper/README.md
@@ -52,4 +52,8 @@ comparison to installing any other Hass.io add-on.
 1. Go to the webui, where you will initialize the app
 1. Restart the addon, to apply any option that should be applied
 
+### Environment variables
+
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 [repository]: https://github.com/alexbelgium/hassio-addons

--- a/whatsapper/config.yaml
+++ b/whatsapper/config.yaml
@@ -6,11 +6,17 @@ map:
   - addon_config:rw
   - share:rw
 name: Whatsapper
+options:
+  env_vars: []
 ports:
   3000/tcp: 4000
 ports_description:
   3000/tcp: Api interface
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
 slug: whatsapper
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/whatsapper
-version: 1.0.4
+version: 1.0.5

--- a/xteve/CHANGELOG.md
+++ b/xteve/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.5.3-3 (18-11-2025)
+- Added `env_vars` option to allow passing custom environment variables from the add-on configuration.
+
 - WARNING : update to supervisor 2022.11 before installing
 
 ## 2.5.3 (22-10-2022)

--- a/xteve/README.md
+++ b/xteve/README.md
@@ -58,6 +58,10 @@ No configuration options are required for this addon. All configuration is done 
 
 **Note**: xTeVe stores its configuration in `/data/` and runs on port 34400. Access the web interface to configure M3U playlists and XMLTV sources.
 
+### Environment variables
+
+Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
 ## Support
 
 Create an issue on github

--- a/xteve/config.yaml
+++ b/xteve/config.yaml
@@ -13,12 +13,18 @@ map:
   - share:rw
   - ssl:ro
 name: Xteve
+options:
+  env_vars: []
 ports:
   34400/tcp: 34400
 ports_description:
   34400/tcp: Web interface
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
 slug: xteve
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: 2.5.3-2
+version: 2.5.3-3
 webui: "[PROTO:ssl]://[HOST]:[PORT:34400]/web"


### PR DESCRIPTION
## Summary
- add `env_vars` options and schemas to remaining add-on configurations
- document the new environment variable support and bump versions/changelogs accordingly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c1fbb7ba883258f00caf330726d8c)