### PR TITLE
Fix empty addon list handling in workflows

### DIFF
--- a/.github/workflows/onpr_check-pr.yaml
+++ b/.github/workflows/onpr_check-pr.yaml
@@ -26,7 +26,7 @@ jobs:
           changed_config_files=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" | grep -E '^[^/]+/config\.(json|ya?ml)$' || true)
           echo "Changed config files:"
           echo "$changed_config_files"
-          changed_addons=$(echo "$changed_config_files" | awk -F/ '{print $1}' | sort -u | jq -R -s -c 'split("\n")[:-1]')
+          changed_addons=$(printf '%s' "$changed_config_files" | awk -F/ '{print $1}' | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "Changed addons: $changed_addons"
           echo "changed_addons=$changed_addons" >> "$GITHUB_OUTPUT"
       - name: Find changelog
@@ -38,7 +38,7 @@ jobs:
           changed_config_files=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" | grep -E '^[^/]+/config\.(json|ya?ml)$' || true)
           echo "$changed_config_files"
           all_changed_files=$(echo -e "$changed_config_files\n$changed_changelog_files" | sort -u)
-          changed_addons=$(echo "$all_changed_files" | awk -F/ '{print $1}' | sort -u | jq -R -s -c 'split("\n")[:-1]')
+          changed_addons=$(printf '%s' "$all_changed_files" | awk -F/ '{print $1}' | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "Changed addons: $changed_addons"
           echo "changed_addons=$changed_addons" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/onpush_builder.yaml
+++ b/.github/workflows/onpush_builder.yaml
@@ -31,7 +31,7 @@ jobs:
           changed_config_files=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" | grep -E '^[^/]+/config\.(json|ya?ml)$' || true)
           echo "Changed config files:"
           echo "$changed_config_files"
-          changed_addons=$(echo "$changed_config_files" | awk -F/ '{print $1}' | sort -u | jq -R -s -c 'split("\n")[:-1]')
+          changed_addons=$(printf '%s' "$changed_config_files" | awk -F/ '{print $1}' | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "Changed addons: $changed_addons"
           echo "changed_addons=$changed_addons" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
### Motivation
- The Addon linter job was failing when the workflow emitted an empty addon entry and the linter attempted to validate the repository root, producing the annotation: "Add-on configuration file not found in '.'".
- The goal is to avoid producing an empty matrix entry when no config/changelog files are detected so downstream jobs (lint/build) don't run against the repo root.

### Description
- Updated addon detection in `.github/workflows/onpr_check-pr.yaml` to build the `changed_addons` JSON array using `printf '%s'` and `jq -R -s -c 'split("\n") | map(select(length > 0))'` to filter out empty strings.
- Applied the same empty-entry filtering fix to `.github/workflows/onpush_builder.yaml` to keep behavior consistent between PR checks and push builds.
- Committed the workflow-only changes with message "Fix empty addon list handling in workflows".

### Testing
- No automated tests were run for this workflow-only change; GitHub Actions will validate the fix on the next PR/push run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978d6440eb88325b37896abd4ad9602)