### PR TITLE
Ensure pg_stat_tmp directory for guacamole postgres

### DIFF
--- a/guacamole/rootfs/etc/cont-init.d/50-folders.sh
+++ b/guacamole/rootfs/etc/cont-init.d/50-folders.sh
@@ -4,5 +4,6 @@ set -e
 
 mkdir -p /config/fonts
 mkdir -p /config/postgres
+mkdir -p /config/postgres/pg_stat_tmp
 chown -R postgres:postgres /config/postgres
 chmod -R 0700 /config/postgres


### PR DESCRIPTION
## Summary
- ensure the PostgreSQL pg_stat_tmp directory is created for the Guacamole add-on data path to avoid startup errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942c0aba20c8325a9f8f791cdeca334)