### PR TITLE
Prefill Joal ingress credentials

### DIFF
--- a/joal/rootfs/etc/cont-init.d/99-run.sh
+++ b/joal/rootfs/etc/cont-init.d/99-run.sh
@@ -73,6 +73,12 @@ UIPATH=$(bashio::config 'ui_path')
 #port=$(bashio::addon.port 80)
 ingress_port=$(bashio::addon.ingress_port)
 ingress_interface=$(bashio::addon.ip_address)
+ui_credentials_json=$(jq -n --arg host "${host_ip}:${host_port}${ingress_url}/" \
+    --arg port "${host_port}" \
+    --arg pathPrefix "${UIPATH}" \
+    --arg secretToken "${TOKEN}" \
+    '{host:$host,port:$port,pathPrefix:$pathPrefix,secretToken:$secretToken}')
+ui_credentials_encoded=$(printf '%s' "$ui_credentials_json" | jq -sRr @uri)
 
 #################
 # NGINX SETTING #
@@ -90,6 +96,7 @@ ingress_interface=$(bashio::addon.ip_address)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%path%%/${UIPATH}/g" /etc/nginx/servers/ingress.conf
+sed -i "s|%%ui_credentials%%|${ui_credentials_encoded}|g" /etc/nginx/servers/ingress.conf
 mkdir -p /var/log/nginx && touch /var/log/nginx/error.log
 
 ###############

--- a/joal/rootfs/etc/nginx/servers/ingress.conf
+++ b/joal/rootfs/etc/nginx/servers/ingress.conf
@@ -12,7 +12,7 @@ server {
        proxy_connect_timeout 30m;
        proxy_send_timeout 30m;
        proxy_read_timeout 30m;
-       proxy_pass         http://backend/%%path%%/ui/;
+       proxy_pass         http://backend/%%path%%/ui?ui_credentials=%%ui_credentials%%;
   }
 
     location /:8123/ {


### PR DESCRIPTION
### Motivation
- Automatically prefill the Joal web UI connection fields when accessed via Home Assistant ingress so users don't need to enter host/port/path/token manually.
- Encode the Joal UI credentials into a query parameter so the upstream app can consume them via the ingress proxy.

### Description
- Update `joal/rootfs/etc/nginx/servers/ingress.conf` to append `?ui_credentials=%%ui_credentials%%` to the `proxy_pass` URL so ingress can forward encoded credentials.
- Generate a JSON object with `host`, `port`, `pathPrefix`, and `secretToken` in `joal/rootfs/etc/cont-init.d/99-run.sh` using `jq` and URL-encode it with `jq -sRr @uri`.
- Inject the encoded credentials into the nginx template by replacing the `%%ui_credentials%%` placeholder at startup with `sed`.
- Changes touch `joal/rootfs/etc/cont-init.d/99-run.sh` and `joal/rootfs/etc/nginx/servers/ingress.conf`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bae40fd08832590e5d4536e200df3)