### PR TITLE
Add ingress icon for changedetection.io

### DIFF
--- a/changedetection.io/config.yaml
+++ b/changedetection.io/config.yaml
@@ -11,6 +11,7 @@ init: false
 map:
   - config:rw
 name: Changedetection.io
+panel_icon: mdi:vector-difference
 options:
   env_vars: []
   PGID: 0


### PR DESCRIPTION
### Motivation
- Provide an Ingress sidebar icon so the Changedetection.io add-on displays a proper Material Design Icon in the Home Assistant panel when Ingress is used.

### Description
- Add `panel_icon: mdi:vector-difference` to `changedetection.io/config.yaml` to specify the ingress MDI for the add-on.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696791c1f26483259a4bd41acd311268)