### PR TITLE
Fix MQTT host comment typo in gazpar2mqtt config template

### DIFF
--- a/gazpar2mqtt/rootfs/templates/config.yaml
+++ b/gazpar2mqtt/rootfs/templates/config.yaml
@@ -1,4 +1,4 @@
 GRDF_USERNAME: username #your GRDF login (ex : myemail@email.com)
 GRDF_PASSWORD: password #your GRDF password
-MQTT_HOST: 127.0.0.1 #hostname or ip adress of the MQTT broker.
+MQTT_HOST: 127.0.0.1 #hostname or ip address of the MQTT broker.
 # OPTIONAL VARIABLES : see https://github.com/ssenart/gazpar2mqtt


### PR DESCRIPTION
### Motivation
- Fix a spelling mistake in the MQTT host comment to improve clarity for users. 
- The typo was in the `MQTT_HOST` comment inside the template used for the gazpar2mqtt addon.

### Description
- Updated the comment in `gazpar2mqtt/rootfs/templates/config.yaml` to change "adress" to "address" for the `MQTT_HOST` line. 
- No functional code changes were made; only the inline comment was edited.

### Testing
- No automated tests were run because this is a text-only comment change. 
- The change was committed with the message `Fix MQTT host comment typo` and prepared for a PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e15d914a08325ba276451cb2bb59c)