### PR TITLE
Fix Seafile database option parsing

### DIFF
--- a/seafile/CHANGELOG.md
+++ b/seafile/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
+## 12.0.16 (15-02-2026)
+- Handle list-based `database` options correctly so SQLite configurations skip MySQL initialization.
+
 ## 12.0.15 (18-12-2025)
 - Normalize `SERVICE_URL` and `FILE_SERVER_ROOT` values in `conf/seahub_settings.py` based on the add-on configuration to generate valid download links.
 

--- a/seafile/README.md
+++ b/seafile/README.md
@@ -1,4 +1,3 @@
-## &#9888; Open Issue : [🐛 [Seafile] 12.0.14 not started (opened 2025-09-15)](https://github.com/alexbelgium/hassio-addons/issues/2104) by [@KoalaMontana](https://github.com/KoalaMontana)
 # Home assistant add-on: seafile
 
 

--- a/seafile/config.yaml
+++ b/seafile/config.yaml
@@ -128,5 +128,5 @@ services:
 slug: seafile
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/seafile
-version: 12.0.15
+version: 12.0.16
 webui: http://[HOST]:[PORT:8000]

--- a/seafile/rootfs/etc/cont-init.d/99-run.sh
+++ b/seafile/rootfs/etc/cont-init.d/99-run.sh
@@ -119,7 +119,14 @@ bashio::log.info "FILE_SERVER_ROOT set to ${FILE_SERVER_ROOT_VALUE}"
 
 bashio::log.info "Defining database"
 
-case $(bashio::config 'database') in
+# The option is defined as a list, so grab the first entry when an array is
+# provided (Home Assistant stores multi-select options this way). Fallback to
+# the raw value to stay compatible with older configurations that used a
+# string.
+DATABASE_SELECTION=$(bashio::config 'database[0]' 2>/dev/null || true)
+DATABASE_SELECTION=${DATABASE_SELECTION:-$(bashio::config 'database')}
+
+case "${DATABASE_SELECTION}" in
 
     # Use sqlite
     sqlite)


### PR DESCRIPTION
## Summary
- handle list-based database selections so SQLite setups skip MySQL initialization
- bump Seafile add-on version to 12.0.16 and document the fix
- remove outdated open issue banner from the README

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694816679db0832593b8250d777f6741)