### PR TITLE
Remove armv7 references from stats and README workflows

### DIFF
--- a/.github/workflows/daily_README.yaml
+++ b/.github/workflows/daily_README.yaml
@@ -134,12 +134,6 @@ jobs:
               if [[ "$SERVICES_LIST" == *"mysql"* ]]; then sed -i "$ADDONSLINE"'a ![MariaDB][mariadb-badge]' README2.md; fi
               if [[ "$INGRESS" == "true" ]]; then sed -i "$ADDONSLINE"'a ![ingress][ingress-badge]' README2.md; fi
 
-              if [[ "$ARCH_LIST" == *"armv7"* ]]; then
-                sed -i "$ADDONSLINE"'a ![armv7][armv7-badge]' README2.md
-              else
-                sed -i "$ADDONSLINE"'a ![armv7no][armv7no-badge]' README2.md
-              fi || true
-
               if [[ "$ARCH_LIST" == *"amd64"* ]]; then
                 sed -i "$ADDONSLINE"'a ![amd64][amd64-badge]' README2.md
               else
@@ -202,14 +196,11 @@ jobs:
           # Breakdown per arch
           # ---------------------------
           echo "Breakdown per arch..."
-          STATS_ARMV7="$(awk '{SUM+=$3}END{print SUM}' Stats2)"
-          STATS_AMD64="$(awk '{SUM+=$4}END{print SUM}' Stats2)"
-          STATS_AARCH64="$(awk '{SUM+=$5}END{print SUM}' Stats2)"
-          STATS_DOWNLOADS="$(( STATS_ARMV7 + STATS_AMD64 + STATS_AARCH64 ))"
-          STATS_ARMV7="$(awk -v t1="$STATS_ARMV7" -v t4="$STATS_DOWNLOADS" 'BEGIN{printf "%.0f", (t4==0?0:t1/t4*100)}')"
+          STATS_AMD64="$(awk '{SUM+=$3}END{print SUM}' Stats2)"
+          STATS_AARCH64="$(awk '{SUM+=$4}END{print SUM}' Stats2)"
+          STATS_DOWNLOADS="$(( STATS_AMD64 + STATS_AARCH64 ))"
           STATS_AMD64="$(awk -v t2="$STATS_AMD64" -v t4="$STATS_DOWNLOADS" 'BEGIN{printf "%.0f", (t4==0?0:t2/t4*100)}')"
           STATS_AARCH64="$(awk -v t3="$STATS_AARCH64" -v t4="$STATS_DOWNLOADS" 'BEGIN{printf "%.0f", (t4==0?0:t3/t4*100)}')"
-          sed -i "s|%%STATS_ARMV7%%|armv7: ${STATS_ARMV7}%|g" README2.md
           sed -i "s|%%STATS_AMD64%%|amd64: ${STATS_AMD64}%|g" README2.md
           sed -i "s|%%STATS_AARCH64%%|aarch64: ${STATS_AARCH64}%|g" README2.md
           echo "... done"

--- a/.github/workflows/weekly_stats.yaml
+++ b/.github/workflows/weekly_stats.yaml
@@ -19,7 +19,6 @@ jobs:
           COUNT=0
           COUNT1=0
           COUNT2=0
-          COUNT3=0
           # Make sure file exists
           file=Stats
           touch "$file"
@@ -38,7 +37,6 @@ jobs:
             DOWNLOADS=0
             COUNT1="-"
             COUNT2="-"
-            COUNT3="-"
             IMAGE=""
             ARCHES=""
             if [ -f "$f"/config.json ] && jq -e '.image' "$f/config.json" >/dev/null; then
@@ -56,28 +54,21 @@ jobs:
               SLUG=""
             fi
             if [ -n "$SLUG" ]; then
-              if printf '%s\n' "$ARCHES" | grep -qx 'armv7'; then
-                ARCH=armv7 && COUNT="$(curl  --connect-timeout 5 -f -s -L https://github.com/alexbelgium/hassio-addons/pkgs/container/$SLUG-$ARCH/latest | awk '/Total downloads/{getline; print}' | awk -F '<|>' '{print $3}')"
+              if printf '%s\n' "$ARCHES" | grep -qx 'amd64'; then
+                ARCH=amd64 && COUNT="$(curl  --connect-timeout 5 -f -s -L https://github.com/alexbelgium/hassio-addons/pkgs/container/$SLUG-$ARCH/latest | awk '/Total downloads/{getline; print}' | awk -F '<|>' '{print $3}')"
                 until [ -n "$COUNT" ]; do COUNT="$(curl --connect-timeout 5 -f -s -L https://github.com/alexbelgium/hassio-addons/pkgs/container/$SLUG-$ARCH/latest | awk '/Total downloads/{getline; print}' | awk -F '<|>' '{print $3}')" && sleep 5; ((c++)) && echo "repeat $c" && if [[ "$c" == 10 ]]; then COUNT=0; fi; done
                 COUNT="${COUNT//,/}"
                 COUNT1="$COUNT"
                 echo "$COUNT $ARCH users with $SLUG" && DOWNLOADS="$(( DOWNLOADS + COUNT))"
               else COUNT1="-"; fi
