### PR TITLE
Switch brave addon to linuxserver/brave and use /config for data

### DIFF
--- a/brave/CHANGELOG.md
+++ b/brave/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 1.0.0 (2026-01-14)
+- Switch addon base to linuxserver/docker-brave and use /config as the data folder
+
 ## 4.16-r0-ls93 (2026-01-14)
 - Update to latest version from linuxserver/docker-webtop (changelog : https://github.com/linuxserver/docker-webtop/releases)
 

--- a/brave/Dockerfile
+++ b/brave/Dockerfile
@@ -39,14 +39,14 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=SC2015,DL4006,SC2013,SC2086
 RUN \
     # Change home folder location
-    usermod --home /config/data_kde abc && \
+    usermod --home /config abc && \
     \
     # Set +e
     if [[ -d /etc/services.d ]] && ls /etc/services.d/*/run 1> /dev/null 2>&1; then sed -i "1a set +e" /etc/services.d/*/run; fi
 
 # Global LSIO modifications
 ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templates/ha_lsio.sh" "/ha_lsio.sh"
-ARG CONFIGLOCATION="/config/data_kde"
+ARG CONFIGLOCATION="/config"
 RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGLOCATION"; fi && rm /ha_lsio.sh
 
 ##################

--- a/brave/README.md
+++ b/brave/README.md
@@ -1,5 +1,4 @@
-# Home assistant add-on: Webtop KDE Alpine
-
+# Home assistant add-on: Brave
 
 I maintain this and other Home Assistant add-ons in my free time: keeping up with upstream changes, HA changes, and testing on real hardware takes a lot of time (and some money). I use around 5-10 of my >110 addons so regularly I install test machines (and purchase some test services such as vpn) that I don't use myself to troubleshoot and improve the addons
 
@@ -10,9 +9,9 @@ If this add-on saves you time or makes your setup easier, I would be very gratef
 
 ## Addon informations
 
-![Version](https://img.shields.io/badge/dynamic/yaml?label=Version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fwebtop%2Fconfig.yaml)
-![Ingress](https://img.shields.io/badge/dynamic/yaml?label=Ingress&query=%24.ingress&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fwebtop%2Fconfig.yaml)
-![Arch](https://img.shields.io/badge/dynamic/yaml?color=success&label=Arch&query=%24.arch&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fwebtop%2Fconfig.yaml)
+![Version](https://img.shields.io/badge/dynamic/yaml?label=Version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fbrave%2Fconfig.yaml)
+![Ingress](https://img.shields.io/badge/dynamic/yaml?label=Ingress&query=%24.ingress&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fbrave%2Fconfig.yaml)
+![Arch](https://img.shields.io/badge/dynamic/yaml?color=success&label=Arch&query=%24.arch&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fbrave%2Fconfig.yaml)
 
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/9c6cf10bdbba45ecb202d7f579b5be0e)](https://www.codacy.com/gh/alexbelgium/hassio-addons/dashboard?utm_source=github.com&utm_medium=referral&utm_content=alexbelgium/hassio-addons&utm_campaign=Badge_Grade)
 [![GitHub Super-Linter](https://img.shields.io/github/actions/workflow/status/alexbelgium/hassio-addons/weekly-supelinter.yaml?label=Lint%20code%20base)](https://github.com/alexbelgium/hassio-addons/actions/workflows/weekly-supelinter.yaml)
@@ -25,12 +24,12 @@ _Thanks to everyone having starred my repo! To star it click on the image below,
 
 [![Stargazers repo roster for @alexbelgium/hassio-addons](https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.github/stars2.svg)](https://github.com/alexbelgium/hassio-addons/stargazers)
 
-![downloads evolution](https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/webtop/stats.png)
+![downloads evolution](https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/brave/stats.png)
 
 ## About
 
-[webtop](https://github.com/webtop/webtop) is a full desktop environments accessible via any modern web browser.
-This addon is based on the docker image https://github.com/linuxserver/docker-webtop
+[Brave](https://brave.com/) is a fast, private and secure web browser for PC, Mac and mobile.
+This addon is based on the docker image https://github.com/linuxserver/docker-brave
 
 ## Configuration
 
@@ -38,7 +37,7 @@ Use the add-on `env_vars` option to pass extra environment variables (uppercase 
 
 Webui can be found with ingress or at <http://homeassistant:PORT>. The port is by default disabled but can be enabled through the addon options.
 
-By default the image is based around the abc user and we recommend using this user as all of the init/config is based around it. The default password is also abc . If you want to change this password and require authentication when accessing the interface simply issue passwd inside a gui terminal in the webtop. Then when accessing the web interface use the path:
+By default the image is based around the abc user and we recommend using this user as all of the init/config is based around it. The default password is also abc . If you want to change this password and require authentication when accessing the interface simply issue passwd inside a GUI terminal in the container. Then when accessing the web interface use the path:
 
 http://localhost:3000/?login=true
 
@@ -46,7 +45,7 @@ Apps installations are not remanent, you need to do it via addon options. Their 
 
 If graphics don't work, use the DRINODE feature to select your graphic device.
 
-See all potential ENV variables here : https://docs.linuxserver.io/images/docker-webtop#optional-environment-variables
+See all potential ENV variables here : https://docs.linuxserver.io/images/docker-brave#optional-environment-variables
 
 ```yaml
 TZ: timezone ; Country/City according to https://manpages.ubuntu.com/manpages/trusty/man3/DateTime::TimeZone::Catalog.3pm.html
@@ -78,9 +77,3 @@ The installation of this add-on is pretty straightforward and not different in c
 Create an issue on github
 
 ## Illustration
-
-![illustration](https://www.linuxserver.io/user/pages/content/images/2021/05/menu.png)
-
-[repository]: https://github.com/alexbelgium/hassio-addons
-
-

--- a/brave/apparmor.txt
+++ b/brave/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile webtop_addon flags=(attach_disconnected,mediate_deleted) {
+profile brave_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   capability,

--- a/brave/build.json
+++ b/brave/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/linuxserver/webtop:arm64v8-ubuntu-kde",
-    "amd64": "ghcr.io/linuxserver/webtop:amd64-ubuntu-kde"
+    "aarch64": "lscr.io/linuxserver/brave:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/brave:amd64-latest"
   }
 }

--- a/brave/config.yaml
+++ b/brave/config.yaml
@@ -66,8 +66,8 @@ devices:
   - /dev/nvme1
   - /dev/nvme2
 environment:
-  FM_HOME: /config/data
-  HOME: /config/data
+  FM_HOME: /config
+  HOME: /config
   START_DOCKER: "false"
   TITLE: Brave browser
   shm_size: 1gb
@@ -87,7 +87,7 @@ options:
   PUID: 0
   additional_apps: engrampa,libreoffice
   certfile: fullchain.pem
-  data_location: /config/data
+  data_location: /config
   keyfile: privkey.pem
   use_own_certs: true
 panel_admin: false
@@ -143,5 +143,5 @@ slug: brave
 tmpfs: true
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "4.16-r0-ls93"
+version: "1.0.0"
 video: true

--- a/brave/rootfs/etc/cont-init.d/20-folders.sh
+++ b/brave/rootfs/etc/cont-init.d/20-folders.sh
@@ -18,7 +18,7 @@ LOCATION=$(bashio::config 'data_location')
 
 if [[ "$LOCATION" = "null" || -z "$LOCATION" ]]; then
     # Default location
-    LOCATION="/config/data_kde"
+    LOCATION="/config"
 else
     # Check if config is located in an acceptable location
     LOCATIONOK=""
@@ -29,7 +29,7 @@ else
     done
 
     if [ -z "$LOCATIONOK" ]; then
-        LOCATION="/config/data_kde"
+        LOCATION="/config"
         bashio::log.fatal "Your data_location value can only be set in /share, /config or /data (internal to addon). It will be reset to the default location : $LOCATION"
     fi
 fi
@@ -48,7 +48,7 @@ done
 # Correct home location
 for folders in /defaults /etc/cont-init.d /etc/services.d /etc/s6-overlay/s6-rc.d; do
     if [ -d "$folders" ]; then
-        sed -i "s|/config/data_kde|$LOCATION|g" $(find "$folders" -type f) &> /dev/null || true
+        sed -i "s|/config|$LOCATION|g" $(find "$folders" -type f) &> /dev/null || true
     fi
 done
 

--- a/brave/rootfs/etc/cont-init.d/90-ssl.sh
+++ b/brave/rootfs/etc/cont-init.d/90-ssl.sh
@@ -12,8 +12,8 @@ if bashio::config.true 'use_own_certs'; then
     echo "... checking if referenced files exist"
     if [ -f /ssl/"$CERTFILE" ] && [ -f /ssl/"$KEYFILE" ]; then
         # Add ssl file
-        sed -i "s|/config/data/ssl/cert.pem|/ssl/$CERTFILE|g" "$NGINX_CONFIG"
-        sed -i "s|/config/data/ssl/cert.key|/ssl/$KEYFILE|g" "$NGINX_CONFIG"
+        sed -i "s|/config/ssl/cert.pem|/ssl/$CERTFILE|g" "$NGINX_CONFIG"
+        sed -i "s|/config/ssl/cert.key|/ssl/$KEYFILE|g" "$NGINX_CONFIG"
         echo "... done"
     else
         bashio::log.warning "...  certificate /ssl/$CERTFILE and /ssl/$KEYFILE and not found, using self-generated certificates"

--- a/brave/updater.json
+++ b/brave/updater.json
@@ -2,8 +2,8 @@
   "github_fulltag": "true",
   "last_update": "2026-01-14",
   "repository": "alexbelgium/hassio-addons",
-  "slug": "webtop",
+  "slug": "brave",
   "source": "github",
-  "upstream_repo": "linuxserver/docker-webtop",
-  "upstream_version": "4.16-r0-ls93"
+  "upstream_repo": "linuxserver/docker-brave",
+  "upstream_version": "latest"
 }


### PR DESCRIPTION
### Motivation
- Replace the previous Webtop KDE base with the official LinuxServer Brave image and standardize the add-on to use `/config` as the data/home folder.
- Align metadata and startup scripts to the new upstream image so the add-on behaves correctly with the LinuxServer Brave image layout.

### Description
- Update `build.json` to pull images from `lscr.io/linuxserver/brave` for both `aarch64` and `amd64`.
- Change the `Dockerfile` to set the `abc` user home to `/config` and update `ARG CONFIGLOCATION` to `/config`.
- Modify `config.yaml` to set `FM_HOME` and `HOME` to `/config`, change the default `data_location` to `/config`, and set the add-on `version` to `1.0.0`.
- Update `rootfs/etc/cont-init.d/20-folders.sh` to default to `/config` and replace references to `/config` in container files, and update `rootfs/etc/cont-init.d/90-ssl.sh` to rewrite SSL paths from `/config/ssl` to the container `/ssl` files.
- Align updater metadata in `updater.json` by changing the `slug` to `brave` and `upstream_repo` to `linuxserver/docker-brave` with `upstream_version` set to `latest`.
- Rename the AppArmor profile to `brave_addon` and refresh `README.md` and `CHANGELOG.md` to reference Brave and the new configuration.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696921d96748832582c2450121a38fd1)