### PR TITLE
Add ingress support to Jackett addon

### DIFF
--- a/jackett/CHANGELOG.md
+++ b/jackett/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 0.24.863-1 (2026-01-16)
+- Add ingress support
+
 ## 0.24.863 (2026-01-16)
 - Update to latest version from linuxserver/docker-jackett (changelog : https://github.com/linuxserver/docker-jackett/releases)
 

--- a/jackett/config.yaml
+++ b/jackett/config.yaml
@@ -71,6 +71,8 @@ environment:
   PGID: "0"
   PUID: "0"
 image: ghcr.io/alexbelgium/jackett_nas-{arch}
+ingress: true
+ingress_entry: jackett
 init: false
 map:
   - config:rw
@@ -82,6 +84,7 @@ options:
   env_vars: []
   PGID: 0
   PUID: 0
+  connection_mode: ingress_noauth
 ports:
   8889/tcp: 8889
   9117/tcp: 9117
@@ -101,10 +104,11 @@ schema:
   cifsdomain: str?
   cifspassword: str?
   cifsusername: str?
+  connection_mode: list(ingress_noauth|noingress_auth|ingress_auth)
   localdisks: str?
   networkdisks: str?
 slug: jackett_nas
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/jackett
-version: "0.24.863"
+version: "0.24.863-1"
 webui: http://[HOST]:[PORT:9117]

--- a/jackett/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/jackett/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+
+#################
+# NGINX SETTING #
+#################
+declare ingress_interface
+declare ingress_port
+
+ingress_port=$(bashio::addon.ingress_port)
+ingress_interface=$(bashio::addon.ip_address)
+ingress_entry=$(bashio::addon.ingress_entry)
+sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
+sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
+sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf
+
+##################
+# CONFIG SETTING #
+##################
+
+# Values
+slug=jackett
+CONFIG_LOCATION=/config/addons_config/Jackett/ServerConfig.json
+
+if [ -f "$CONFIG_LOCATION" ]; then
+
+    # Define addon mode
+    connection_mode="$(bashio::config "connection_mode")"
+    bashio::log.green "---------------------------"
+    bashio::log.green "Connection_mode is $connection_mode"
+    bashio::log.green "---------------------------"
+    case "$connection_mode" in
+        # Ingress mode, authentification is disabled
+        ingress_noauth)
+            bashio::log.green "Ingress is enabled, authentification is disabled"
+            bashio::log.yellow "WARNING : Make sure that the port is not exposed externally by your router to avoid a security risk !"
+            sed -i -E "s/\"BasePathOverride\"[[:space:]]*:[[:space:]]*\"[^\"]*\"/\"BasePathOverride\": \"${slug}\"/" "$CONFIG_LOCATION"
+            sed -i -E "s/\"AdminPassword\"[[:space:]]*:[[:space:]]*\"[^\"]*\"/\"AdminPassword\": \"\"/" "$CONFIG_LOCATION"
+            ;;
+        # Ingress mode, with authentification
+        ingress_auth)
+            bashio::log.green "Ingress is enabled, and external authentification is enabled"
+            sed -i -E "s/\"BasePathOverride\"[[:space:]]*:[[:space:]]*\"[^\"]*\"/\"BasePathOverride\": \"${slug}\"/" "$CONFIG_LOCATION"
+            ;;
+        # No ingress mode, with authentification
+        noingress_auth)
+            bashio::log.green "Disabling ingress and enabling authentification"
+            bashio::log.yellow "WARNING : Ingress is disabled so the app won't be available from HA itself !"
+            sed -i -E "s/\"BasePathOverride\"[[:space:]]*:[[:space:]]*\"[^\"]*\"/\"BasePathOverride\": \"\"/" "$CONFIG_LOCATION"
+            ;;
+    esac
+
+fi