-              if printf '%s\n' "$ARCHES" | grep -qx 'amd64'; then
-                ARCH=amd64 && COUNT="$(curl  --connect-timeout 5 -f -s -L https://github.com/alexbelgium/hassio-addons/pkgs/container/$SLUG-$ARCH/latest | awk '/Total downloads/{getline; print}' | awk -F '<|>' '{print $3}')"
-                until [ -n "$COUNT" ]; do COUNT="$(curl --connect-timeout 5 -f -s -L https://github.com/alexbelgium/hassio-addons/pkgs/container/$SLUG-$ARCH/latest | awk '/Total downloads/{getline; print}' | awk -F '<|>' '{print $3}')" && sleep 5; ((c++)) && echo "repeat $c" && if [[ "$c" == 10 ]]; then COUNT=0; fi; done
-                COUNT="${COUNT//,/}"
-                COUNT2="$COUNT"
-                echo "$COUNT $ARCH users with $SLUG" && DOWNLOADS="$(( DOWNLOADS + COUNT))"
-              else COUNT2="-"; fi
               if printf '%s\n' "$ARCHES" | grep -qx 'aarch64'; then
                 ARCH=aarch64 && COUNT="$(curl --connect-timeout 5 -f -s -L https://github.com/alexbelgium/hassio-addons/pkgs/container/$SLUG-$ARCH/latest | awk '/Total downloads/{getline; print}' | awk -F '<|>' '{print $3}')"
                 until [ -n "$COUNT" ]; do COUNT="$(curl --connect-timeout 5 -f -s -L https://github.com/alexbelgium/hassio-addons/pkgs/container/$SLUG-$ARCH/latest | awk '/Total downloads/{getline; print}' | awk -F '<|>' '{print $3}')" && sleep 5; ((c++)) && echo "repeat $c" && if [[ "$c" == 10 ]]; then COUNT=0; fi; done
                 COUNT="${COUNT//,/}"
-                COUNT3="$COUNT"
+                COUNT2="$COUNT"
                 echo "$COUNT $ARCH users with $SLUG" && DOWNLOADS="$(( DOWNLOADS + COUNT))"
-              else COUNT3="-";fi
-              echo "$SLUG $DOWNLOADS $COUNT1 $COUNT2 $COUNT3" >> "$file"2
+              else COUNT2="-";fi
+              echo "$SLUG $DOWNLOADS $COUNT1 $COUNT2" >> "$file"2
               # Create line if not existing
               if ! grep -q "${SLUG}$" "$file"; then
                 sed -i "\$a$SLUG" "$file"
@@ -110,7 +101,7 @@ jobs:
           # Sort file
           (head -n 2 "$file" && tail -n +3 "$file" | sort -k1 -r -n) > tmp && mv tmp "$file"
 
-          sed -i "1i Name Total armv7 amd64 aarch64" "$file"2
+          sed -i "1i Name Total amd64 aarch64" "$file"2
           sed -i "1a ------------------------------" "$file"2
           #TOTAL="$(awk '{SUM+=$2}END{print SUM}' Stats)"
           #TOTAL1="$(awk '{SUM+=$2}END{print SUM}' Stats)"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ If you want to do add the repository manually, please follow the procedure highl
 
 - amd64: 63%
 - aarch64: 37%
-- armv7: 0%
 
 ### Stars evolution
 
@@ -84,7 +83,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Farpspoof%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/television-classic.svg) [Autobrr](autobrr/) : Automation for downloads
 
@@ -92,7 +90,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fautobrr%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003;  [Baikal](baikal/) : Calendar+Contacts server
@@ -101,7 +98,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fbaikal%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/bird.svg) [BattyBirdNET-Pi](battybirdnet-pi/) : A realtime acoustic bat & bird classification system for the Raspberry Pi 4/5 built on BattyBirdNET-Analyzer
 
@@ -109,7 +105,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fbattybirdnet-pi%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 ![mqtt][mqtt-badge]
 
@@ -119,7 +114,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fbazarr%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/bitcoin.svg) [Binance Trading Bot](binance-trading-bot/) : Automated Binance trading bot - Trade multiple cryptocurrencies. Buy low/sell high with Grid Trading. Integrated with TradingView technical analysis
 
