### PR TITLE
Bump epicgamesfree to debian-2025-11-19

### DIFF
--- a/epicgamesfree/CHANGELOG.md
+++ b/epicgamesfree/CHANGELOG.md
@@ -1,6 +1,10 @@
 
+## debian-2025-11-19 (2025-11-19)
+- Recreate a default config.json when only a legacy config.yaml is present so upgrades keep a usable configuration file
+
 ## debian-2025-11-18 (2025-11-18)
 - Restore the default configuration template to config.json with the expected sample values
+- Recreate a default config.json when only a legacy config.yaml is present so upgrades keep a usable configuration file
 
 ## debian-2025-11-16 (2025-11-16)
 - Update to latest version from charlocharlie/epicgames-freegames

--- a/epicgamesfree/config.yaml
+++ b/epicgamesfree/config.yaml
@@ -86,5 +86,5 @@ schema:
 slug: epicgamesfree
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "debian-2025-11-18"
+version: "debian-2025-11-19"
 webui: "[PROTO:ssl]://[HOST]:[PORT:3000]"

--- a/epicgamesfree/rootfs/etc/cont-init.d/99-run.sh
+++ b/epicgamesfree/rootfs/etc/cont-init.d/99-run.sh
@@ -12,15 +12,15 @@ LEGACY_YAML="$HOME/config.yaml"
 
 if [ ! -f "$CONFIG_JSON" ]; then
     if [ -f "$LEGACY_YAML" ]; then
-        bashio::log.warning "A config.yaml file was found but the add-on expects config.json. Please convert your configuration to JSON as documented upstream."
-    else
-        # Copy default config.json
-        cp /templates/config.json "$CONFIG_JSON"
-        chmod 755 "$CONFIG_JSON"
-        bashio::log.warning "A default config.json file was copied in $HOME. Please customize according to https://github.com/claabs/epicgames-freegames-node#configuration and restart the add-on"
-        sleep 5
-        bashio::exit.nok
+        bashio::log.warning "A legacy config.yaml was found. A default config.json will be created. Please migrate your settings to the new file format and restart the add-on"
     fi
+
+    # Copy default config.json
+    cp /templates/config.json "$CONFIG_JSON"
+    chmod 755 "$CONFIG_JSON"
+    bashio::log.warning "A default config.json file was copied in $HOME. Please customize according to https://github.com/claabs/epicgames-freegames-node#configuration and restart the add-on"
+    sleep 5
+    bashio::exit.nok
 else
     bashio::log.warning "The config.json file found in $HOME will be used. Please customize according to https://github.com/claabs/epicgames-freegames-node#configuration and restart the add-on"
 fi


### PR DESCRIPTION
## Summary
- bump the epicgamesfree add-on version to debian-2025-11-19
- document the release that recreates a default config.json when only a legacy config.yaml is present

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692327689498832581525a9e63befe5b)