--- a/jackett/rootfs/etc/nginx/includes/mime.types
+++ b/jackett/rootfs/etc/nginx/includes/mime.types
@@ -1,0 +1,96 @@
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    application/javascript                           js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                         wmlc;
+    application/x-7z-compressed                      7z;
+    application/x-cocoa                              cco;
+    application/x-java-archive-diff                  jardiff;
+    application/x-java-jnlp-file                     jnlp;
+    application/x-makeself                           run;
+    application/x-perl                               pl pm;
+    application/x-pilot                              prc pdb;
+    application/x-rar-compressed                     rar;
+    application/x-redhat-package-manager             rpm;
+    application/x-sea                                sea;
+    application/x-shockwave-flash                    swf;
+    application/x-stuffit                            sit;
+    application/x-tcl                                tcl tk;
+    application/x-x509-ca-cert                       der pem crt;
+    application/x-xpinstall                          xpi;
+    application/xhtml+xml                            xhtml;
+    application/xspf+xml                             xspf;
+    application/zip                                  zip;
+
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+
+    audio/midi                                       mid midi kar;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        ogg;
+    audio/x-m4a                                      m4a;
+    audio/x-realaudio                                ra;
+
+    video/3gpp                                       3gpp 3gp;
+    video/mp2t                                       ts;
+    video/mp4                                        mp4;
+    video/mpeg                                       mpeg mpg;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-m4v                                      m4v;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asx asf;
+    video/x-ms-wmv                                   wmv;
+    video/x-msvideo                                  avi;
+}

--- a/jackett/rootfs/etc/nginx/includes/proxy_params.conf
+++ b/jackett/rootfs/etc/nginx/includes/proxy_params.conf
@@ -1,0 +1,16 @@
+proxy_http_version          1.1;
+proxy_ignore_client_abort   off;
+proxy_read_timeout          86400s;
+proxy_redirect              off;
+proxy_send_timeout          86400s;
+proxy_max_temp_file_size    0;
+
+proxy_hide_header X-Frame-Options;
+proxy_set_header Accept-Encoding "";
+#proxy_set_header Connection $http_connection;
+#proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Host $http_host;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-NginX-Proxy true;
+proxy_set_header X-Real-IP $remote_addr; 

--- a/jackett/rootfs/etc/nginx/includes/resolver.conf
+++ b/jackett/rootfs/etc/nginx/includes/resolver.conf
@@ -1,0 +1,1 @@
+resolver 127.0.0.11 ipv6=off;

--- a/jackett/rootfs/etc/nginx/includes/server_params.conf
+++ b/jackett/rootfs/etc/nginx/includes/server_params.conf
@@ -1,0 +1,6 @@
+root            /app/radarr/bin/UI;
+server_name     $hostname;
+
+add_header X-Content-Type-Options nosniff;
+add_header X-XSS-Protection "1; mode=block";
+add_header X-Robots-Tag none;

--- a/jackett/rootfs/etc/nginx/includes/ssl_params.conf
+++ b/jackett/rootfs/etc/nginx/includes/ssl_params.conf
@@ -1,0 +1,9 @@
+ssl_protocols TLSv1.2;
+ssl_prefer_server_ciphers on;
+ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA;
+ssl_ecdh_curve secp384r1;
+ssl_session_timeout  10m;
+ssl_session_cache shared:SSL:10m;
+ssl_session_tickets off;
+ssl_stapling on;
+ssl_stapling_verify on;

--- a/jackett/rootfs/etc/nginx/includes/upstream.conf
+++ b/jackett/rootfs/etc/nginx/includes/upstream.conf
@@ -1,0 +1,3 @@
+upstream backend {
+    server 127.0.0.1:8080;
+} 

