### PR TITLE
Handle WireGuard sysctl failure on read-only hosts

### DIFF
--- a/qbittorrent/CHANGELOG.md
+++ b/qbittorrent/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.1.4-4 (30-12-2025)
+- Allow WireGuard to continue when src_valid_mark sysctl cannot be set on read-only hosts
+
 ## 5.1.4-3 (22-12-2025)
 - Minor bugs fixed
 

--- a/qbittorrent/config.yaml
+++ b/qbittorrent/config.yaml
@@ -144,4 +144,4 @@ schema:
 slug: qbittorrent
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: 5.1.4-3
+version: 5.1.4-4

--- a/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
+++ b/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
@@ -55,6 +55,17 @@ _setup_wireguard() {
 
         if [ "${status}" -eq 0 ]; then return 0; fi
 
+        # Allow sysctl failures on read-only hosts while keeping the interface up
+        if echo "${output}" | grep -qi 'net\.ipv4\.conf\.all\.src_valid_mark=1'; then
+            if echo "${output}" | grep -qiE 'read-only file system|operation not permitted'; then
+                if ip link show "${wireguard_interface}" >/dev/null 2>&1; then
+                    bashio::log.warning 'WireGuard applied but sysctl net.ipv4.conf.all.src_valid_mark=1 could not be set (read-only). Continuing.'
+                    status=0
+                    return 0
+                fi
+            fi
+        fi
+
         # Check for iptables errors and try legacy fallback
         if echo "${output}" | grep -qiE 'iptables-restore|ip6tables-restore|xtables'; then
             if command -v iptables-legacy >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- allow the WireGuard startup path to tolerate read-only sysctl failures when src_valid_mark cannot be set
- bump the qBittorrent add-on version to 5.1.4-4 and document the change in the changelog

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948f69fa428832582d04325661804b1)