### PR TITLE
Align Portainer Agent hostname with container name

### DIFF
--- a/portainer_agent/rootfs/etc/services.d/portainer_agent/run
+++ b/portainer_agent/rootfs/etc/services.d/portainer_agent/run
@@ -7,6 +7,9 @@ bashio::log.info "Starting app"
 
 cd /app || exit 1
 
+container_name="${HOSTNAME//-/_}"
+export HOSTNAME="${container_name}"
+
 args=()
 if bashio::config.has_value 'PORTAINER_AGENT_ARGS'; then
   read -r -a args <<<"$(bashio::config 'PORTAINER_AGENT_ARGS')"


### PR DESCRIPTION
### Motivation
- Ensure the Portainer Agent uses a hostname that matches the container name by converting dashes to underscores. 
- Prevent hostname/container-name mismatches that can cause identification or lookup issues when the agent starts. 

### Description
- Modify `portainer_agent/rootfs/etc/services.d/portainer_agent/run` to compute `container_name` from `HOSTNAME` using `${HOSTNAME//-/_}` and export it back to `HOSTNAME` before starting the agent. 
- Preserve existing argument handling and still launch the agent with `./agent "${args[@]}"`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954f950a7808325932b220696bd5b25)