### PR TITLE
Fix Birdnet-Go microphone selection override

### DIFF
--- a/birdnet-go/CHANGELOG.md
+++ b/birdnet-go/CHANGELOG.md
@@ -1,5 +1,7 @@
 - Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
+- Preserve the microphone selected in the BirdNET-Go UI unless the `homeassistant_microphone` option explicitly forces the default device.
+
 ## "nightly-20251028" (01-11-2025)
 - Minor bugs fixed
 

--- a/birdnet-go/rootfs/etc/cont-init.d/99-run.sh
+++ b/birdnet-go/rootfs/etc/cont-init.d/99-run.sh
@@ -13,11 +13,10 @@ CONFIG_LOCATION="/config/config.yaml"
 if bashio::config.true "homeassistant_microphone"; then
     bashio::log.info "homeassistant_microphone option is selected. The audio card config value is set to 'default'. Set in the addon options to which this is set"
     audio_card="default"
+    yq -iy ".realtime.audio.source = \"${audio_card}\"" "$CONFIG_LOCATION"
 else
-    bashio::log.warning "homeassistant_microphone option is not set, disabling microphone input"
-    audio_card=""
+    bashio::log.info "homeassistant_microphone option is not set, keeping audio source configured via the UI"
 fi
-yq -iy ".realtime.audio.source = \"${audio_card}\"" "$CONFIG_LOCATION"
 
 ########################
 # CONFIGURE birdnet-go #


### PR DESCRIPTION
## Summary
- keep the Birdnet-Go audio source chosen in the UI unless the homeassistant_microphone option is explicitly enabled
- document the change in the changelog

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942c172752083258a199049ac063b41)