### PR TITLE
Update gazpar2mqtt upstream to ssenart/gazpar2mqtt (0.2.4)

### DIFF
--- a/gazpar2mqtt/CHANGELOG.md
+++ b/gazpar2mqtt/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.2.4 (24-12-2025)
+- Update to latest version from ssenart/gazpar2mqtt
 
 ## 0.8.2 (24-12-2025)
 - Update to latest version from yukulehe/gazpar2mqtt

--- a/gazpar2mqtt/Dockerfile
+++ b/gazpar2mqtt/Dockerfile
@@ -15,8 +15,8 @@
 #################
 
 ARG BUILD_FROM
-ARG BUILD_UPSTREAM="0.8.2"
-FROM yukulehe/gazpar2mqtt:$BUILD_UPSTREAM
+ARG BUILD_UPSTREAM="0.2.4"
+FROM ssenart/gazpar2mqtt:$BUILD_UPSTREAM
 
 ##################
 # 2 Modify Image #
@@ -50,7 +50,7 @@ ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templat
 RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
 
 # Manual apps
-ENV PACKAGES="0.8.2"
+ENV PACKAGES="0.2.4"
 
 # Automatic apps & bashio
 ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templates/ha_autoapps.sh" "/ha_autoapps.sh"

--- a/gazpar2mqtt/README.md
+++ b/gazpar2mqtt/README.md
@@ -30,7 +30,7 @@ _Thanks to everyone having starred my repo! To star it click on the image below,
 ## About
 
 Python script to fetch GRDF data and publish data to a mqtt broker.
-See its github for all informations : https://github.com/yukulehe/gazpar2mqtt
+See its github for all informations : https://github.com/ssenart/gazpar2mqtt
 
 ## Configuration
 
@@ -91,7 +91,7 @@ mqtt:
 update_frequency: 3600  # seconds
 ```
 
-For complete configuration options, see: https://github.com/yukulehe/gazpar2mqtt
+For complete configuration options, see: https://github.com/ssenart/gazpar2mqtt
 
 ## Installation
 
@@ -106,5 +106,4 @@ comparison to installing any other Hass.io add-on.
 1. Carefully configure the add-on to your preferences, see the official documentation for for that.
 
 [repository]: https://github.com/alexbelgium/hassio-addons
-
 

--- a/gazpar2mqtt/config.yaml
+++ b/gazpar2mqtt/config.yaml
@@ -88,4 +88,4 @@ services:
 slug: gazpar2mqtt
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "0.8.2"
+version: "0.2.4"

--- a/gazpar2mqtt/rootfs/templates/config.yaml
+++ b/gazpar2mqtt/rootfs/templates/config.yaml
@@ -1,4 +1,4 @@
 GRDF_USERNAME: username #your GRDF login (ex : myemail@email.com)
 GRDF_PASSWORD: password #your GRDF password
 MQTT_HOST: 127.0.0.1 #hostname or ip adress of the MQTT broker.
-# OPTIONAL VARIABLES : see https://github.com/yukulehe/gazpar2mqtt
+# OPTIONAL VARIABLES : see https://github.com/ssenart/gazpar2mqtt

--- a/gazpar2mqtt/updater.json
+++ b/gazpar2mqtt/updater.json
@@ -3,6 +3,6 @@
   "repository": "alexbelgium/hassio-addons",
   "slug": "gazpar2mqtt",
   "source": "dockerhub",
-  "upstream_repo": "yukulehe/gazpar2mqtt",
-  "upstream_version": "0.8.2"
+  "upstream_repo": "ssenart/gazpar2mqtt",
+  "upstream_version": "0.2.4"
 }


### PR DESCRIPTION
### Motivation
- Move the add-on to the maintained `ssenart/gazpar2mqtt` upstream image and align version metadata with that upstream.
- Update documentation and template references to point at the correct upstream repository for users and config examples.
- Ensure the add-on uses the matching upstream package version for building and runtime.

### Description
- Change the build base image in `Dockerfile` to `ssenart/gazpar2mqtt:0.2.4` and update the `PACKAGES` build variable to `0.2.4`.
- Update `updater.json` to set `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c13d5805483259d746abf598c91b0)