### PR TITLE
Remove paths-filter label check from PR workflow

### DIFF
--- a/.github/workflows/onpr_check-pr.yaml
+++ b/.github/workflows/onpr_check-pr.yaml
@@ -61,28 +61,6 @@ jobs:
             exit 1
           fi
 
-  check-addon-label:
-    name: Check for existence of the addon label
-    needs: check-addon-changes
-    if: ${{ needs.check-addon-changes.outputs.changedAddons != '[]' }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        addon: ${{ fromJSON(needs.check-addon-changes.outputs.changedAddons) }}
-    steps:
-      - name: ↩️ Checkout
-        uses: actions/checkout@v6
-
-      - name: 🔎 Check if a label for the addon exists
-        shell: bash
-        run: |
-          labeltext=$(grep -E "^\s*${{ matrix.addon }}:" '.github/paths-filter.yml' || true)
-          if [[ -z "$labeltext" ]]; then
-            echo "::error::There is no label for this addon! Please add it to .github/paths-filter.yml"
-            exit 1
-          fi
-
   addon-linter:
     name: Addon linting
     needs: check-addon-changes


### PR DESCRIPTION
### Motivation
- Remove the dependency on `.github/paths-filter.yml` from the PR workflow to avoid failing the PR check when that file or its labels are not present.

### Description
- Deleted the `check-addon-label` job from `.github/workflows/onpr_check-pr.yaml`, which previously grepped `.github/paths-filter.yml` for addon labels.
- Left the remaining workflow jobs and logic intact so addon linting and build checks continue to run as before.

### Testing
- No automated tests were executed because this is a workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978d4c950b08325ac5b6310a00f2d1b)