--- a/jackett/rootfs/etc/nginx/nginx.conf
+++ b/jackett/rootfs/etc/nginx/nginx.conf
@@ -1,0 +1,57 @@
+
+# Run nginx in foreground.
+daemon off;
+
+# This is run inside Docker.
+user root;
+
+# Pid storage location.
+pid /var/run/nginx.pid;
+
+# Set number of worker processes.
+worker_processes 1;
+
+# Enables the use of JIT for regular expressions to speed-up their processing.
+pcre_jit on;
+
+# Write error log to Hass.io add-on log.
+error_log /proc/1/fd/1 error;
+
+# Load allowed environment vars
+env HASSIO_TOKEN;
+
+# Load dynamic modules.
+include /etc/nginx/modules/*.conf;
+
+# Max num of simultaneous connections by a worker process.
+events {
+    worker_connections 512;
+}
+
+http {
+    include /etc/nginx/includes/mime.types;
+
+    log_format hassio '[$time_local] $status '
+                        '$http_x_forwarded_for($remote_addr) '
+                        '$request ($http_user_agent)';
+
+    access_log              /proc/1/fd/1 hassio;
+    client_max_body_size    4G;
+    default_type            application/octet-stream;
+    gzip                    on;
+    keepalive_timeout       65;
+    sendfile                on;
+    server_tokens           off;
+    tcp_nodelay             on;
+    tcp_nopush              on;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
+    include /etc/nginx/includes/resolver.conf;
+    include /etc/nginx/includes/upstream.conf;
+
+    include /etc/nginx/servers/*.conf;
+} 

--- a/jackett/rootfs/etc/nginx/servers/ingress.conf
+++ b/jackett/rootfs/etc/nginx/servers/ingress.conf
@@ -1,0 +1,23 @@
+server {
+    listen %%interface%%:%%port%% default_server;
+
+    #include /etc/nginx/includes/server_params.conf;
+    #include /etc/nginx/includes/proxy_params.conf;
+
+    client_max_body_size 0;
+
+   location / {
+       add_header Access-Control-Allow-Origin *;
+       proxy_connect_timeout 30m;
+       proxy_send_timeout 30m;
+       proxy_read_timeout 30m;
+       proxy_pass         http://127.0.0.1:9117;
+
+       # Correct base_url
+       proxy_set_header Accept-Encoding "";
+       sub_filter_once off;
+       sub_filter_types *;
+       sub_filter /jackett %%ingress_entry%%/jackett;
+  }
+
+}

--- a/jackett/rootfs/etc/services.d/nginx/finish
+++ b/jackett/rootfs/etc/services.d/nginx/finish
@@ -1,0 +1,8 @@
+#!/usr/bin/execlineb -S0
+# ==============================================================================
+# Take down the S6 supervision tree when Nginx fails
+# ==============================================================================
+if { s6-test ${1} -ne 0 }
+if { s6-test ${1} -ne 256 }
+
+s6-svscanctl -t /var/run/s6/services

--- a/jackett/rootfs/etc/services.d/nginx/run
+++ b/jackett/rootfs/etc/services.d/nginx/run
@@ -1,0 +1,24 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+# ==============================================================================
+
+# Set variables
+slug=jackett
+port=9117
+CONFIG_LOCATION=/config/addons_config/Jackett/ServerConfig.json
+
+# Wait for Jackett to become available
+bashio::net.wait_for "$port" localhost 900
+
+# Ensure BasePathOverride is set for ingress
+if [ -f "$CONFIG_LOCATION" ] && ! bashio::config.true "ingress_disabled"; then
+    if ! grep -q "\"BasePathOverride\"[[:space:]]*:[[:space:]]*\"${slug}\"" "$CONFIG_LOCATION"; then
+        bashio::log.warning "BasePathOverride not set properly, restarting"
+        sed -i -E "s/\"BasePathOverride\"[[:space:]]*:[[:space:]]*\"[^\"]*\"/\"BasePathOverride\": \"${slug}\"/" "$CONFIG_LOCATION"
+        bashio::addon.restart
+    fi
+fi
+
+bashio::log.info "Starting NGinx..."
+exec nginx


### PR DESCRIPTION
### Motivation
- Enable Home Assistant ingress for the Jackett add-on using the same approach as Prowlarr/Radarr/Sonarr so the app can be proxied and reachable via the HA frontend.
- Provide a connection_mode option to allow ingress_noauth/ingress_auth/noingress_auth behavior consistent with other NAS add-ons.

### Description
- Enabled `ingress: true`, added `ingress_entry: jackett`, added `connection_mode` option and bumped the add-on `version` in `jackett/config.yaml`.
- Added nginx files under `jackett/rootfs/etc/nginx/` and a services script under `jackett/rootfs/etc/services.d/nginx/` to proxy requests to Jackett on port `9117` and perform URL subfiltering of the base path.
- Added `jackett/rootfs/etc/cont-init.d/32-nginx_ingress.sh` and updated startup script logic to set `BasePathOverride` (and clear `AdminPassword` for `ingress_noauth`) in `ServerConfig.json` depending on `connection_mode` and to use the ingress port/interface/entry.
- Updated `CHANGELOG.md` and bumped the add-on version to record the new ingress support.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e40e57e8c832582e64acba048727f)