### PR TITLE
Update wger README port mapping

### DIFF
--- a/wger/README.md
+++ b/wger/README.md
@@ -37,7 +37,7 @@ _Thanks to everyone having starred my repo! To star it click on the image below,
 Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 - Start the addon. Wait a while and check the log for any errors. Initial start can take up to 15 minutes !
-- Open yourdomain.com:8000 (where ":8000" is the port configured in the addon).
+- Open yourdomain.com:9927 (default host mapping for the add-on port `80/tcp`, as indicated by the `webui` hint).
 - Default
   - Username: `admin`
   - Password: `adminadmin`
@@ -73,5 +73,4 @@ comparison to installing any other Hass.io add-on.
 If you have in issue with your installation, please be sure to checkout github.
 
 [repository]: https://github.com/alexbelgium/hassio-addons
-
 


### PR DESCRIPTION
### Motivation
- Ensure the README reflects the add-on's configured host port mapping so users open the correct web UI address.
- Replace the outdated `:8000` example with the correct default host port for this add-on.
- Make the guidance consistent with the add-on `webui` hint and the `ports` mapping (`80/tcp`).

### Description
- Updated `wger/README.md` to replace "Open yourdomain.com:8000" with "Open yourdomain.com:9927" and added a note that this is the default host mapping for the add-on port `80/tcp` as indicated by the `webui` hint.
- Only the documentation file `wger/README.md` was modified and surrounding instructions were kept intact.

### Testing
- This is a documentation-only change, so no unit or integration tests were run.
- No automated CI tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e159b900c8325975cd2cf7e79391a)