### PR TITLE
Align Meilisearch option naming with HA conventions

### DIFF
--- a/monica/CHANGELOG.md
+++ b/monica/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v5.0_beta5-6 (17-11-2025)
+- Rename the Meilisearch configuration option to `meilisearch_key` and align schema/options with Home Assistant add-on best practices.
+
+## v5.0_beta5-5 (16-11-2025)
+- Add a configurable `MEILISEARCH_KEY` option so the bundled Meilisearch can be secured (or left blank to disable auth) without relying on custom env vars.
+
 ## v5.0_beta5-4 (15-11-2025)
 - Increment version for rebuilt add-on
 ## v5.0_beta5-3 (15-11-2025)

--- a/monica/README.md
+++ b/monica/README.md
@@ -105,7 +105,7 @@ Configure SMTP settings to enable:
 
 This addon supports custom scripts and environment variables through the `addon_config` mapping:
 
-- **Meilisearch full-text search**: The addon ships with an embedded [Meilisearch](https://www.meilisearch.com/) service that Monica uses by default. The search API listens on `http://127.0.0.1:7700` inside the container. Override `MEILISEARCH_URL` via `env_vars` if you prefer an external Meilisearch instance—the init script will detect that and skip starting the bundled daemon. You can further tweak Meilisearch by defining extra environment variables through the `env_vars` option if needed.
+- **Meilisearch full-text search**: The addon ships with an embedded [Meilisearch](https://www.meilisearch.com/) service that Monica uses by default. The search API listens on `http://127.0.0.1:7700` inside the container. Override `MEILISEARCH_URL` via `env_vars` if you prefer an external Meilisearch instance—the init script will detect that and skip starting the bundled daemon. You can further tweak Meilisearch by defining extra environment variables through the `env_vars` option if needed. To secure (or disable) Meilisearch authentication without custom env vars, set the `meilisearch_key` add-on option; the init script will pass it to both Monica and the bundled Meilisearch instance.
 - **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
 - **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 

--- a/monica/config.yaml
+++ b/monica/config.yaml
@@ -70,12 +70,13 @@ environment:
   SCOUT_DRIVER: meilisearch
   SCOUT_QUEUE: "false"
   MEILISEARCH_URL: http://127.0.0.1:7700
-  MEILISEARCH_KEY: ""
+  MEILISEARCH_KEY: "{{meilisearch_key}}"
 image: ghcr.io/alexbelgium/monica-{arch}
 init: false
 options:
   env_vars: []
   database: sqlite
+  meilisearch_key: ""
 map:
   - type: addon_config
     read_only: false
@@ -95,6 +96,7 @@ schema:
   DB_PASSWORD: str?
   DB_PORT: int?
   DB_USERNAME: str?
+  meilisearch_key: password?
   MAIL_MAILER: str?
   MAIL_HOST: str?
   MAIL_PORT: str?
@@ -107,5 +109,5 @@ services:
   - mysql:want
 slug: monica
 url: https://github.com/alexbelgium/hassio-addons/tree/master/monica
-version: v5.0_beta5-4
+version: v5.0_beta5-6
 webui: "[PROTO:ssl]://[HOST]:[PORT:80]"

--- a/monica/rootfs/etc/cont-init.d/99-run.sh
+++ b/monica/rootfs/etc/cont-init.d/99-run.sh
@@ -143,7 +143,9 @@ if [[ "${MEILISEARCH_LOCAL}" == true ]]; then
     MEILISEARCH_DB_PATH="/data/meilisearch"
     mkdir -p "${MEILISEARCH_DB_PATH}"
 
-    MEILISEARCH_ENV_KEY="${MEILISEARCH_KEY:-}"
+    MEILISEARCH_ENV_KEY="$(bashio::config 'meilisearch_key')"
+    MEILISEARCH_KEY="${MEILISEARCH_ENV_KEY}"
+    export MEILISEARCH_KEY
     MEILISEARCH_ENVIRONMENT="${MEILI_ENV:-production}"
     MEILISEARCH_NO_ANALYTICS="${MEILI_NO_ANALYTICS:-true}"
 


### PR DESCRIPTION
## Summary
- rename the Meilisearch configuration option to `meilisearch_key` to follow Home Assistant add-on conventions
- update the init script, default environment template, and documentation to use the new option name
- bump add-on version and changelog for the naming alignment

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921c2a8ed848325b6284fc67847121c)