### PR TITLE
Document cron disable option and bump version

### DIFF
--- a/epicgamesfree/CHANGELOG.md
+++ b/epicgamesfree/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## debian-2025-12-04-1 (2025-12-04)
+- Add an add-on option to disable the bundled cron service and honor it at startup
+
 ## debian-2025-11-25 (2025-11-25)
 - Update to latest version from charlocharlie/epicgames-freegames
 

--- a/epicgamesfree/README.md
+++ b/epicgamesfree/README.md
@@ -35,7 +35,7 @@ This addon is based on the docker image https://hub.docker.com/r/charlocharlie/e
 
 ## Configuration
 
-Addon options expose the `env_vars` field for passing extra environment variables; all other configuration is done via the JSON file.
+Addon options expose the `env_vars` field for passing extra environment variables and a `disable_cron` switch to stop the built-in cron service; all other application configuration is done via the JSON file.
 
 ### Configuration Files
 
@@ -95,6 +95,7 @@ Create `/config/addons_config/epicgamesfree/config.json`:
 | `logLevel` | string | Application log level |
 | `webPortalConfig.baseUrl` | string | Base URL used by the included web portal |
 | `notifiers` | array | Notification targets such as email, Discord, Telegram, Apprise, etc. |
+| `disable_cron` | boolean | Disable the add-on's cron service if an external scheduler is used |
 
 ### Account Configuration
 

--- a/epicgamesfree/config.yaml
+++ b/epicgamesfree/config.yaml
@@ -75,6 +75,7 @@ map:
 name: Epic Games Free
 options:
   env_vars: []
+  disable_cron: false
 ports:
   3000/tcp: 3000
 ports_description:
@@ -83,8 +84,9 @@ schema:
   env_vars:
     - name: match(^[A-Za-z0-9_]+$)
       value: str?
+  disable_cron: bool?
 slug: epicgamesfree
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "debian-2025-11-25"
+version: "debian-2025-12-04-1"
 webui: "[PROTO:ssl]://[HOST]:[PORT:3000]"

--- a/epicgamesfree/rootfs/etc/cont-init.d/99-run.sh
+++ b/epicgamesfree/rootfs/etc/cont-init.d/99-run.sh
@@ -10,6 +10,22 @@ HOME="/config/addons_config/epicgamesfree"
 CONFIG_JSON="$HOME/config.json"
 LEGACY_YAML="$HOME/config.yaml"
 
+if bashio::config.true 'disable_cron'; then
+    bashio::log.info "Disabling cron service as requested by configuration"
+
+    if bashio::command.exists s6-rc && s6-rc -a list | grep -q "^cron$"; then
+        s6-rc -d change cron || true
+    fi
+
+    if [ -d /etc/services.d/cron ]; then
+        rm -rf /etc/services.d/cron
+    fi
+
+    if bashio::command.exists service; then
+        service cron stop >/dev/null 2>&1 || true
+    fi
+fi
+
 if [ ! -f "$CONFIG_JSON" ]; then
     if [ -f "$LEGACY_YAML" ]; then
         bashio::log.warning "A legacy config.yaml was found. A default config.json will be created. Please migrate your settings to the new file format and restart the add-on"


### PR DESCRIPTION
## Summary
- document the new `disable_cron` add-on option in the README and configuration table
- record the cron toggle addition in the changelog and bump the add-on version

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931a24bf7dc8325addddd5fe89fd820)