### PR TITLE
Fix NetAlertX startup directories

### DIFF
--- a/netalertx/CHANGELOG.md
+++ b/netalertx/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 25.10.1-4 (02-12-2025)
+- Fix addon initialization by creating missing runtime directories and seeding default NetAlertX config/database files for new installs.
+
 ## 25.10.1-3 (29-11-2025)
 - Breaking change: data directories now use /data symlinks to /config; back up your installation before updating. Migration is supported only from version v25.5.24.
 - Added tmpfs support for temporary storage.

--- a/netalertx/config.yaml
+++ b/netalertx/config.yaml
@@ -46,4 +46,4 @@ slug: netalertx
 tmpfs: true
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: 25.10.1-3
+version: 25.10.1-4

--- a/netalertx/rootfs/etc/cont-init.d/99-run.sh
+++ b/netalertx/rootfs/etc/cont-init.d/99-run.sh
@@ -8,6 +8,11 @@ set -e
 
 bashio::log.info "Update structure"
 
+# Ensure required runtime directories exist before any migration
+for dir in /data/config /data/db /tmp/api /tmp/log /tmp/run; do
+    mkdir -p "$dir"
+done
+
 # In the addon script, make symlinks on the fly
 echo "Creating symlinks"
 for folder in config db; do
@@ -29,6 +34,15 @@ for folder in config db; do
     rm -rf /data/"$folder"
     ln -sf "$target" /data/"$folder"
 done
+
+# Populate missing default files from the application image when available
+if [ -f /app/config/app.conf ] && [ ! -f /config/config/app.conf ]; then
+    cp -n /app/config/app.conf /config/config/app.conf
+fi
+
+if [ -f /app/db/app.db ] && [ ! -f /config/db/app.db ]; then
+    cp -n /app/db/app.db /config/db/app.db
+fi
 
 sudo chown -R nginx:www-data /config/db/
 sudo chown -R nginx:www-data /config/config/


### PR DESCRIPTION
## Summary
- ensure NetAlertX runtime directories exist before initialization and seed default config/database files when missing
- bump add-on version and update changelog

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d3dda0d708325ab4fd76db89b0239)