### PR TITLE
Improve WireGuard IPv6 fallbacks

### DIFF
--- a/qbittorrent/CHANGELOG.md
+++ b/qbittorrent/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.2-13 (21-11-2025)
+- Automatically retry WireGuard with an IPv4-only configuration when IPv6 connectivity (verified via ping to 2606:4700:4700::1111) is unavailable.
+- Allow wg-quick to proceed even when iptables/ip6tables firewall modules are missing by logging warnings and skipping the offending rules.
+
 ## 5.1.2-12 (19-11-2025)
 - Improve ip monitoring with wireguard
 

--- a/qbittorrent/README.md
+++ b/qbittorrent/README.md
@@ -80,6 +80,8 @@ Network disk is mounted to `/mnt/<share_name>`. You need to map the exposed port
 
 WireGuard configuration files must be stored in `/config/wireguard`. If several `.conf` files are present, set `wireguard_config` to the file name you want to use (for example `wg0.conf`). Expose UDP port `51820` in the add-on options and forward it from your router only when your tunnel expects inbound peers (for example, site-to-site setups). Outbound-only commercial VPN providers usually do not require a mapped port. The runtime configuration now preserves both IPv4 and IPv6 entries, so you can use dual-stack WireGuard peers when your endpoint supports them.
 
+The add-on also prepares an IPv4-only version of your WireGuard configuration. If bringing the tunnel up fails and an IPv6 connectivity probe (`ping -6` to Cloudflare's `2606:4700:4700::1111` by default) does not succeed, the service automatically retries with the IPv4-only copy to keep the tunnel operational. You can override the probe target by defining the `WIREGUARD_IPV6_CHECK_TARGET` environment variable. Additionally, the bundled `iptables-restore`/`ip6tables-restore` wrappers now downgrade to warning-only behavior when the host kernel is missing the required firewall modules, allowing `wg-quick` to continue instead of aborting.
+
 ### Example Configuration
 
 ```yaml

--- a/qbittorrent/rootfs/etc/cont-init.d/94-wireguard.sh
+++ b/qbittorrent/rootfs/etc/cont-init.d/94-wireguard.sh
@@ -6,7 +6,79 @@ WIREGUARD_STATE_DIR="/var/run/wireguard"
 QBT_CONFIG_FILE="/config/qBittorrent/qBittorrent.conf"
 declare wireguard_config=""
 declare wireguard_runtime_config=""
+declare wireguard_runtime_config_ipv4=""
 declare configured_name
+
+create_ipv4_only_config() {
+    local source_file="$1"
+    local target_file="$2"
+    local temp_file
+
+    temp_file="$(mktemp)"
+
+    awk 'BEGIN { IGNORECASE = 1 }
+function trim(str) {
+    gsub(/^[ \t]+/, "", str)
+    gsub(/[ \t]+$/, "", str)
+    return str
+}
+{
+    line = $0
+    if (match(line, /^([[:space:]]*)(Address|AllowedIPs|DNS)([[:space:]]*=[[:space:]]*)(.*)$/, parts)) {
+        prefix = parts[1]
+        key = parts[2]
+        sep = parts[3]
+        rest = parts[4]
+        comment = ""
+        hash_index = index(rest, "#")
+        if (hash_index > 0) {
+            comment = substr(rest, hash_index)
+            rest = substr(rest, 1, hash_index - 1)
+        }
+        gsub(/[\r\n]+/, "", rest)
+        delete filtered
+        filtered_count = 0
+        n = split(rest, raw, /[,[:space:]]+/)
+        for (i = 1; i <= n; i++) {
+            entry = trim(raw[i])
+            if (entry == "") {
+                continue
+            }
+            if (index(entry, ":") > 0) {
+                continue
+            }
+            filtered[++filtered_count] = entry
+        }
+        if (filtered_count == 0) {
+            if (comment != "") {
+                print prefix comment
+            }
+            next
+        }
+        line = prefix key sep filtered[1]
+        for (i = 2; i <= filtered_count; i++) {
+            line = line ", " filtered[i]
+        }
+        if (comment != "") {
+            line = line comment
+        }
+        print line
+        next
+    }
+    print line
+}' "${source_file}" > "${temp_file}"
+
+    if cmp -s "${source_file}" "${temp_file}"; then
+        rm -f "${temp_file}" "${target_file}" "${WIREGUARD_STATE_DIR}/config_ipv4"
+        return 1
+    fi
+
+    mv "${temp_file}" "${target_file}"
+    chmod 600 "${target_file}" 2>/dev/null || true
+    echo "${target_file}" > "${WIREGUARD_STATE_DIR}/config_ipv4"
+    bashio::log.info "Prepared IPv4-only WireGuard fallback configuration at ${target_file##*/}."
+    return 0
+}
 
 mkdir -p "${WIREGUARD_STATE_DIR}"
 
@@ -58,10 +130,15 @@ if [[ -z "${interface_name}" ]]; then
 fi
 
 wireguard_runtime_config="${WIREGUARD_STATE_DIR}/${interface_name}.conf"
+wireguard_runtime_config_ipv4="${WIREGUARD_STATE_DIR}/${interface_name}.ipv4.conf"
 
 cp "${wireguard_config}" "${wireguard_runtime_config}"
 chmod 600 "${wireguard_runtime_config}" 2>/dev/null || true
 bashio::log.info 'Prepared WireGuard runtime configuration with both IPv4 and IPv6 entries.'
+
+if ! create_ipv4_only_config "${wireguard_runtime_config}" "${wireguard_runtime_config_ipv4}"; then
+    bashio::log.debug 'IPv4-only WireGuard fallback configuration not required for this setup.'
+fi
 
 echo "${wireguard_runtime_config}" > "${WIREGUARD_STATE_DIR}/config"
 echo "${interface_name}" > "${WIREGUARD_STATE_DIR}/interface"

--- a/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
+++ b/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
@@ -29,6 +29,10 @@ else
         fi
 
         wireguard_config="$(cat "${WIREGUARD_STATE_DIR}/config")"
+        wireguard_config_ipv4=""
+        if bashio::fs.file_exists "${WIREGUARD_STATE_DIR}/config_ipv4"; then
+            wireguard_config_ipv4="$(cat "${WIREGUARD_STATE_DIR}/config_ipv4" 2>/dev/null || true)"
+        fi
         wireguard_interface="$(cat "${WIREGUARD_STATE_DIR}/interface" 2>/dev/null || echo 'wg0')"
 
         if ip link show "${wireguard_interface}" &> /dev/null; then
@@ -39,17 +43,41 @@ else
         bashio::log.info "Starting WireGuard interface ${wireguard_interface} using ${wireguard_config##*/}."
 
         if ! output=$(wg-quick up "${wireguard_config}" 2>&1); then
-            bashio::log.error 'WireGuard failed to establish a connection.'
-            bashio::log.error "wg-quick output:"
-            bashio::log.error "${output}"
-            bashio::log.error 'Troubleshooting steps:'
-            bashio::log.error "  1. Confirm that the WireGuard configuration file '${wireguard_config}' exists inside the container and contains valid private/public keys, endpoint and AllowedIPs."
-            bashio::log.error '  2. Ensure UDP port 51820 (or the port defined in your config) is forwarded on your router to this host and not blocked by your firewall or ISP.'
-            bashio::log.error '  3. Verify that the configured endpoint (IP/hostname and port) is reachable from this container (e.g. ping or nc from a debug shell).'
-            bashio::log.error '  4. Check that the system time is correct (NTP); large time drift can break key handshakes.'
-            bashio::log.error '  5. Confirm that WireGuard kernel support / module is available in the host system.'
-            bashio::log.error '  6. If DNS names are used for the endpoint, verify DNS resolution from inside the container (e.g. nslookup or dig).'
-            bashio::exit.nok 'WireGuard start failed. See the log above for details.'
+            ipv4_retry_success=false
+            ipv4_retry_output=""
+            ipv6_probe_target="${WIREGUARD_IPV6_CHECK_TARGET:-2606:4700:4700::1111}"
+
+            if [[ -n "${wireguard_config_ipv4}" ]]; then
+                if ping -6 -c 1 -W 2 "${ipv6_probe_target}" >/dev/null 2>&1; then
+                    bashio::log.debug "IPv6 connectivity check to ${ipv6_probe_target} succeeded; skipping IPv4-only WireGuard fallback."
+                else
+                    bashio::log.warning "IPv6 connectivity check to ${ipv6_probe_target} failed. Retrying WireGuard with IPv4-only configuration."
+                    if ipv4_retry_output=$(wg-quick up "${wireguard_config_ipv4}" 2>&1); then
+                        ipv4_retry_success=true
+                        wireguard_config="${wireguard_config_ipv4}"
+                        echo "${wireguard_config}" > "${WIREGUARD_STATE_DIR}/config"
+                        bashio::log.info "WireGuard interface ${wireguard_interface} is up using IPv4-only fallback configuration."
+                    fi
+                fi
+            fi
+
+            if [[ "${ipv4_retry_success}" != true ]]; then
+                bashio::log.error 'WireGuard failed to establish a connection.'
+                bashio::log.error "wg-quick output:"
+                bashio::log.error "${output}"
+                if [[ -n "${ipv4_retry_output}" ]]; then
+                    bashio::log.error 'IPv4-only retry output:'
+                    bashio::log.error "${ipv4_retry_output}"
+                fi
+                bashio::log.error 'Troubleshooting steps:'
+                bashio::log.error "  1. Confirm that the WireGuard configuration file '${wireguard_config}' exists inside the container and contains valid private/public keys, endpoint and AllowedIPs."
+                bashio::log.error '  2. Ensure UDP port 51820 (or the port defined in your config) is forwarded on your router to this host and not blocked by your firewall or ISP.'
+                bashio::log.error '  3. Verify that the configured endpoint (IP/hostname and port) is reachable from this container (e.g. ping or nc from a debug shell).'
+                bashio::log.error '  4. Check that the system time is correct (NTP); large time drift can break key handshakes.'
+                bashio::log.error '  5. Confirm that WireGuard kernel support / module is available in the host system.'
+                bashio::log.error '  6. If DNS names are used for the endpoint, verify DNS resolution from inside the container (e.g. nslookup or dig).'
+                bashio::exit.nok 'WireGuard start failed. See the log above for details.'
+            fi
         fi
 
         bashio::log.info "WireGuard interface ${wireguard_interface} is up."

--- a/qbittorrent/rootfs/usr/local/sbin/ip6tables-restore
+++ b/qbittorrent/rootfs/usr/local/sbin/ip6tables-restore
@@ -21,6 +21,10 @@ ipv6_unavailable() {
     [[ $message =~ address[[:space:]]family[[:space:]]not[[:space:]]supported ]] && return 0
     [[ $message =~ can[[:punct:]]t[[:space:]]initialize[[:space:]]ip6tables[[:space:]]table ]] && return 0
     [[ $message =~ IPv6[[:space:]]support[[:space:]]not[[:space:]]available ]] && return 0
+    [[ $message =~ [Nn]o[[:space:]]chain/target/match[[:space:]]by[[:space:]]that[[:space:]]name ]] && return 0
+    [[ $message =~ [Cc]ouldn.t[[:space:]]load[[:space:]]target ]] && return 0
+    [[ $message =~ [Cc]ould[[:space:]]not[[:space:]]load[[:space:]]target ]] && return 0
+    [[ $message =~ [Pp]rotocol[[:space:]]not[[:space:]]supported ]] && return 0
     return 1
 }
 

--- a/qbittorrent/rootfs/usr/local/sbin/iptables-restore
+++ b/qbittorrent/rootfs/usr/local/sbin/iptables-restore
@@ -15,6 +15,18 @@ trap cleanup EXIT
 RULES_FILE="$(mktemp)"
 cat > "${RULES_FILE}"
 
+firewall_modules_missing() {
+    local message="$1"
+    [[ -z "${message}" ]] && return 1
+    [[ ${message} =~ [Nn]o[[:space:]]chain/target/match[[:space:]]by[[:space:]]that[[:space:]]name ]] && return 0
+    [[ ${message} =~ [Tt]able[[:space:]]does[[:space:]]not[[:space:]]exist ]] && return 0
+    [[ ${message} =~ [Cc]ouldn.t[[:space:]]load[[:space:]]target ]] && return 0
+    [[ ${message} =~ [Cc]ould[[:space:]]not[[:space:]]load[[:space:]]target ]] && return 0
+    [[ ${message} =~ [Pp]rotocol[[:space:]]not[[:space:]]supported ]] && return 0
+    [[ ${message} =~ [Ii]ptables[[:space:]]v[[:digit:]]+\.[[:digit:]]+:[[:space:]]cannot[[:space:]]initialize ]] && return 0
+    return 1
+}
+
 # First attempt with the original ruleset
 if output="$(${REAL_IPTABLES_RESTORE} "$@" < "${RULES_FILE}" 2>&1)"; then
     [[ -n "${output}" ]] && printf '%s\n' "${output}" >&2
@@ -35,6 +47,7 @@ fi
 retry_status=$?
 
 # Final fallback: try legacy backend if available
+legacy_output=""
 for legacy in /sbin/iptables-restore-legacy /usr/sbin/iptables-restore-legacy; do
     if [[ -x "${legacy}" ]]; then
         if legacy_output="$(${legacy} "$@" < "${RULES_FILE}" 2>&1)"; then
@@ -45,6 +58,14 @@ for legacy in /sbin/iptables-restore-legacy /usr/sbin/iptables-restore-legacy; d
         fi
     fi
 done
+
+if firewall_modules_missing "${output}" || firewall_modules_missing "${retry_output:-}" || firewall_modules_missing "${legacy_output:-}"; then
+    printf '%s\n' "iptables-restore failed because kernel firewall modules are unavailable; continuing without applying IPv4 rules." >&2
+    printf '%s\n' "Original error: ${output}" >&2
+    [[ -n "${retry_output}" ]] && printf '%s\n' "Sanitized retry error: ${retry_output}" >&2
+    [[ -n "${legacy_output:-}" ]] && printf '%s\n' "Legacy backend error: ${legacy_output}" >&2
+    exit 0
+fi
 
 printf '%s\n' "iptables-restore failed and fallbacks were unsuccessful." >&2
 printf '%s\n' "Original error: ${output}" >&2


### PR DESCRIPTION
## Summary
- create an IPv4-only WireGuard runtime configuration and automatically retry with it when the IPv6 connectivity probe fails after an initial wg-quick error
- allow wg-quick to continue on hosts without the required iptables/ip6tables modules by turning those failures into warnings instead of fatal errors
- document the new behavior and environment variable while updating the changelog

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e042d5c108325a98d1917b8e0f37f)