### PR TITLE
Fix migration lock handling for Joplin addon

### DIFF
--- a/joplin/CHANGELOG.md
+++ b/joplin/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 3.5.2 (22-12-2025)
+- Automatically clear stale migration locks for SQLite and PostgreSQL databases on startup to avoid blocked fresh installs
+- Add database client utilities for unlocking migrations
+
 ## 3.5.1 (06-12-2025)
 - Update to latest version from etechonomy/joplin-server (changelog : https://github.com/etechonomy/joplin-server/releases)
 - Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.

--- a/joplin/Dockerfile
+++ b/joplin/Dockerfile
@@ -55,7 +55,7 @@ ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templat
 RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
 
 # Manual apps
-ENV PACKAGES="procps"
+ENV PACKAGES="procps sqlite3 postgresql-client"
 
 # Automatic apps & bashio
 ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templates/ha_autoapps.sh" "/ha_autoapps.sh"

--- a/joplin/config.yaml
+++ b/joplin/config.yaml
@@ -104,5 +104,5 @@ schema:
 slug: joplin
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "3.5.1"
+version: "3.5.2"
 webui: "[PROTO:ssl]://[HOST]:[PORT:22300]"


### PR DESCRIPTION
## Summary
- add database client utilities to the image for migration maintenance
- clear stale knex migration locks for SQLite and PostgreSQL before starting Joplin
- bump the add-on version and changelog for the fix

## Testing
- bash -n rootfs/etc/cont-init.d/99-run.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69452084193c8325b43a357626e50792)