### PR TITLE
Add IPv6 detection and firewall fallback for WireGuard

### DIFF
--- a/qbittorrent/CHANGELOG.md
+++ b/qbittorrent/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.2-13 (19-11-2025)
+- Detect when the host disables IPv6, automatically strip IPv6-only WireGuard assignments and record the state for qBittorrent bindings.
+- Add iptables/ip6tables fallback wrappers so WireGuard can still start (with warnings) on systems without the required kernel firewall modules.
+
 ## 5.1.2-12 (19-11-2025)
 - Improve ip monitoring with wireguard
 

--- a/qbittorrent/README.md
+++ b/qbittorrent/README.md
@@ -78,7 +78,7 @@ Network disk is mounted to `/mnt/<share_name>`. You need to map the exposed port
 
 ### WireGuard Setup
 
-WireGuard configuration files must be stored in `/config/wireguard`. If several `.conf` files are present, set `wireguard_config` to the file name you want to use (for example `wg0.conf`). Expose UDP port `51820` in the add-on options and forward it from your router only when your tunnel expects inbound peers (for example, site-to-site setups). Outbound-only commercial VPN providers usually do not require a mapped port. The runtime configuration now preserves both IPv4 and IPv6 entries, so you can use dual-stack WireGuard peers when your endpoint supports them.
+WireGuard configuration files must be stored in `/config/wireguard`. If several `.conf` files are present, set `wireguard_config` to the file name you want to use (for example `wg0.conf`). Expose UDP port `51820` in the add-on options and forward it from your router only when your tunnel expects inbound peers (for example, site-to-site setups). Outbound-only commercial VPN providers usually do not require a mapped port. The runtime configuration now preserves IPv4 and IPv6 entries whenever the host supports both stacks, automatically strips IPv6-only assignments when IPv6 is disabled, and can fall back to a degraded (no iptables/ip6tables) mode when the host kernel lacks the necessary firewall modules.
 
 ### Example Configuration
 

--- a/qbittorrent/rootfs/etc/cont-init.d/94-wireguard.sh
+++ b/qbittorrent/rootfs/etc/cont-init.d/94-wireguard.sh
@@ -4,14 +4,37 @@ set -e
 
 WIREGUARD_STATE_DIR="/var/run/wireguard"
 QBT_CONFIG_FILE="/config/qBittorrent/qBittorrent.conf"
+WIREGUARD_IPV6_STATE_FILE="${WIREGUARD_STATE_DIR}/ipv6_state"
 declare wireguard_config=""
 declare wireguard_runtime_config=""
 declare configured_name
 
+wireguard_ipv6_supported() {
+    local ipv6_disabled="0"
+    if command -v sysctl >/dev/null 2>&1; then
+        ipv6_disabled="$(sysctl -n net.ipv6.conf.all.disable_ipv6 2>/dev/null || echo 0)"
+    fi
+
+    if [[ "${ipv6_disabled}" == "1" ]]; then
+        return 1
+    fi
+
+    if [[ ! -s /proc/net/if_inet6 ]]; then
+        return 1
+    fi
+
+    return 0
+}
+
+record_ipv6_state() {
+    local state="$1"
+    echo "${state}" > "${WIREGUARD_IPV6_STATE_FILE}"
+}
+
 mkdir -p "${WIREGUARD_STATE_DIR}"
 
 if ! bashio::config.true 'wireguard_enabled'; then
-    rm -f "${WIREGUARD_STATE_DIR}/config" "${WIREGUARD_STATE_DIR}/interface"
+    rm -f "${WIREGUARD_STATE_DIR}/config" "${WIREGUARD_STATE_DIR}/interface" "${WIREGUARD_IPV6_STATE_FILE}"
     exit 0
 fi
 
@@ -61,10 +84,72 @@ wireguard_runtime_config="${WIREGUARD_STATE_DIR}/${interface_name}.conf"
 
 cp "${wireguard_config}" "${wireguard_runtime_config}"
 chmod 600 "${wireguard_runtime_config}" 2>/dev/null || true
-bashio::log.info 'Prepared WireGuard runtime configuration with both IPv4 and IPv6 entries.'
+bashio::log.info 'Prepared WireGuard runtime configuration copy. Performing compatibility checks next.'
 
 echo "${wireguard_runtime_config}" > "${WIREGUARD_STATE_DIR}/config"
 echo "${interface_name}" > "${WIREGUARD_STATE_DIR}/interface"
