### PR TITLE
Organizr: honor configured PUID/PGID for /data and set version to v2-2

### DIFF
--- a/organizr/CHANGELOG.md
+++ b/organizr/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v2-2 (18-03-2026)
+- Ensure folder permissions use configured PUID/PGID values
+
 ## v2 (11-01-2026)
 - Minor bugs fixed
 

--- a/organizr/config.yaml
+++ b/organizr/config.yaml
@@ -86,5 +86,5 @@ schema:
 slug: organizr
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "v2"
+version: "v2-2"
 webui: "[PROTO:ssl]://[HOST]:[PORT:80]"

--- a/organizr/rootfs/etc/cont-init.d/00-folders.sh
+++ b/organizr/rootfs/etc/cont-init.d/00-folders.sh
@@ -2,6 +2,9 @@
 # shellcheck shell=bash
 set -e
 
+PUID="$(bashio::config 'PUID')"
+PGID="$(bashio::config 'PGID')"
+
 echo "Creating /data/organizr"
 mkdir -p /data/organizr
 chown -R "$PUID:$PGID" /data


### PR DESCRIPTION
### Motivation
- Ensure the add-on initializes folder ownership using the configured `PUID` and `PGID` options.
- Keep the add-on metadata consistent by updating the version label to `v2-2`.

### Description
- Read `PUID` and `PGID` from add-on options in `rootfs/etc/cont-init.d/00-folders.sh` using `PUID="$(bashio::config 'PUID')"` and `PGID="$(bashio::config 'PGID')"` and apply them with `chown -R "$PUID:$PGID" /data`.
- Update `config.yaml` to set `version: "v2-2"`.
- Adjust the `CHANGELOG.md` header to `## v2-2 (18-03-2026)` to reflect the version change.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69634da007ec8325a072971a5c99e885)