@@ -127,7 +121,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fbinance-trading-bot%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/bird.svg) [BirdNET-pi](birdnet-pi/) : Realtime acoustic bird classification system
@@ -136,7 +129,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fbirdnet-pi%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 ![mqtt][mqtt-badge]
 
@@ -146,7 +138,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fbirdnet-go%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 ![MariaDB][mariadb-badge]
 ![mqtt][mqtt-badge]
@@ -157,7 +148,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fbooksonic_air%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Browserless Chromium](browserless_chrome/) : Chromium as a service container
 
@@ -165,7 +155,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fbrowserless_chrome%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/book-multiple.svg) [Calibre](calibre/) : e-book manager
 
@@ -173,7 +162,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fcalibre%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/library.svg) [Calibre-web](calibre_web/) : Browsing, reading and downloading eBooks using an existing Calibre database
@@ -182,7 +170,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fcalibre_web%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003;  [Castsponsorskip](sponsorblockcast/) : Skip YouTube ads and sponsorships on all local Google Cast devices
@@ -191,7 +178,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fsponsorblockcast%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Changedetection.io](changedetection.io/) : web page monitoring, notification and change detection
 
@@ -199,7 +185,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fchangedetection.io%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/file-search.svg) [Cloudcommander](cloudcommander/) : Cloud Commander a file manager for the web with console and editor
 
@@ -207,7 +192,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fcloudcommander%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/book-open.svg) [Codex](codex/) : Web based comic archive browser and reader
@@ -216,7 +200,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fcodex%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003;  [Collabora](collabora/) : Collabora Online office suite
@@ -225,7 +208,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fcollabora%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/book-open.svg) [Comixed](comixed/) : managing digital comics
 
@@ -233,14 +215,12 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fcomixed%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Elasticsearch server](elasticsearch/) : Free and Open, Distributed, RESTful Search Engine
 
 &emsp;&emsp;![Version](https://img.shields.io/badge/dynamic/yaml?label=Version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Felasticsearch%2Fconfig.yaml)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/emby.svg) [Emby](emby/) : A free Software Media System that puts you in control of managing and streaming your media
 
@@ -248,7 +228,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Femby%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/emby.svg) [Emby Beta](emby_beta/) : A free Software Media System that puts you in control of managing and streaming your media (beta version)
@@ -257,7 +236,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Femby_beta%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003;  [Ente](ente/) : Self-hosted, end-to-end-encrypted photo & video storage (Ente server + MinIO)
@@ -266,7 +244,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fente%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Epic Games Free](epicgamesfree/) : Automatically login and redeem promotional free games from Epic Games Store
 
@@ -274,7 +251,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fepicgamesfree%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/file-search.svg) [Filebrowser (10076x)](filebrowser/) : filebrowser provides a file managing interface within a specified directory and it can be used to upload, delete, preview, rename and edit your files
 
@@ -282,7 +258,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Ffilebrowser%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003;  [Firefly iii](fireflyiii/) : A free and open source personal finance manager
@@ -291,7 +266,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Ffireflyiii%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![MariaDB][mariadb-badge]
 
 &#10003;  [Firefly iii Data Importer](fireflyiii_data_importer/) : Data importer for Firefly III (separate addon)
@@ -300,7 +274,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Ffireflyiii_data_importer%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Firefly iii FinTS Importer](fireflyiii_fints_importer/) : Import financial transactions from your FinTS enabled bank into Firefly III
 
@@ -308,7 +281,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Ffireflyiii_fints_importer%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [FlareSolverr](flaresolverr/) : Proxy server to bypass Cloudflare protection
 
@@ -316,7 +288,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fflaresolverr%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Flexget](flexget/) : FlexGet is a multipurpose automation tool for all of your media
 
@@ -324,7 +295,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fflexget%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Free Games Claimer (NoVNC not working)](free_games_claimer/) : automatically claims free games on the Epic Games Store, Amazon Prime Gaming and GOG
 
@@ -332,7 +302,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Ffree_games_claimer%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Gazpar2mqtt](gazpar2mqtt/) : fetch GRDF data and publish data to a mqtt broker
 
@@ -340,7 +309,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fgazpar2mqtt%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![mqtt][mqtt-badge]
 
 &#10003;  [Gitea](gitea/) : Gitea for Home Assistant
@@ -349,7 +317,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fgitea%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Grampsweb](grampsweb/) : Open Source Online Genealogy System
 
@@ -357,7 +324,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fgrampsweb%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![MariaDB][mariadb-badge]
 
 &#10003;  [Grav web server](grav/) : Fast, Simple, and Flexible, file-based Web-platform
@@ -366,7 +332,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fgrav%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/lan.svg) [Guacamole Client](guacamole/) : Clientless remote desktop gateway
 