+
+if wireguard_ipv6_supported; then
+    record_ipv6_state 'enabled'
+else
+    record_ipv6_state 'disabled'
+    if command -v python3 >/dev/null 2>&1; then
+        if WIREGUARD_RUNTIME_CONFIG="${wireguard_runtime_config}" python3 <<'PY'
+import os
+from pathlib import Path
+
+runtime_config = Path(os.environ['WIREGUARD_RUNTIME_CONFIG'])
+raw_text = runtime_config.read_text()
+lines = raw_text.splitlines()
+keys = {'Address', 'AllowedIPs', 'DNS'}
+changed = False
+result = []
+
+for line in lines:
+    stripped = line.strip()
+    if not stripped or stripped.startswith('#') or '=' not in line:
+        result.append(line)
+        continue
+
+    key, rest = line.split('=', 1)
+    key_name = key.strip()
+    if key_name not in keys:
+        result.append(line)
+        continue
+
+    comment = ''
+    if '#' in rest:
+        rest, comment = rest.split('#', 1)
+        comment = '#' + comment
+
+    values = [entry.strip() for entry in rest.split(',') if entry.strip()]
+    filtered = [entry for entry in values if ':' not in entry]
+
+    if len(filtered) != len(values):
+        changed = True
+
+    if filtered:
+        new_line = f"{key.rstrip()} = {', '.join(filtered)}"
+        if comment:
+            new_line = f"{new_line} {comment.strip()}"
+        result.append(new_line)
+    else:
+        if comment:
+            result.append(comment.strip())
+
+if changed:
+    ending = '\n' if raw_text.endswith('\n') else ''
+    runtime_config.write_text('\n'.join(result) + ending)
+PY
+        then
+            bashio::log.warning 'IPv6 support not detected on the host. IPv6 entries have been stripped from the WireGuard runtime configuration.'
+        else
+            bashio::log.warning 'IPv6 support not detected and automatic IPv6 stripping failed. Please ensure your WireGuard configuration only contains IPv4 values.'
+        fi
+    else
+        bashio::log.warning 'IPv6 support not detected but python3 is unavailable. Please provide an IPv4-only WireGuard configuration.'
+    fi
+fi
 
 if bashio::fs.file_exists "${QBT_CONFIG_FILE}"; then
     sed -i '/Interface/d' "${QBT_CONFIG_FILE}"

--- a/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
+++ b/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
@@ -5,6 +5,62 @@ WEBUI_PORT=${WEBUI_PORT:-8080}
 
 export PATH="/usr/local/sbin:/usr/local/bin:${PATH}"
 
+wireguard_firewall_command_works() {
+    local cmd="$1"
+
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+        return 1
+    fi
+
+    if ! { printf '%s\n' '*filter'; printf '%s\n' 'COMMIT'; } | "${cmd}" -n >/dev/null 2>&1; then
+        return 1
+    fi
+
+    return 0
+}
+
+wireguard_create_firewall_wrapper() {
+    local cmd="$1"
+    local dir="$2"
+    local target="${dir}/${cmd}"
+
+    {
+        echo '#!/bin/sh'
+        printf 'echo "WireGuard firewall fallback: %s skipped." >&2\n' "${cmd}"
+        echo 'exit 0'
+    } > "${target}"
+
+    chmod +x "${target}"
+}
+
+wireguard_prepare_firewall_wrappers() {
+    local ipv6_state="$1"
+    local fallback_dir="${WIREGUARD_STATE_DIR}/iptables-fallback"
+    local wrappers_created=false
+
+    rm -rf "${fallback_dir}"
+    mkdir -p "${fallback_dir}"
+
+    if ! wireguard_firewall_command_works 'iptables-restore'; then
+        wrappers_created=true
+        bashio::log.warning 'iptables-restore is unavailable or failed to initialize. WireGuard will skip iptables firewall programming.'
+        wireguard_create_firewall_wrapper 'iptables-restore' "${fallback_dir}"
+    fi
+
+    if [[ "${ipv6_state}" != 'disabled' ]] && ! wireguard_firewall_command_works 'ip6tables-restore'; then
+        wrappers_created=true
+        bashio::log.warning 'ip6tables-restore is unavailable or failed to initialize. WireGuard will skip IPv6 firewall programming.'
+        wireguard_create_firewall_wrapper 'ip6tables-restore' "${fallback_dir}"
+    fi
+
+    if [[ "${wrappers_created}" == true ]]; then
+        export PATH="${fallback_dir}:${PATH}"
+        bashio::log.warning 'Continuing without kernel iptables support. Consider enabling the required modules on the host for full kill-switch protection.'
+    else
+        rmdir "${fallback_dir}" 2>/dev/null || true
+    fi
+}
+
 if bashio::config.true 'silent'; then
     sed -i 's|/proc/1/fd/1 hassio;|off;|g' /etc/nginx/nginx.conf
 fi
@@ -30,6 +86,9 @@ else
 
         wireguard_config="$(cat "${WIREGUARD_STATE_DIR}/config")"
         wireguard_interface="$(cat "${WIREGUARD_STATE_DIR}/interface" 2>/dev/null || echo 'wg0')"
+        wireguard_ipv6_state="$(cat "${WIREGUARD_STATE_DIR}/ipv6_state" 2>/dev/null || echo 'unknown')"
+
+        wireguard_prepare_firewall_wrappers "${wireguard_ipv6_state}"
 
         if ip link show "${wireguard_interface}" &> /dev/null; then
             bashio::log.warning "WireGuard interface ${wireguard_interface} already exists. Attempting to reset it."


### PR DESCRIPTION
## Summary
- detect whether the host supports IPv6, persist the state and automatically strip IPv6-only entries from the runtime WireGuard configuration when necessary
- introduce iptables/ip6tables fallbacks so wg-quick can still bring the tunnel up (with warnings) when the host kernel lacks the required firewall modules
- document the new behaviour in the README and changelog

## Testing
- Not run (not applicable for this change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ddc34b9648325b36bb3627c06787b)