### PR TITLE
Rerelease immich and immich-noml 2.3.1

### DIFF
--- a/immich/config.yaml
+++ b/immich/config.yaml
@@ -141,6 +141,6 @@ slug: immich
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: 2.3.1-2
+version: 2.3.1-3
 video: true
 webui: http://[HOST]:[PORT:8080]

--- a/immich_noml/config.yaml
+++ b/immich_noml/config.yaml
@@ -140,6 +140,6 @@ slug: immich_noml
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: 2.3.1-2
+version: 2.3.1-3
 video: true
 webui: http://[HOST]:[PORT:8080]


### PR DESCRIPTION
The base image with the fixes was released 3 hours ago.

Fixes #2221 