@@ -374,7 +339,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fguacamole%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/file-search.svg) [Immich](immich/) : Self-hosted photo and video backup solution directly from your mobile phone
@@ -383,7 +347,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fimmich%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![MariaDB][mariadb-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/file-search.svg) [Immich Cuda](immich_cuda/) : Self-hosted photo and video backup solution directly from your mobile phone
@@ -392,7 +355,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fimmich_cuda%2Fupdater.json)
 ![aarch64no][aarch64no-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![MariaDB][mariadb-badge]
 
 &#10003;  [Immich Frame](immich_frame/) : Display your immich gallery as a digital photo frame
@@ -401,7 +363,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fimmich_frame%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/file-search.svg) [Immich Openvino](immich_openvino/) : Self-hosted photo and video backup solution directly from your mobile phone
 
@@ -409,7 +370,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fimmich_openvino%2Fupdater.json)
 ![aarch64no][aarch64no-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![MariaDB][mariadb-badge]
 
 &#10003;  [Immich Power Tools](immich_power_tools/) : Power tools for organizing your immich library
@@ -418,7 +378,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fimmich_power_tools%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/file-search.svg) [Immich without Machine Learning](immich_noml/) : Self-hosted photo and video backup solution directly from your mobile phone
 
@@ -426,7 +385,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fimmich_noml%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![MariaDB][mariadb-badge]
 
 &#10003;  [Inadyn](inadyn/) : Inadyn is a small and simple Dynamic DNS, DDNS, client with HTTPS support. A large number of dynamic dns providers are supported (https://github.com/troglobit/inadyn#supported-providers). For those that are not, you can use a custom provider as per this project's documentation (https://github.com/nalipaz/hassio-addons/blob/master/README.md)
@@ -435,7 +393,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Finadyn%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Jackett NAS](jackett/) : Translates queries from apps (Sonarr, Sickrage, CouchPotato, Mylar, etc) into tracker-site-specific http queries, parses the html response, then sends results back to the requesting software
 
@@ -443,7 +400,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fjackett%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/billiards-rack.svg) [Jellyfin NAS](jellyfin/) : A Free Software Media System that puts you in control of managing and streaming your media
 
@@ -451,7 +407,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fjellyfin%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003;  [Jellyseerr](jellyseerr/) : Fork of overseerr for jellyfin support
@@ -460,7 +415,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fjellyseerr%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/owl.svg) [Joal](joal/) : An open source command line RatioMaster with WebUI
 
@@ -468,7 +422,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fjoal%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003;  [Joplin Server](joplin/) : Self-hosted open source note-taking application
@@ -477,7 +430,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fjoplin%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Kometa](kometa/) : Python script to update metadata information for movies, shows, and collections as well as automatically build collections
 
@@ -485,7 +437,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fkometa%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/speedometer.svg) [LibreSpeed](librespeed/) : A very lightweight speed test implemented in Javascript, using XMLHttpRequest and Web Workers
 
@@ -493,7 +444,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Flibrespeed%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003;  [Lidarr NAS](lidarr/) : Music collection manager for Usenet and BitTorrent users
@@ -502,7 +452,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Flidarr%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Linkwarden](linkwarden/) : collaborative bookmark manager to collect, organize, and preserve webpages and articles
 
@@ -510,7 +459,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Flinkwarden%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/silverware-fork-knife.svg) [Mealie](mealie/) : Mealie is a self hosted recipe manager and meal planner built in Vue
 
@@ -518,7 +466,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fmealie%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003;  [Monica](monica/) : Personal Relationship Manager
@@ -527,7 +474,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fmonica%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![MariaDB][mariadb-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/lightning-bolt-outline.svg) [MyElectricalData](enedisgateway2mqtt/) : Use Enedis Gateway API to send data in your MQTT Broker (latest channel)
@@ -536,7 +482,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fenedisgateway2mqtt%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 ![mqtt][mqtt-badge]
 
@@ -546,7 +491,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fenedisgateway2mqtt_dev%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 ![mqtt][mqtt-badge]
 
@@ -556,7 +500,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fmylar3%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Navidrome](navidrome/) : Navidrome for Home Assistant
 
@@ -564,7 +507,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fnavidrome%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/wifi-check.svg) [NetAlertX](netalertx/) : 🖧🔍 WIFI / LAN scanner, intruder, and presence detector
 
@@ -572,7 +514,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fnetalertx%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 ![mqtt][mqtt-badge]
 
@@ -582,7 +523,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fnetalertx_fa%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 ![mqtt][mqtt-badge]
 ![full_access][full_access-badge]
