### PR TITLE
Auto-download Chromium extensions for karakeep

### DIFF
--- a/karakeep/Dockerfile
+++ b/karakeep/Dockerfile
@@ -57,6 +57,7 @@ RUN \
         ttf-freefont \
         font-noto-emoji \
         font-wqy-zenhei \
+        unzip \
     && mkdir -p /usr/src/chrome \
     && adduser -D chrome \
     && chown -R chrome:chrome /usr/src/chrome
@@ -108,6 +109,23 @@ ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templat
 RUN chmod 777 /.bashio-standalone.sh
 
 RUN sed -i "s|/usr/bin/env|/usr/bin/with-contenv|g" /etc/cont-init.d/*
+
+RUN set -e; \
+    extensions_dir="/usr/src/chrome/extensions"; \
+    mkdir -p "${extensions_dir}"; \
+    for entry in \
+      "i-dont-care-about-cookies:fllaojicojecljbmefodhfapmkghcbnh" \
+      "ublock-origin:cjpalhdlnbpafiamejdnhcphjbkeiagm"; do \
+        name="${entry%%:*}"; \
+        ext_id="${entry##*:}"; \
+        curl -fsSL "https://clients2.google.com/service/update2/crx?response=redirect&prodversion=120.0&acceptformat=crx2,crx3&x=id%3D${ext_id}%26installsource%3Dondemand%26uc" \
+          -o "/tmp/${name}.crx"; \
+        rm -rf "${extensions_dir:?}/${name}"; \
+        mkdir -p "${extensions_dir}/${name}"; \
+        unzip -q "/tmp/${name}.crx" -d "${extensions_dir}/${name}"; \
+        rm "/tmp/${name}.crx"; \
+    done; \
+    chown -R chrome:chrome "${extensions_dir}"
 
 ############
 # 5 Labels #

--- a/karakeep/README.md
+++ b/karakeep/README.md
@@ -63,7 +63,7 @@ Webui can be found at `<your-ip>:3000`.
 | `CRAWLER_VIDEO_DOWNLOAD_MAX_SIZE` | int | | Max video size (MB). |
 | `CRAWLER_VIDEO_DOWNLOAD_TIMEOUT_SEC` | int | | Video download timeout. |
 | `CRAWLER_ENABLE_ADBLOCKER` | bool | `true` | Enable ad blocking in the crawler. |
-| `CHROME_EXTENSIONS_DIR` | str | `/share/karakeep/extensions` | Host-mounted extensions directory for headless Chromium. |
+| `CHROME_EXTENSIONS_DIR` | str | `/usr/src/chrome/extensions` | Extensions directory for headless Chromium. |
 | `MEILI_MASTER_KEY` | password | | Meilisearch master key (auto-generated if left blank). |
 | `MEILI_ADDR` | str | | Meilisearch URL. |
 | `BROWSER_WEB_URL` | str | | Chromium remote debugging URL. |
@@ -72,15 +72,9 @@ Webui can be found at `<your-ip>:3000`.
 
 ### Extensions for headless Chromium
 
-This add-on loads extensions in headless Chromium with the `--headless=new` flag. To use the included defaults:
+This add-on loads extensions in headless Chromium with the `--headless=new` flag. The defaults are downloaded automatically during the image build and refreshed each time the add-on starts into `/usr/src/chrome/extensions` (non-persistent).
 
-1. Create these folders on the host (via the `/share` mount):
-   - `/share/karakeep/extensions/i-dont-care-about-cookies`
-   - `/share/karakeep/extensions/ublock-origin`
-2. Unzip each extension into its corresponding folder.
-3. Restart the add-on.
-
-You can override the base folder with the `CHROME_EXTENSIONS_DIR` option. Any missing extension folder is skipped at runtime.
+You can override the base folder with the `CHROME_EXTENSIONS_DIR` option to point to a host-mounted directory if you prefer to manage extensions manually. Any missing extension folder is skipped at runtime.
 
 ### Custom Scripts and Environment Variables
 

--- a/karakeep/config.yaml
+++ b/karakeep/config.yaml
@@ -4,7 +4,7 @@ arch:
 description: bookmark-everything app with a touch of AI for the data hoarders out there
 environment:
   BROWSER_WEB_URL: http://127.0.0.1:9222
-  CHROME_EXTENSIONS_DIR: /share/karakeep/extensions
+  CHROME_EXTENSIONS_DIR: /usr/src/chrome/extensions
   DATA_DIR: /data
   DISABLE_NEW_RELEASE_CHECK: "true"
   MEILI_ADDR: http://127.0.0.1:7700
@@ -19,7 +19,7 @@ map:
 name: Karakeep
 options:
   env_vars: []
-  CHROME_EXTENSIONS_DIR: /share/karakeep/extensions
+  CHROME_EXTENSIONS_DIR: /usr/src/chrome/extensions
   CRAWLER_DOWNLOAD_BANNER_IMAGE: true
   CRAWLER_ENABLE_ADBLOCKER: true
   CRAWLER_FULL_PAGE_ARCHIVE: false

--- a/karakeep/rootfs/etc/cont-init.d/90-folders.sh
+++ b/karakeep/rootfs/etc/cont-init.d/90-folders.sh
@@ -7,9 +7,9 @@ bashio::log.info "Creating folders"
 mkdir -p \
   /data/cache \
   /data/chrome \
-  /share/karakeep/extensions \
-  /config/meili
+  /config/meili \
+  /usr/src/chrome/extensions
 
 if id chrome &>/dev/null; then
-  chown -R chrome:chrome /data/cache /data/chrome
+  chown -R chrome:chrome /data/cache /data/chrome /usr/src/chrome/extensions
 fi

--- a/karakeep/rootfs/etc/cont-init.d/92-chrome-extensions.sh
+++ b/karakeep/rootfs/etc/cont-init.d/92-chrome-extensions.sh
@@ -1,0 +1,30 @@
+#!/command/with-contenv bashio
+# shellcheck shell=bash
+set -e
+
+EXTENSIONS_DIR="${CHROME_EXTENSIONS_DIR:-/usr/src/chrome/extensions}"
+
+bashio::log.info "Refreshing Chromium extensions in ${EXTENSIONS_DIR}"
+
+mkdir -p "${EXTENSIONS_DIR}"
+
+download_extension() {
+  local name="$1"
+  local extension_id="$2"
+  local crx_path
+
+  crx_path="$(mktemp)"
+  curl -fsSL "https://clients2.google.com/service/update2/crx?response=redirect&prodversion=120.0&acceptformat=crx2,crx3&x=id%3D${extension_id}%26installsource%3Dondemand%26uc" \
+    -o "${crx_path}"
+  rm -rf "${EXTENSIONS_DIR:?}/${name}"
+  mkdir -p "${EXTENSIONS_DIR}/${name}"
+  unzip -q "${crx_path}" -d "${EXTENSIONS_DIR}/${name}"
+  rm -f "${crx_path}"
+}
+
+download_extension "i-dont-care-about-cookies" "fllaojicojecljbmefodhfapmkghcbnh"
+download_extension "ublock-origin" "cjpalhdlnbpafiamejdnhcphjbkeiagm"
+
+if id chrome &>/dev/null; then
+  chown -R chrome:chrome "${EXTENSIONS_DIR}"
+fi

--- a/karakeep/rootfs/etc/s6-overlay/s6-rc.d/svc-chrome/run
+++ b/karakeep/rootfs/etc/s6-overlay/s6-rc.d/svc-chrome/run
@@ -2,7 +2,7 @@
 # shellcheck shell=bash
 set -e
 
-EXTENSIONS_DIR="${CHROME_EXTENSIONS_DIR:-/share/karakeep/extensions}"
+EXTENSIONS_DIR="${CHROME_EXTENSIONS_DIR:-/usr/src/chrome/extensions}"
 
 extensions=()
 for extension in "${EXTENSIONS_DIR}/i-dont-care-about-cookies" "${EXTENSIONS_DIR}/ublock-origin"; do


### PR DESCRIPTION
### Motivation

- Ensure headless Chromium has the expected default extensions available without requiring users to create host-mounted folders. 
- Keep extensions in a non-persistent Chrome location so the add-on can ship sensible defaults while still allowing overrides. 
- Refresh bundled extensions at add-on startup to pick up updates without rebuilding the image. 

### Description

- Install `unzip` and download/unpack default CRX extensions during image build into ` /usr/src/chrome/extensions` via a Dockerfile `RUN` step. 
- Add a startup script `rootfs/etc/cont-init.d/92-chrome-extensions.sh` to refresh the same extensions at container start by downloading and unpacking their CRX packages. 
- Change the default `CHROME_EXTENSIONS_DIR` to ` /usr/src/chrome/extensions` and update runtime code paths in `rootfs/etc/s6-overlay/s6-rc.d/svc-chrome/run` and folder creation in `rootfs/etc/cont-init.d/90-folders.sh`. 
- Update `README.md` and `config.yaml` to document the automatic downloading behavior and new default location. 

### Testing

- No automated tests were executed for this change. 
- Files were added/modified and made executable where required (`rootfs/etc/cont-init.d/92-chrome-extensions.sh`). 
- Build-time download logic was added to the Dockerfile and validated in the patch; no CI build was run as part of this change. 
- Runtime refresh is implemented as an init script but was not executed in an automated environment during this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963c4f7fc408325ba682a750f3576ec)