### PR TITLE
Ensure HOME exists before writing user shell files and guard HOME usage

### DIFF
--- a/.templates/00-global_var.sh
+++ b/.templates/00-global_var.sh
@@ -301,11 +301,14 @@ done
 update_scripts_with_block
 
 # --- MINIMAL CHANGE: also inject into /etc/bash.bashrc (for interactive bash shells)
-mkdir -p /etc "$HOME"
+mkdir -p /etc
 touch "/etc/bash.bashrc"
-touch "$HOME/bash.bashrc"
 inject_block_into_file "/etc/bash.bashrc"
-inject_block_into_file "$HOME/bash.bashrc"
+if [[ -n "${HOME:-}" ]]; then
+    mkdir -p "$HOME"
+    touch "$HOME/bash.bashrc"
+    inject_block_into_file "$HOME/bash.bashrc"
+fi
 
 ################
 # Set timezone #

--- a/.templates/01-config_yaml.sh
+++ b/.templates/01-config_yaml.sh
@@ -205,7 +205,10 @@ while IFS= read -r line; do
         if [ -d /var/run/s6/container_environment ]; then printf "%s" "${VALUE}" > /var/run/s6/container_environment/"${KEYS}"; fi
 
         # Persist for interactive shells
-        append_unique_line "$HOME/.bashrc" "export $line"
+        if [[ -n "${HOME:-}" ]]; then
+            mkdir -p "$HOME"
+            append_unique_line "$HOME/.bashrc" "export $line"
+        fi
         append_unique_line "/etc/bash.bashrc" "export $line"
 
         # Show in log


### PR DESCRIPTION
### Motivation
- Avoid creating or writing user files when `HOME` is unset so we do not persist environment into unexpected locations.
- Always inject environment blocks into the system shell file but only modify per-user shell files when a valid `HOME` exists.
- Prevent unbound-variable errors by guarding `HOME` references using a safe parameter expansion check.

### Description
- In `./templates/00-global_var.sh` stop using `mkdir -p /etc "$HOME"` and instead run `mkdir -p /etc` and always `touch "/etc/bash.bashrc"`, then conditionally `mkdir -p "$HOME"`, `touch "$HOME/bash.bashrc"` and call `inject_block_into_file "$HOME/bash.bashrc"` inside `if [[ -n "${HOME:-}" ]]; then ... fi`.
- In `./templates/01-config_yaml.sh` wrap `append_unique_line "$HOME/.bashrc" "export $line"` with `if [[ -n "${HOME:-}" ]]; then mkdir -p "$HOME"; append_unique_line ...; fi` so the user bashrc is only modified when `HOME` is present.
- Preserve existing behavior for system targets such as `/etc/bash.bashrc`, `/etc/environment`, s6 container environment files, entrypoints, and other script exports by leaving those writes unchanged.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696352aa1010832586ac330f93ae15bf)