@@ -593,7 +533,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fnextcloud%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![MariaDB][mariadb-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/arrow-down-bold-circle-outline.svg) [Nzbget](nzbget/) : usenet downloader
@@ -602,7 +541,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fnzbget%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003;  [Omada](omada/) : TP-Link Omada Controller
@@ -611,7 +549,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fomada%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Omada v3.2](omada_v3/) : TP-Link Omada Controller
 
@@ -619,7 +556,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fomada_v3%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Ombi](ombi/) : Self-hosted Plex Request and user management system
 
@@ -627,7 +563,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fombi%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Omni Tools](omni-tools/) : Self-hosted collection of powerful web-based tools for everyday tasks. No ads, no tracking, just fast, accessible utilities right from your browser
 
@@ -635,7 +570,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fomni-tools%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Openproject](openproject/) : Openproject for Home Assistant
 
@@ -643,7 +577,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fopenproject%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Organizr](organizr/) : An HTPC/Homelab services organizer that is written in PHP
 
@@ -651,7 +584,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Forganizr%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Overseerr](overseerr/) : Request management and media discovery tool built to work with your existing Plex ecosystem
 
@@ -659,7 +591,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Foverseerr%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/camera.svg) [Photoprism](photoprism/) : A server-based application for browsing, organizing and sharing your personal photo collection
 
@@ -667,7 +598,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fphotoprism%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 ![MariaDB][mariadb-badge]
 
@@ -677,7 +607,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fpiwigo%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Plex NAS](plex/) : Plex organizes video, music and photos from personal media libraries and streams them to smart TVs, streaming boxes and mobile devices
 
@@ -685,7 +614,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fplex%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/docker.svg) [Portainer (7502x)](portainer/) : Manage your Docker environment with ease
 
@@ -693,7 +621,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fportainer%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003;  [Portainer (7502x) Agent](portainer_agent/) : An agent used to manage all the resources in a Swarm cluster
@@ -702,7 +629,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fportainer_agent%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![full_access][full_access-badge]
 
 &#10003;  [Postgres 15](postgres_15/) : Postgres 15 with VectorChord support
@@ -711,7 +637,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fpostgres_15%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Postgres 17](postgres_17/) : Postgres 17 with VectorChord support
 
@@ -719,7 +644,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fpostgres_17%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Prowlarr NAS](prowlarr/) : Torrent Trackers and Usenet indexers offering complete management ofSonarr, Radarr, Lidarr, and Readarr indexers with no per app setup required
 
@@ -727,7 +651,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fprowlarr%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/movie-outline.svg) [Radarr](radarr/) : A fork of Sonarr to work with movies like Couchpotato
 
@@ -735,7 +658,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fradarr%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/download-circle.svg) [Readarr](readarr/) : Book manager and automation
@@ -744,7 +666,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Freadarr%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003;  [Repository Updater](addons_updater/) : Automatic addons update by aligning version tag with upstream releases
@@ -752,7 +673,6 @@ If you want to do add the repository manually, please follow the procedure highl
 &emsp;&emsp;![Version](https://img.shields.io/badge/dynamic/yaml?label=Version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Faddons_updater%2Fconfig.yaml)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Requestrr](requestrr/) : Chatbot used to simplify using services like Sonarr/Radarr/Ombi via the use of chat
 
@@ -760,7 +680,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Frequestrr%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/cloud-sync-outline.svg) [ResilioSync](resiliosync/) : Self-hosted file share and collaboration platform on the web
 
@@ -768,7 +687,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fresiliosync%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/arrow-down-bold-circle-outline.svg) [Sabnzbd](sabnzbd/) : Makes Usenet as simple and streamlined as possible by automating everything we can
@@ -777,7 +695,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fsabnzbd%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/glasses.svg) [Scrutiny](scrutiny/) : Scrutiny webUI for smartd S.M.A.R.T monitoring
 
@@ -785,7 +702,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fscrutiny%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/glasses.svg) [Scrutiny (Full Access)](scrutiny_fa/) : Scrutiny WebUI for smartd S.M.A.R.T monitoring (Full Access)
@@ -793,7 +709,6 @@ If you want to do add the repository manually, please follow the procedure highl
 &emsp;&emsp;![Version](https://img.shields.io/badge/dynamic/yaml?label=Version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fscrutiny_fa%2Fconfig.yaml)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 ![full_access][full_access-badge]
 
@@ -803,7 +718,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fseafile%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![MariaDB][mariadb-badge]
 
 &#10003;  [Signalk Server](signalk/) : An implementation of a Signal K central server for boats
@@ -812,7 +726,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fsignalk%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/television-classic.svg) [Sonarr](sonarr/) : Can monitor multiple RSS feeds for new episodes of your favorite shows and will grab, sort and rename them
 
