### PR TITLE
Add ingress support to changedetection.io add-on

### DIFF
--- a/changedetection.io/CHANGELOG.md
+++ b/changedetection.io/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 0.52.2-1 (2026-01-13)
+- Add ingress support
+
 ## 0.52.2 (2026-01-13)
 - Update to latest version from linuxserver/docker-changedetection.io (changelog : https://github.com/linuxserver/docker-changedetection.io/releases)
 ## 0.51.4-2 (2026-01-09)

--- a/changedetection.io/Dockerfile
+++ b/changedetection.io/Dockerfile
@@ -54,7 +54,7 @@ ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templat
 RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
 
 # Manual apps
-ENV PACKAGES=""
+ENV PACKAGES="nginx"
 
 # Automatic apps & bashio
 ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templates/ha_autoapps.sh" "/ha_autoapps.sh"

--- a/changedetection.io/README.md
+++ b/changedetection.io/README.md
@@ -39,7 +39,7 @@ Use the add-on `env_vars` option to pass extra environment variables (uppercase 
 
 ### Main app
 
-Web UI can be found at `<your-ip>:5000`, also accessible from the add-on page.
+Web UI can be found at `<your-ip>:5000`, also accessible from the add-on page or through the sidebar using Ingress.
 
 #### Sidebar shortcut
 

--- a/changedetection.io/config.yaml
+++ b/changedetection.io/config.yaml
@@ -6,6 +6,7 @@ environment:
   LC_ALL: en_US.UTF-8
   TIMEOUT: "60000"
 image: ghcr.io/alexbelgium/changedetection.io-{arch}
+ingress: true
 init: false
 map:
   - config:rw
@@ -18,7 +19,7 @@ options:
 ports:
   5000/tcp: 5000
 ports_description:
-  5000/tcp: Webui
+  5000/tcp: Webui (not required for Ingress)
 schema:
   env_vars:
     - name: match(^[A-Za-z0-9_]+$)
@@ -32,5 +33,5 @@ schema:
 slug: changedetection.io
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/changedetection.io
-version: "0.52.2"
+version: "0.52.2-1"
 webui: http://[HOST]:[PORT:5000]

--- a/changedetection.io/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/changedetection.io/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+
+#################
+# NGINX SETTING #
+#################
+declare ingress_interface
+declare ingress_port
+declare ingress_entry
+
+ingress_port=$(bashio::addon.ingress_port)
+ingress_interface=$(bashio::addon.ip_address)
+ingress_entry=$(bashio::addon.ingress_entry)
+
+sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
+sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
+sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf
+
+if [ -d /var/run/s6/container_environment ]; then
+    printf "%s" "1" > /var/run/s6/container_environment/USE_X_SETTINGS
+fi

--- a/changedetection.io/rootfs/etc/nginx/includes/mime.types
+++ b/changedetection.io/rootfs/etc/nginx/includes/mime.types
@@ -1,0 +1,96 @@
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    application/javascript                           js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                         wmlc;
+    application/x-7z-compressed                      7z;
+    application/x-cocoa                              cco;
+    application/x-java-archive-diff                  jardiff;
+    application/x-java-jnlp-file                     jnlp;
+    application/x-makeself                           run;
+    application/x-perl                               pl pm;
+    application/x-pilot                              prc pdb;
+    application/x-rar-compressed                     rar;
+    application/x-redhat-package-manager             rpm;
+    application/x-sea                                sea;
+    application/x-shockwave-flash                    swf;
+    application/x-stuffit                            sit;
+    application/x-tcl                                tcl tk;
+    application/x-x509-ca-cert                       der pem crt;
+    application/x-xpinstall                          xpi;
+    application/xhtml+xml                            xhtml;
+    application/xspf+xml                             xspf;
+    application/zip                                  zip;
+
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+
+    audio/midi                                       mid midi kar;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        ogg;
+    audio/x-m4a                                      m4a;
+    audio/x-realaudio                                ra;
+
+    video/3gpp                                       3gpp 3gp;
+    video/mp2t                                       ts;
+    video/mp4                                        mp4;
+    video/mpeg                                       mpeg mpg;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-m4v                                      m4v;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asx asf;
+    video/x-ms-wmv                                   wmv;
+    video/x-msvideo                                  avi;
+}

--- a/changedetection.io/rootfs/etc/nginx/includes/proxy_params.conf
+++ b/changedetection.io/rootfs/etc/nginx/includes/proxy_params.conf
@@ -1,0 +1,16 @@
+proxy_http_version          1.1;
+proxy_ignore_client_abort   off;
+proxy_read_timeout          86400s;
+proxy_redirect              off;
+proxy_send_timeout          86400s;
+proxy_max_temp_file_size    0;
+
+proxy_hide_header X-Frame-Options;
+proxy_set_header Accept-Encoding "";
+proxy_set_header Connection $connection_upgrade;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Host $http_host;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-NginX-Proxy true;
+proxy_set_header X-Real-IP $remote_addr; 

--- a/changedetection.io/rootfs/etc/nginx/includes/resolver.conf
+++ b/changedetection.io/rootfs/etc/nginx/includes/resolver.conf
@@ -1,0 +1,1 @@
+resolver 127.0.0.11 ipv6=off;

--- a/changedetection.io/rootfs/etc/nginx/includes/server_params.conf
+++ b/changedetection.io/rootfs/etc/nginx/includes/server_params.conf
@@ -1,0 +1,5 @@
+server_name     $hostname;
+
+add_header X-Content-Type-Options nosniff;
+add_header X-XSS-Protection "1; mode=block";
+add_header X-Robots-Tag none;

--- a/changedetection.io/rootfs/etc/nginx/includes/ssl_params.conf
+++ b/changedetection.io/rootfs/etc/nginx/includes/ssl_params.conf
@@ -1,0 +1,9 @@
+ssl_protocols TLSv1.2;
+ssl_prefer_server_ciphers on;
+ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA;
+ssl_ecdh_curve secp384r1;
+ssl_session_timeout  10m;
+ssl_session_cache shared:SSL:10m;
+ssl_session_tickets off;
+ssl_stapling on;
+ssl_stapling_verify on;

--- a/changedetection.io/rootfs/etc/nginx/includes/upstream.conf
+++ b/changedetection.io/rootfs/etc/nginx/includes/upstream.conf
@@ -1,0 +1,3 @@
+upstream backend {
+    server 127.0.0.1:5000;
+}

--- a/changedetection.io/rootfs/etc/nginx/nginx.conf
+++ b/changedetection.io/rootfs/etc/nginx/nginx.conf
@@ -1,0 +1,57 @@
+
+# Run nginx in foreground.
+daemon off;
+
+# This is run inside Docker.
+user root;
+
+# Pid storage location.
+pid /var/run/nginx.pid;
+
+# Set number of worker processes.
+worker_processes 1;
+
+# Enables the use of JIT for regular expressions to speed-up their processing.
+pcre_jit on;
+
+# Write error log to Hass.io add-on log.
+error_log /proc/1/fd/1 error;
+
+# Load allowed environment vars
+env HASSIO_TOKEN;
+
+# Load dynamic modules.
+include /etc/nginx/modules/*.conf;
+
+# Max num of simultaneous connections by a worker process.
+events {
+    worker_connections 512;
+}
+
+http {
+    include /etc/nginx/includes/mime.types;
+
+    log_format hassio '[$time_local] $status '
+                        '$http_x_forwarded_for($remote_addr) '
+                        '$request ($http_user_agent)';
+
+    access_log              /proc/1/fd/1 hassio;
+    client_max_body_size    4G;
+    default_type            application/octet-stream;
+    gzip                    on;
+    keepalive_timeout       65;
+    sendfile                on;
+    server_tokens           off;
+    tcp_nodelay             on;
+    tcp_nopush              on;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
+    include /etc/nginx/includes/resolver.conf;
+    include /etc/nginx/includes/upstream.conf;
+
+    include /etc/nginx/servers/*.conf;
+} 

--- a/changedetection.io/rootfs/etc/nginx/servers/ingress.conf
+++ b/changedetection.io/rootfs/etc/nginx/servers/ingress.conf
@@ -1,0 +1,19 @@
+server {
+    listen %%interface%%:%%port%% default_server;
+
+    include /etc/nginx/includes/proxy_params.conf;
+
+    client_max_body_size 0;
+
+    location / {
+        add_header Access-Control-Allow-Origin *;
+        proxy_connect_timeout 30m;
+        proxy_send_timeout 30m;
+        proxy_read_timeout 30m;
+        proxy_pass http://backend;
+
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-Prefix %%ingress_entry%%;
+    }
+}

--- a/changedetection.io/rootfs/etc/services.d/nginx/finish
+++ b/changedetection.io/rootfs/etc/services.d/nginx/finish
@@ -1,0 +1,8 @@
+#!/usr/bin/execlineb -S0
+# ==============================================================================
+# Take down the S6 supervision tree when Nginx fails
+# ==============================================================================
+if { s6-test ${1} -ne 0 }
+if { s6-test ${1} -ne 256 }
+
+s6-svscanctl -t /var/run/s6/services

--- a/changedetection.io/rootfs/etc/services.d/nginx/run
+++ b/changedetection.io/rootfs/etc/services.d/nginx/run
@@ -1,0 +1,10 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+# ==============================================================================
+
+bashio::net.wait_for 5000 localhost 900
+
+bashio::log.info "Starting NGinx..."
+
+exec nginx


### PR DESCRIPTION
### Motivation
- Provide Home Assistant Ingress support so the add-on can be opened from the HA sidebar without exposing the host port. 
- Follow patterns used across other add-ons (nginx reverse proxy, X-Forwarded-Prefix support and `USE_X_SETTINGS`) to ensure correct subpath/proxy behaviour.

### Description
- Enable ingress in `changedetection.io/config.yaml` (`ingress: true`), mark the web UI port as optional and bump the add-on `version` to `0.52.2-1`.
- Install `nginx` in the add-on image by adding `ENV PACKAGES="nginx"` to the `Dockerfile` so the proxy is available inside the container.
- Add an nginx ingress stack under `changedetection.io/rootfs/etc/nginx/` including `nginx.conf`, `servers/ingress.conf`, `includes/*` and an `upstream` pointing to the upstream app on port `5000`.
- Add startup/service scripts `changedetection.io/rootfs/etc/cont-init.d/32-nginx_ingress.sh` and `changedetection.io/rootfs/etc/services.d/nginx/run` (plus `finish`) to populate ingress variables, enable `USE_X_SETTINGS` (via s6 container environment) and start nginx, and update `README.md` and `CHANGELOG.md` to document the change.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69676db1cb908325aade79aa481c6200)