### PR TITLE
Fix Scrutiny config example: Add required 'env_vars'

### DIFF
--- a/scrutiny_fa/README.md
+++ b/scrutiny_fa/README.md
@@ -46,6 +46,7 @@ It automatically mounts all local drives.
 Enable full access only if you are encountering issues. SMART access should work without full access in all other scenarios.
 
 ```yaml
+env_vars: [] # Required field, leave empty if unused
 Updates: Hourly, Daily, Weekly
 Updates_custom_time : if you select "Custom" as "Updates" variable, you can define specific updates in natural language in the "Updates_custom_time" field. Example : select "Custom" as "Updates", then type a custom intervals like "5m", "2h", "1w", or "2mo" to have an update every 5 minutes, or every 2 hours, or evey week, or every 2 months
 TZ: timezone


### PR DESCRIPTION
Added clarification on env_vars

The current example causes a 'Missing option env_vars' error on save. Added env_vars: [] to fix validation.