### PR TITLE
Fix Jellyfin GuC option default handling

### DIFF
--- a/jellyfin/CHANGELOG.md
+++ b/jellyfin/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 10.11.3-1 (23-11-2025)
+- Fix optional `i915_enable_guc` setting so the add-on no longer requires a value after updates.
+
 ## 10.11.3 (22-11-2025)
 - Update to latest version from linuxserver/docker-jellyfin (changelog : https://github.com/linuxserver/docker-jellyfin/releases)
 - The Home Assistant project has deprecated support for the armv7, armhf and i386 architectures. Support wil be fully dropped in the upcoming Home Assistant 2025.12 release

--- a/jellyfin/config.yaml
+++ b/jellyfin/config.yaml
@@ -91,7 +91,6 @@ options:
   PGID: 0
   PUID: 0
   data_location: /share/jellyfin
-  i915_enable_guc: null
 panel_admin: false
 panel_icon: mdi:billiards-rack
 ports:
@@ -126,5 +125,5 @@ schema:
 slug: jellyfin
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "10.11.3"
+version: "10.11.3-1"
 video: true


### PR DESCRIPTION
## Summary
- remove the null default for the optional `i915_enable_guc` setting so the add-on no longer requires a value after updates
- bump the Jellyfin add-on version to 10.11.3-1 and document the change

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923177674808325bfccdfe56102149a)