### PR TITLE
Handle VPN monitor interface binding

### DIFF
--- a/qbittorrent/rootfs/etc/services.d/vpn-monitor/run
+++ b/qbittorrent/rootfs/etc/services.d/vpn-monitor/run
@@ -129,7 +129,7 @@ if bashio::config.true 'openvpn_enabled'; then
     vpn_openvpn=true
 fi
 
-if [[ "${vpn_openvpn}" == true ]] && bashio::config.false 'openvpn_alt_mode'; then
+if [[ "${vpn_openvpn}" == true ]] && ! bashio::config.true 'openvpn_alt_mode'; then
     VPN_INTERFACE="tun0"
     bashio::log.info "VPN monitor set to query external IP through interface ${VPN_INTERFACE} (interface binding)."
 else


### PR DESCRIPTION
## Summary
- ensure VPN monitor queries external IP through tun0 when OpenVPN uses interface binding
- keep default container-level checks for alternative OpenVPN mode and other VPN setups

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924c89025488325870e5ea558141944)