### PR TITLE
Handle missing SSL files in Omada startup script

### DIFF
--- a/omada/rootfs/etc/cont-init.d/99-run.sh
+++ b/omada/rootfs/etc/cont-init.d/99-run.sh
@@ -7,7 +7,11 @@ CONFIGSOURCE="/config"
 # Use ssl
 if [ -d /ssl ]; then
     mkdir -p /cert
-    cp -r /ssl/* /cert
+    if compgen -G "/ssl/*" > /dev/null; then
+        cp -r /ssl/* /cert
+    else
+        echo "No SSL files found in /ssl, skipping copy"
+    fi
     chown -R 508:508 /cert
 fi
 


### PR DESCRIPTION
## Summary
- avoid failing Omada init when /ssl contains no files by checking before copy
- keep permission handling intact while skipping SSL copy when empty

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942c0b930bc83259a3389c708d83a06)