### PR TITLE
Add gosu dependency, enable ha_entrypoint and bump social_to_mealie version

### DIFF
--- a/social_to_mealie/Dockerfile
+++ b/social_to_mealie/Dockerfile
@@ -49,7 +49,7 @@ ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templat
 RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
 
 # Manual apps
-ENV PACKAGES="jq"
+ENV PACKAGES="jq gosu"
 
 # Automatic apps & bashio
 ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templates/ha_autoapps.sh" "/ha_autoapps.sh"
@@ -71,8 +71,7 @@ RUN chmod 777 /ha_entrypoint.sh /ha_entrypoint_modif.sh && /ha_entrypoint_modif.
 ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templates/bashio-standalone.sh" "/.bashio-standalone.sh"
 RUN chmod 777 /.bashio-standalone.sh
 
-#ENTRYPOINT [ "/ha_entrypoint.sh" ]
-#CMD [ "/ha_entrypoint.sh" ]
+ENTRYPOINT [ "/ha_entrypoint.sh" ]
 
 ############
 # 5 Labels #

--- a/social_to_mealie/config.yaml
+++ b/social_to_mealie/config.yaml
@@ -1,5 +1,5 @@
 name: Social to Mealie
-version: 0.1.0-3
+version: 0.1.0-4
 slug: social_to_mealie
 description: Import recipes from social media directly into Mealie
 url: https://github.com/alexbelgium/hassio-addons

--- a/social_to_mealie/rootfs/etc/cont-init.d/99-run.sh
+++ b/social_to_mealie/rootfs/etc/cont-init.d/99-run.sh
@@ -4,4 +4,4 @@ set -e
 
 bashio::log.info "Starting Social to Mealie"
 cd /app || bashio::exit.nok "App directory not found"
-/./app/entrypoint.sh node --run start
+exec gosu nextjs /app/entrypoint.sh node --run start


### PR DESCRIPTION
### Motivation

- Allow the container entrypoint to drop privileges by including `gosu` in the add-on package list.
- Ensure the add-on uses the Home Assistant entrypoint so the wrapper can perform initialization and signal handling.
- Run the application as the non-root `nextjs` user to improve security and process ownership.
- Update the add-on version to reflect the changes.

### Description

- Added `gosu` to `ENV PACKAGES` in `social_to_mealie/Dockerfile` so it will be installed in the image.
- Enabled the Home Assistant entrypoint by setting `ENTRYPOINT [ "/ha_entrypoint.sh" ]` in the `Dockerfile`.
- Updated `rootfs/etc/cont-init.d/99-run.sh` to `exec gosu nextjs /app/entrypoint.sh node --run start` so the process is replaced and runs as `nextjs`.
- Bumped the add-on `version` in `social_to_mealie/config.yaml` from `0.1.0-3` to `0.1.0-4`.

### Testing

- No automated tests were run for this change.
- No test failures reported because no tests executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695004db7a848325bca2bde30d4d5d76)