### PR TITLE
Ensure mktemp parent directory exists

### DIFF
--- a/.templates/00-global_var.sh
+++ b/.templates/00-global_var.sh
@@ -32,7 +32,13 @@ fi
 BLOCK_BEGIN="# --- BEGIN ADDON ENV (generated) ---"
 BLOCK_END="# --- END ADDON ENV (generated) ---"
 
-EXPORT_BLOCK_FILE="$(mktemp)"
+mktemp_safe() {
+    local tmpdir="${TMPDIR:-/tmp}"
+    mkdir -p "$tmpdir"
+    mktemp -p "$tmpdir"
+}
+
+EXPORT_BLOCK_FILE="$(mktemp_safe)"
 trap 'rm -f "$EXPORT_BLOCK_FILE"' EXIT
 
 {
@@ -148,7 +154,7 @@ is_shell_run_script() {
 inject_block_into_file() {
     local file="$1"
     local tmp
-    tmp="$(mktemp)"
+    tmp="$(mktemp_safe)"
 
     awk -v bfile="${EXPORT_BLOCK_FILE}" -v begin="${BLOCK_BEGIN}" -v end="${BLOCK_END}" '
         function print_block() {


### PR DESCRIPTION
### Motivation
- Prevent failures when `mktemp` is invoked with a `TMPDIR` that doesn't exist by creating the parent directory first.
- Make temporary file creation more robust inside constrained/containerized environments where the temp directory may not be present.

### Description
- Add a helper function `mktemp_safe` that ensures `TMPDIR` (defaulting to `/tmp`) exists and then calls `mktemp -p`.
- Replace direct `mktemp` usage with `mktemp_safe` for the export block file in `/.templates/00-global_var.sh`.
- Replace the temporary file creation inside `inject_block_into_file` with `mktemp_safe` to use the safe helper.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960b9d5c5ec8325be8a8b831c1c4e6b)