### PR TITLE
Switch Brave add-on to linuxserver Chromium upstream image

### DIFF
--- a/brave/CHANGELOG.md
+++ b/brave/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.86.139-ls69-3 (2026-01-16)
+- Switch upstream base to linuxserver/docker-chromium
+
 ## 1.86.139-ls69-2 (16-01-2026)
 - Minor bugs fixed
 

--- a/brave/Dockerfile
+++ b/brave/Dockerfile
@@ -44,8 +44,8 @@ RUN \
     # Set +e
     if [[ -d /etc/services.d ]] && ls /etc/services.d/*/run 1> /dev/null 2>&1; then sed -i "1a set +e" /etc/services.d/*/run; fi
 
-# Modify brave commands
-RUN sed -i '/no-first-run/a\  --remote-debugging-port=9221 --disable-background-networking --metrics-recording-only --disable-blink-features=AutomationControlled --autoplay-policy=no-user-gesture-required \\' /usr/bin/wrapped-brave
+# Modify chromium commands
+RUN sed -i '/no-first-run/a\  --remote-debugging-port=9221 --disable-background-networking --metrics-recording-only --disable-blink-features=AutomationControlled --autoplay-policy=no-user-gesture-required \\' /usr/bin/wrapped-chromium
 
 # Global LSIO modifications
 ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templates/ha_lsio.sh" "/ha_lsio.sh"

--- a/brave/README.md
+++ b/brave/README.md
@@ -28,8 +28,8 @@ _Thanks to everyone having starred my repo! To star it click on the image below,
 
 ## About
 
-[Brave](https://brave.com/) is a fast, private and secure web browser for PC, Mac and mobile.
-This addon is based on the docker image https://github.com/linuxserver/docker-brave
+[Chromium](https://www.chromium.org/Home/) is the open-source browser project behind modern web browsers.
+This addon is based on the docker image https://github.com/linuxserver/docker-chromium
 
 ## Configuration
 
@@ -45,7 +45,7 @@ Apps installations are not remanent, you need to do it via addon options. Their 
 
 If graphics don't work, use the DRINODE feature to select your graphic device.
 
-See all potential ENV variables here : https://docs.linuxserver.io/images/docker-brave#optional-environment-variables
+See all potential ENV variables here : https://docs.linuxserver.io/images/docker-chromium#optional-environment-variables
 
 ```yaml
 TZ: timezone ; Country/City according to https://manpages.ubuntu.com/manpages/trusty/man3/DateTime::TimeZone::Catalog.3pm.html

--- a/brave/build.json
+++ b/brave/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "lscr.io/linuxserver/brave:arm64v8-latest",
-    "amd64": "lscr.io/linuxserver/brave:amd64-latest"
+    "aarch64": "lscr.io/linuxserver/chromium:arm64v8-latest",
+    "amd64": "lscr.io/linuxserver/chromium:amd64-latest"
   }
 }

--- a/brave/config.yaml
+++ b/brave/config.yaml
@@ -2,7 +2,7 @@ arch:
   - aarch64
   - amd64
 audio: true
-description: Brave browser
+description: Chromium browser
 devices:
   - /dev/dri
   - /dev/dri/card0
@@ -20,7 +20,7 @@ environment:
   FM_HOME: /config
   HOME: /config
   START_DOCKER: "false"
-  TITLE: Brave browser
+  TITLE: Chromium browser
   shm_size: 1gb
 image: ghcr.io/alexbelgium/brave-{arch}
 ingress: true
@@ -69,5 +69,5 @@ slug: brave
 tmpfs: true
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "1.86.139-ls69-2"
+version: "1.86.139-ls69-3"
 video: true

--- a/brave/updater.json
+++ b/brave/updater.json
@@ -4,6 +4,6 @@
   "repository": "alexbelgium/hassio-addons",
   "slug": "brave",
   "source": "github",
-  "upstream_repo": "linuxserver/docker-brave",
-  "upstream_version": "1.86.139-ls69"
+  "upstream_repo": "linuxserver/docker-chromium",
+  "upstream_version": "latest"
 }


### PR DESCRIPTION
### Motivation
- Replace the Brave upstream image with the LinuxServer Chromium image so the add-on runs Chromium instead of Brave and uses the corresponding upstream image and docs.
- Update wrapper invocation and metadata so the add-on configuration, documentation and updater tracking reflect the Chromium base.

### Description
- Change the wrapper modification in `Dockerfile` to target `/usr/bin/wrapped-chromium` instead of `/usr/bin/wrapped-brave` to apply the same startup flags to Chromium.
- Update `build.json` to use `lscr.io/linuxserver/chromium:...` images for `aarch64` and `amd64` instead of the Brave image.
- Update `updater.json` to track `linuxserver/docker-chromium` with `upstream_version` set to `latest`.
- Refresh `config.yaml` metadata (`description`, `TITLE`, and `version`) and update `README.md` and `CHANGELOG.md` to describe the switch to Chromium and point to Chromium docs.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a4a18f71483258593bbb02c31f715)