### PR TITLE
Bump birdnet-go version and fix ingress subpath rewrites

### DIFF
--- a/birdnet-go/config.yaml
+++ b/birdnet-go/config.yaml
@@ -117,4 +117,4 @@ slug: birdnet-go
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-go
 usb: true
-version: "nightly-20251223"
+version: "nightly-20251224"

--- a/birdnet-go/rootfs/etc/nginx/servers/ingress.conf
+++ b/birdnet-go/rootfs/etc/nginx/servers/ingress.conf
@@ -45,15 +45,15 @@ server {
       sub_filter action=\"/ action=\"%%ingress_entry%%/;
       sub_filter EventSource('/ EventSource('%%ingress_entry%%/;
       sub_filter fetch('/ fetch('%%ingress_entry%%/;
-      sub_filter `/api/v `%%ingress_entry%%/api/v;
-      sub_filter "'/api/v" "'%%ingress_entry%%/api/v";
-      sub_filter \"/api/v \"%%ingress_entry%%/api/v;
-      sub_filter `/u `%%ingress_entry%%/u;
-      sub_filter "'/u" "'%%ingress_entry%%/u";
-      sub_filter \"/u \"%%ingress_entry%%/u;
-      sub_filter `/asset `%%ingress_entry%%/asset;
-      sub_filter "'/asset" "'%%ingress_entry%%/asset";
-      sub_filter \"/asset \"%%ingress_entry%%/asset;
+      sub_filter `/api/v2 `%%ingress_entry%%/api/v2;
+      sub_filter "'/api/v2" "'%%ingress_entry%%/api/v2";
+      sub_filter \"/api/v2 \"%%ingress_entry%%/api/v2;
+      sub_filter `/ui `%%ingress_entry%%/ui;
+      sub_filter "'/ui" "'%%ingress_entry%%/ui";
+      sub_filter \"/ui \"%%ingress_entry%%/ui;
+      sub_filter `/assets `%%ingress_entry%%/assets;
+      sub_filter "'/assets" "'%%ingress_entry%%/assets";
+      sub_filter \"/assets \"%%ingress_entry%%/assets;
 
       # Fix streaming
       sub_filter window.location.origin} window.location.origin}%%ingress_entry%%;


### PR DESCRIPTION
### Motivation
- Ensure the addon package version is advanced to the next nightly release by updating the `version` field.  
- Support the Svelte SPA frontend served under Home Assistant ingress by correcting subpath rewrites.  
- Route API calls to the new API prefix and avoid broken asset and UI requests by targeting the updated paths.  
- Preserve existing SSE/client-side routing fixes so streaming and navigation continue to work under an ingress subpath.  

### Description
- Updated `rootfs/etc/nginx/servers/ingress.conf` to replace sub_filter rules to target `/api/v2`, `/ui`, and `/assets` instead of the old `/api/v`, `/u`, and `/asset` prefixes.  
- Kept generic `sub_filter` and streaming-related headers and rules (`sub_filter_once off`, `sub_filter_types *`, SSE headers) to maintain client-side routing and SSE functionality.  
- Bumped the addon `version` in `config.yaml` from `nightly-20251223` to `nightly-20251224`.  

### Testing
- No automated tests were executed for this change.  
- The change is a configuration and metadata update, so CI/unit tests were not applicable.  
- Manual runtime validation is recommended after deployment to confirm assets, SPA routes, and API endpoints are correctly served under the ingress subpath.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c0fedaafc83258e848f3aa66fff4a)