### PR TITLE
Add history recording storage extension configuration

### DIFF
--- a/guacamole/CHANGELOG.md
+++ b/guacamole/CHANGELOG.md
@@ -1,5 +1,8 @@
 - Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
+## 1.6.0-12 (02-10-2025)
+- Added configuration to enable the history recording storage extension with a configurable recording path
+
 ## 1.6.0-11 (16-09-2025)
 - Minor bugs fixed
 ## 1.6.0-10 (16-09-2025)

--- a/guacamole/README.md
+++ b/guacamole/README.md
@@ -45,13 +45,15 @@ The default username is `guacadmin` with password `guacadmin`. It is strongly re
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `EXTENSIONS` | str | `auth-totp` | Guacamole extensions to enable (e.g., `auth-totp`) |
+| `EXTENSIONS` | str | `auth-totp` | Guacamole extensions to enable (e.g., `auth-totp`, `history-recording-storage`) |
+| `recording_search_path` | str | `/config/recordings` | Directory added to `guacamole.properties` as the `recording-search-path` used by the history recording storage extension |
 | `TZ` | str | | Timezone (e.g., `Europe/London`) |
 
 ### Example Configuration
 
 ```yaml
-EXTENSIONS: "auth-totp"
+EXTENSIONS: "auth-totp,history-recording-storage"
+recording_search_path: "/config/recordings"
 TZ: "Europe/London"
 ```
 

--- a/guacamole/config.yaml
+++ b/guacamole/config.yaml
@@ -85,6 +85,7 @@ name: Guacamole Client
 options:
   env_vars: []
   EXTENSIONS: auth-totp
+  recording_search_path: /config/recordings
 panel_admin: false
 panel_icon: mdi:lan
 ports:
@@ -96,9 +97,10 @@ schema:
     - name: match(^[A-Za-z0-9_]+$)
       value: str?
   EXTENSIONS: str?
+  recording_search_path: str?
   TZ: str?
 slug: guacamole
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: 1.6.0-11
+version: 1.6.0-12
 video: true

--- a/guacamole/rootfs/etc/cont-init.d/60-recordings.sh
+++ b/guacamole/rootfs/etc/cont-init.d/60-recordings.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+
+readonly GUAC_PROPERTIES_FILE="/config/guacamole.properties"
+
+recording_path="$(bashio::config 'recording_search_path')"
+if bashio::var.is_empty "${recording_path}"; then
+    recording_path="/config/recordings"
+fi
+
+bashio::log.info "Ensuring recording storage path exists: ${recording_path}"
+mkdir -p "${recording_path}"
+
+if [ ! -f "${GUAC_PROPERTIES_FILE}" ]; then
+    bashio::log.info "Creating guacamole.properties at ${GUAC_PROPERTIES_FILE}"
+    touch "${GUAC_PROPERTIES_FILE}"
+fi
+
+if grep -q "^recording-search-path:" "${GUAC_PROPERTIES_FILE}"; then
+    sed -i "s|^recording-search-path:.*|recording-search-path: ${recording_path}|" "${GUAC_PROPERTIES_FILE}"
+else
+    echo "recording-search-path: ${recording_path}" >> "${GUAC_PROPERTIES_FILE}"
+fi


### PR DESCRIPTION
## Summary
- add a configurable recording search path to support the history recording storage extension
- ensure guacamole.properties is updated and the recording directory is created at startup
- document the new option and bump the add-on version

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944563dc08083259d3292b3f4fffabd)