### PR TITLE
Use latest bashio release in package download template

### DIFF
--- a/.templates/ha_automatic_packages.sh
+++ b/.templates/ha_automatic_packages.sh
@@ -237,9 +237,10 @@ for files in "/etc/services.d" "/etc/cont-init.d"; do
     # Bashio
     if grep -q -rnw "$files/" -e 'bashio' && [ ! -f "/usr/bin/bashio" ]; then
         [ "$VERBOSE" = true ] && echo "install bashio"
-        BASHIO_VERSION="0.14.3"
+        BASHIO_VERSION="latest"
         mkdir -p /tmp/bashio
-        curl -f -L -s -S "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" | tar -xzf - --strip 1 -C /tmp/bashio
+        BASHIO_TAG="$(curl -f -L -s -S "https://api.github.com/repos/hassio-addons/bashio/releases/${BASHIO_VERSION}" | awk -F '\"' '/tag_name/{print $4; exit}')"
+        curl -f -L -s -S "https://github.com/hassio-addons/bashio/archive/${BASHIO_TAG}.tar.gz" | tar -xzf - --strip 1 -C /tmp/bashio
         mv /tmp/bashio/lib /usr/lib/bashio
         ln -s /usr/lib/bashio/bashio /usr/bin/bashio
         rm -rf /tmp/bashio


### PR DESCRIPTION
### Motivation
- Ensure the package install template always fetches the most recent `bashio` release instead of a hardcoded version.  
- Avoid manual updates to the pinned `BASHIO_VERSION` when new `bashio` releases are published.  
- Improve reliability of addon containers that rely on `bashio` being present.  

### Description
- Update `.templates/ha_automatic_packages.sh` to set `BASHIO_VERSION="latest"` instead of a fixed version.  
- Resolve the real release tag by querying the GitHub Releases API with `curl "https://api.github.com/repos/hassio-addons/bashio/releases/${BASHIO_VERSION}"` and extract `tag_name`.  
- Download the `bashio` archive using the resolved tag via `https://github.com/hassio-addons/bashio/archive/${BASHIO_TAG}.tar.gz` and unpack into `/tmp/bashio`.  

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695389c12ac483258062728dc1c82c2b)