### PR TITLE
Update Bitwarden base to Debian 15 and bump add-on version

### DIFF
--- a/bitwarden/Dockerfile
+++ b/bitwarden/Dockerfile
@@ -14,7 +14,7 @@
 # 1 Build Image #
 #################
 
-ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:9.1.0
+ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:15.0.0
 ###############################################################################
 # Get prebuild containers from Vaultwarden
 ###############################################################################

--- a/bitwarden/build.yaml
+++ b/bitwarden/build.yaml
@@ -1,4 +1,4 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:7.1.0
-  amd64: ghcr.io/hassio-addons/debian-base/amd64:7.1.0
+  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:15.0.0
+  amd64: ghcr.io/hassio-addons/debian-base/amd64:15.0.0

--- a/bitwarden/config.yaml
+++ b/bitwarden/config.yaml
@@ -28,5 +28,5 @@ schema:
 slug: bitwarden
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/bitwarden
-version: 1.35.0-4
+version: 1.35.0-5
 webui: "[PROTO:ssl]://[HOST]:[PORT:7277]"


### PR DESCRIPTION
### Motivation
- Fix the `GLIBC_2.39` mismatch by using a newer Debian base image that provides the required GLIBC version.
- Ensure the prebuilt `vaultwarden` binary from the upstream image runs correctly on the add-on runtime.
- Keep both architectures aligned to the same base release to avoid cross-arch inconsistencies.
- Increment the add-on version to indicate the compatibility and base image change.

### Description
- Updated `bitwarden/Dockerfile` to use `ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:15.0.0` instead of the older Debian base.
- Updated `bitwarden/build.yaml` to use `ghcr.io/hassio-addons/debian-base/*:15.0.0` for both `aarch64` and `amd64`.
- Bumped the add-on `version` in `bitwarden/config.yaml` from `1.35.0-4` to `1.35.0-5`.
- No other functional changes to start/entrypoint logic or copied upstream artifacts were made.

### Testing
- No automated tests or CI pipelines were executed as part of this change.
- No local build or container runtime validation was run during this update.
- Changes were syntactically validated by file updates and a successful commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69519c4d0e5c8325b4f81663682c9b8a)