@@ -820,7 +733,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fsonarr%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/chart-timeline.svg) [Spotweb](spotweb/) : Spotweb is a decentralized usenet community based on the Spotnet protocol
@@ -829,7 +741,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fspotweb%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 ![MariaDB][mariadb-badge]
 
@@ -839,7 +750,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Ftandoor_recipes%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![MariaDB][mariadb-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/file-search.svg) [Tdarr](tdarr/) : Distributed transcode automation using FFmpeg/HandBrake
@@ -848,21 +758,18 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Ftdarr%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Teamspeak server](teamspeak/) : voice communication for online gaming, education and training
 
 &emsp;&emsp;![Version](https://img.shields.io/badge/dynamic/yaml?label=Version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fteamspeak%2Fconfig.yaml)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Tor with bridges](tor/) : Protect your privacy and access Home Assistant via Tor
 
 &emsp;&emsp;![Version](https://img.shields.io/badge/dynamic/yaml?label=Version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Ftor%2Fconfig.yaml)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/transmission-tower.svg) [Transmission](transmission/) : Bittorrent client based on linuxserver image
 
@@ -870,7 +777,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Ftransmission%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/transmission-tower.svg) [Transmission Openvpn](transmission_openvpn/) : Docker container running Transmission torrent client with WebUI over an OpenVPN tunnel
@@ -879,7 +785,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Ftransmission_openvpn%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003;  [Ubooquity](ubooquity/) : Free, lightweight, and easy-to-use home server for your comics and ebooks
@@ -888,7 +793,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fubooquity%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Unpackerr](unpackerr/) : Unpacks RARd files for Sonarr, Lidarr and Radarr
 
@@ -896,7 +800,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Funpackerr%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/monitor.svg) [Webtop KDE](webtop_kde/) : Full linux desktop environment accessible via any modern web browser
 
@@ -904,7 +807,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fwebtop_kde%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/monitor.svg) [Webtop xfce](webtop/) : Full linux desktop environment accessible via any modern web browser
@@ -913,7 +815,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fwebtop%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003;  [Webtrees](webtrees/) : web's leading on-line collaborative genealogy application
@@ -922,7 +823,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fwebtrees%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![MariaDB][mariadb-badge]
 
 &#10003;  [Wger](wger/) : manage your personal workouts, weight and diet plans
@@ -931,7 +831,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fwger%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Whatsapper](whatsapper/) : Whatsapper for Home Assistant
 
@@ -939,7 +838,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fwhatsapper%2Fupdater.json)
 ![aarch64no][aarch64no-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/magnify.svg) [Whoogle Search](whoogle/) : Self-hosted, ad-free, privacy-respecting metasearch engine
 
@@ -947,7 +845,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fwhoogle%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003;  [Xteve](xteve/) : M3U Proxy for Plex DVR and Emby Live TV
@@ -956,7 +853,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fxteve%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [Zoneminder](zoneminder/) : A full-featured, open source, state-of-the-art video surveillance software system
 
@@ -964,7 +860,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fzoneminder%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![MariaDB][mariadb-badge]
 
 &#10003; ![image](https://api.iconify.design/mdi/progress-download.svg) [qBittorrent](qbittorrent/) : Bittorrent client with optional vpn
@@ -973,7 +868,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fqbittorrent%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![ingress][ingress-badge]
 
 &#10003;  [zzz_archived - Paperless NGX](zzz_archived_paperless_ngx/) : Scan, index and archive all your physical documents
@@ -982,7 +876,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fzzz_archived_paperless_ngx%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 ![MariaDB][mariadb-badge]
 
 &#10003;  [zzz_archived - Papermerge](zzz_archived_papermerge/) : Open source document management system (DMS)
@@ -991,7 +884,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fzzz_archived_papermerge%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [zzz_archived - Plex meta manager](zzz_archived_plex_meta_manager/) : Python script to update metadata information for movies, shows, and collections as well as automatically build collections
 
@@ -999,7 +891,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fzzz_archived_plex_meta_manager%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [zzz_archived - Vaultwarden](zzz_archived_bitwarden/) : Deprecated - please use community version
 
@@ -1007,7 +898,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fzzz_archived_bitwarden%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 &#10003;  [zzz_archived : Code-server (VScode)](zzz_archived_code-server/) : Deprecated : Code-server is VS Code running on a remote server, accessible through the browser
 
@@ -1015,7 +905,6 @@ If you want to do add the repository manually, please follow the procedure highl
 ![Update](https://img.shields.io/badge/dynamic/json?label=Updated&query=%24.last_update&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fzzz_archived_code-server%2Fupdater.json)
 ![aarch64][aarch64-badge]
 ![amd64][amd64-badge]
-![armv7no][armv7no-badge]
 
 
 ## Support
@@ -1029,10 +918,8 @@ You have several options to get them answered:
 
 [aarch64-badge]: https://img.shields.io/badge/aarch64--green.svg?logo=arm
 [amd64-badge]: https://img.shields.io/badge/amd64--green.svg?logo=amd
-[armv7-badge]: https://img.shields.io/badge/armv7--green.svg?logo=arm
 [aarch64no-badge]: https://img.shields.io/badge/aarch64--orange.svg?logo=arm
 [amd64no-badge]: https://img.shields.io/badge/amd64--orange.svg?logo=amd
-[armv7no-badge]: https://img.shields.io/badge/armv7--orange.svg?logo=arm
 [ingress-badge]: https://img.shields.io/badge/-ingress-blueviolet.svg?logo=Ingress
 [mariadb-badge]: https://img.shields.io/badge/Service-MariaDB-green.svg?logo=mariadb&logoColor=white
 [mqtt-badge]: https://img.shields.io/badge/Service-MQTT-green.svg?logo=chromecast&logoColor=white

--- a/Stats2
+++ b/Stats2
@@ -1,112 +1,112 @@
-Name Total armv7 amd64 aarch64
+Name Total amd64 aarch64
 ------------------------------
-plex-media-manager 457 - 313 144
-papermerge 931 - 478 453
-paperless_ng 250 - 163 87
-code_server 59 - 38 21
-vaultwarden 30 - 20 10
-zoneminder 246 - 162 84
-xteve 134 - 93 41
-whoogle-search 214 - 153 61
-whatsapper 232 - 232 -
-wger 243 - 171 72
-webtrees 164 - 106 58
-webtop_kde 110 - 77 33
-webtop 883 - 632 251
-unpackerr 84 - 59 25
-ubooquity 121 - 73 48
-transmission_openvpn 520 - 322 198
-transmission_ls 2029 - 1266 763
-tor 176 - 99 77
-teamspeak 2232 - 1242 990
-tdarr 79 - 59 20
-tandoor_recipes 1031 - 662 369
-spotweb 316 - 229 87
-sponsorblockcast 2296 - 1457 839
-sonarr_nas 499 - 348 151
-signalk 8 - 3 5
-seafile 185 - 108 77
-scrutiny-fa 1733 - 1093 640
-scrutiny 523 - 323 200
-sabnzbd 182 - 132 50
-resiliosync 311 - 177 134
-requestrr 86 - 52 34
-readarr_nas 14 - 7 7
-radarr_nas 552 - 367 185
-qbittorrent 496 - 309 187
-prowlarr 341 - 233 108
-postgres_17 2299 - 1482 817
-postgres 2264 - 1466 798
-portainer_agent 1390 - 923 467
-portainer 7502 - 4738 2764
-plex_nas 546 - 370 176
-piwigo 40 - 23 17
-photoprism 268 - 170 98
-overseerr 1072 - 724 348
-organizr 2544 - 1575 969
-openproject 80 - 53 27
-omni-tools 145 - 86 59
-ombi 351 - 255 96
-omada_v3 21 - 16 5
-omada 48 - 32 16
-nzbget 86 - 56 30
-nextcloud_ocr 1566 - 919 647
-netalertx 3150 - 2143 1007
-netalertx 3150 - 2143 1007
-navidrome 102 - 58 44
-mylar3 50 - 36 14
-monica 139 - 78 61
-mealie 1436 - 950 486
-linkwarden 340 - 224 116
-lidarr_nas 123 - 86 37
-librespeed 700 - 441 259
-kometa 113 - 73 40
-joplin 427 - 271 156
-joal 889 - 369 520
-jellyseerr 751 - 491 260
-jellyfin 1006 - 681 325
-jackett_nas 305 - 203 102
-inadyn 1 - 1 0
-immich_power_tools 206 - 133 73
-immich_openvino 77 - 77 -
-immich_noml 45 - 15 30
-immich_frame 192 - 148 44
-immich_cuda 8 - 8 -
-immich 1035 - 648 387
-guacamole 797 - 563 234
-grav 78 - 52 26
-grampsweb 149 - 101 48
-gitea 267 - 153 114
-gazpar2mqtt 1845 - 938 907
-free_games_claimer 830 - 527 303
-flexget 44 - 33 11
-flaresolverr 289 - 200 89
-fireflyiii_fints_importer 95 - 62 33
-fireflyiii_data_importer 187 - 125 62
-fireflyiii 368 - 232 136
-filebrowser 10076 - 6540 3536
-epicgamesfree 606 - 421 185
-ente 26 - 14 12
-myelectricaldata_dev 252 - 135 117
-myelectricaldata 3997 - 2256 1741
-emby 185 - 117 68
-emby_stable 154 - 92 62
-elasticsearch 0 - 0 0
-comixed 519 - 237 282
-collabora 80 - 52 28
-codex 49 - 35 14
-cloudcommander 483 - 334 149
-changedetection.io 397 - 240 157
-calibre_web 598 - 372 226
-calibre 231 - 152 79
-browserless_chrome 583 - 375 208
-calibre_web 598 - 372 226
-birdnet-pi 73 - 47 26
-birdnet-go 271 - 210 61
-binance_trading_bot 265 - 167 98
-bazarr 234 - 166 68
-battybirdnet-pi 139 - 91 48
-baikal 142 - 92 50
-autobrr 61 - 32 29
-arpspoof 3086 - 1829 1257
-addons_updater 266 - 167 99
+plex-media-manager 457 313 144
+papermerge 931 478 453
+paperless_ng 250 163 87
+code_server 59 38 21
+vaultwarden 30 20 10
+zoneminder 246 162 84
+xteve 134 93 41
+whoogle-search 214 153 61
+whatsapper 232 232 -
+wger 243 171 72
+webtrees 164 106 58
+webtop_kde 110 77 33
+webtop 883 632 251
+unpackerr 84 59 25
+ubooquity 121 73 48
+transmission_openvpn 520 322 198
+transmission_ls 2029 1266 763
+tor 176 99 77
+teamspeak 2232 1242 990
+tdarr 79 59 20
+tandoor_recipes 1031 662 369
+spotweb 316 229 87
+sponsorblockcast 2296 1457 839
+sonarr_nas 499 348 151
+signalk 8 3 5
+seafile 185 108 77
+scrutiny-fa 1733 1093 640
+scrutiny 523 323 200
+sabnzbd 182 132 50
+resiliosync 311 177 134
+requestrr 86 52 34
+readarr_nas 14 7 7
+radarr_nas 552 367 185
+qbittorrent 496 309 187
+prowlarr 341 233 108
+postgres_17 2299 1482 817
+postgres 2264 1466 798
+portainer_agent 1390 923 467
+portainer 7502 4738 2764
+plex_nas 546 370 176
+piwigo 40 23 17
+photoprism 268 170 98
+overseerr 1072 724 348
+organizr 2544 1575 969
+openproject 80 53 27
+omni-tools 145 86 59
+ombi 351 255 96
+omada_v3 21 16 5
+omada 48 32 16
+nzbget 86 56 30
+nextcloud_ocr 1566 919 647
+netalertx 3150 2143 1007
+netalertx 3150 2143 1007
+navidrome 102 58 44
+mylar3 50 36 14
+monica 139 78 61
+mealie 1436 950 486
+linkwarden 340 224 116
+lidarr_nas 123 86 37
+librespeed 700 441 259
+kometa 113 73 40
+joplin 427 271 156
+joal 889 369 520
+jellyseerr 751 491 260
+jellyfin 1006 681 325
+jackett_nas 305 203 102
+inadyn 1 1 0
+immich_power_tools 206 133 73
+immich_openvino 77 77 -
+immich_noml 45 15 30
+immich_frame 192 148 44
+immich_cuda 8 8 -
+immich 1035 648 387
+guacamole 797 563 234
+grav 78 52 26
+grampsweb 149 101 48
+gitea 267 153 114
+gazpar2mqtt 1845 938 907
+free_games_claimer 830 527 303
+flexget 44 33 11
+flaresolverr 289 200 89
+fireflyiii_fints_importer 95 62 33
+fireflyiii_data_importer 187 125 62
+fireflyiii 368 232 136
+filebrowser 10076 6540 3536
+epicgamesfree 606 421 185
+ente 26 14 12
+myelectricaldata_dev 252 135 117
+myelectricaldata 3997 2256 1741
+emby 185 117 68
+emby_stable 154 92 62
+elasticsearch 0 0 0
+comixed 519 237 282
+collabora 80 52 28
+codex 49 35 14
+cloudcommander 483 334 149
+changedetection.io 397 240 157
+calibre_web 598 372 226
+calibre 231 152 79
+browserless_chrome 583 375 208
+calibre_web 598 372 226
+birdnet-pi 73 47 26
+birdnet-go 271 210 61
+binance_trading_bot 265 167 98
+bazarr 234 166 68
+battybirdnet-pi 139 91 48
+baikal 142 92 50
+autobrr 61 32 29
+arpspoof 3086 1829 1257
+addons_updater 266 167 99


### PR DESCRIPTION
## Summary
- remove armv7 architecture handling from the weekly statistics workflow and generated Stats2 output
- update the README generation workflow to drop armv7 badges and architecture breakdown entries
- refresh the committed README and Stats2 data to reflect only amd64 and aarch64 reporting

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69280d6524e08325865aa8f619b021f7)