### PR TITLE
Add BirdNET-PiPy add-on with ingress support and remove icon assets

### DIFF
--- a/birdnet-pipy/CHANGELOG.md
+++ b/birdnet-pipy/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial BirdNET-PiPy add-on with ingress support.

--- a/birdnet-pipy/DOCS.md
+++ b/birdnet-pipy/DOCS.md
@@ -1,0 +1,17 @@
+# BirdNET-PiPy add-on
+
+## Installation
+
+1. Add this repository to your Home Assistant add-on store.
+2. Install the BirdNET-PiPy add-on.
+3. Configure the options and start the add-on.
+4. Open the Web UI.
+
+## Access
+
+- **Ingress:** Use the Home Assistant sidebar entry.
+- **Direct:** `http://<host>:8099`
+
+## Audio
+
+The add-on expects audio via PulseAudio (default) or an RTSP stream configured in the BirdNET-PiPy settings.

--- a/birdnet-pipy/Dockerfile
+++ b/birdnet-pipy/Dockerfile
@@ -1,0 +1,140 @@
+#============================#
+#  ALEXBELGIUM'S DOCKERFILE  #
+#============================#
+#           _.------.
+#       _.-`    ('>.-`"""-.
+# '.--'`       _'`   _ .--.)
+#    -'         '-.-';`   `
+#    ' -      _.'  ``'--.
+#        '---`    .-'""`
+#               /`
+#=== Home Assistant Addon ===#
+
+#################
+# 1 Build Image #
+#################
+
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM node:20-alpine AS frontend-builder
+
+ARG BIRDNET_PIPY_VERSION=main
+
+RUN apk add --no-cache curl tar
+RUN mkdir -p /src \
+    && curl -fsSL "https://codeload.github.com/Suncuss/BirdNET-PiPy/tar.gz/refs/heads/${BIRDNET_PIPY_VERSION}" \
+        | tar -xz -C /src --strip-components=1
+
+WORKDIR /src/frontend
+RUN npm ci --prefer-offline
+RUN npm run build
+
+FROM ${BUILD_FROM}
+
+ARG BIRDNET_PIPY_VERSION=main
+
+##################
+# 2 Modify Image #
+##################
+
+# Set S6 wait time
+ENV S6_CMD_WAIT_FOR_SERVICES=1 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+USER root
+
+##################
+# 3 Install apps #
+##################
+
+# Copy local files
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" \) -print -exec chmod +x {} \;
+
+# Uses /bin for compatibility purposes
+# hadolint ignore=DL4005
+RUN if [ ! -f /bin/sh ] && [ -f /usr/bin/sh ]; then ln -s /usr/bin/sh /bin/sh; fi && \
+    if [ ! -f /bin/bash ] && [ -f /usr/bin/bash ]; then ln -s /usr/bin/bash /bin/bash; fi
+
+# Modules
+ARG MODULES="00-banner.sh 01-custom_script.sh 00-global_var.sh"
+
+# Automatic modules download
+ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templates/ha_automodules.sh" "/ha_automodules.sh"
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+# Manual apps
+ENV PACKAGES="python3 python3-pip python3-venv build-essential ffmpeg sox libpulse0 icecast2 nginx jq curl"
+
+# Automatic apps & bashio
+ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templates/ha_autoapps.sh" "/ha_autoapps.sh"
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+RUN mkdir -p /opt/birdnet-pipy \
+    && curl -fsSL "https://codeload.github.com/Suncuss/BirdNET-PiPy/tar.gz/refs/heads/${BIRDNET_PIPY_VERSION}" \
+        | tar -xz -C /opt/birdnet-pipy --strip-components=1
+
+RUN mkdir -p /app \
+    && cp -a /opt/birdnet-pipy/backend/. /app/ \
+    && pip install --no-cache-dir -r /app/requirements.txt
+
+# Patch service hostnames for single-container usage
+RUN sed -i \
+    -e "s/API_HOST = 'api'/API_HOST = '127.0.0.1'/" \
+    -e "s/BIRDNET_HOST = 'model-server'/BIRDNET_HOST = '127.0.0.1'/" \
+    /app/config/settings.py
+
+RUN install -m 755 /opt/birdnet-pipy/deployment/audio/scripts/start-icecast.sh /usr/local/bin/start-icecast.sh
+
+COPY --from=frontend-builder /src/frontend/dist /usr/share/nginx/html
+
+################
+# 4 Entrypoint #
+################
+
+# Add entrypoint
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templates/ha_entrypoint.sh" "/ha_entrypoint.sh"
+RUN chmod 777 /ha_entrypoint.sh
+
+ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templates/bashio-standalone.sh" "/.bashio-standalone.sh"
+RUN chmod 777 /.bashio-standalone.sh
+
+ENTRYPOINT [ "/usr/bin/env" ]
+CMD [ "/ha_entrypoint.sh" ]
+
+############
+# 5 Labels #
+############
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="alexbelgium (https://github.com/alexbelgium)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="alexbelgium (https://github.com/alexbelgium)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/alexbelgium" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version=${BUILD_VERSION}
+
+####################
+# 6 HealthcheckNOT #
+####################

--- a/birdnet-pipy/README.md
+++ b/birdnet-pipy/README.md
@@ -1,0 +1,23 @@
+# Home assistant add-on: BirdNET-PiPy
+
+BirdNET-PiPy is a self-hosted system that uses the BirdNET deep-learning model to identify birds from their sounds, with a modern web dashboard for monitoring detections. This add-on packages the upstream project for Home Assistant with ingress support.
+
+## About
+
+- Upstream project: https://github.com/Suncuss/BirdNET-PiPy
+- This add-on runs the BirdNET-PiPy backend services, Icecast audio stream, and Vue.js frontend in a single container.
+
+## Configuration
+
+```yaml
+TZ: Etc/UTC
+ICECAST_PASSWORD: "" # Optional: set a persistent password for the audio stream
+STREAM_BITRATE: 320k # Bitrate for the mp3 stream
+```
+
+After starting, open the add-on web UI. Use the BirdNET-PiPy settings page to configure location, audio source, and other options.
+
+## Notes
+
+- Audio input uses Home Assistant's PulseAudio server by default.
+- Ingress is enabled; direct access is available on the configured port.

--- a/birdnet-pipy/apparmor.txt
+++ b/birdnet-pipy/apparmor.txt
@@ -1,0 +1,58 @@
+#include <tunables/global>
+
+profile birdnet-pipy_addon flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  capability,
+  file,
+  signal,
+  mount,
+  umount,
+  remount,
+  network udp,
+  network tcp,
+  network dgram,
+  network stream,
+  network inet,
+  network inet6,
+  network netlink raw,
+  network unix dgram,
+
+  capability setgid,
+  capability setuid,
+  capability sys_admin,
+  capability dac_read_search,
+
+# S6-Overlay
+  /init ix,
+  /run/{s6,s6-rc*,service}/** ix,
+  /package/** ix,
+  /command/** ix,
+  /run/{,**} rwk,
+  /dev/tty rw,
+  /bin/** ix,
+  /usr/bin/** ix,
+  /usr/lib/bashio/** ix,
+  /etc/s6/** rix,
+  /run/s6/** rix,
+  /etc/services.d/** rwix,
+  /etc/cont-init.d/** rwix,
+  /etc/cont-finish.d/** rwix,
+  /init rix,
+  /var/run/** mrwkl,
+  /var/run/ mrwkl,
+  /dev/i2c-1 mrwkl,
+  /dev/fuse mrwkl,
+  /dev/* mrwkl,
+  /tmp/** mrkwl,
+
+  # Data access
+  /data/** rw,
+
+  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
+  ptrace (trace,read) peer=docker-default,
+
+  # docker daemon confinement requires explict allow rule for signal
+  signal (receive) set=(kill,term) peer=/usr/bin/docker,
+
+}

--- a/birdnet-pipy/build.yaml
+++ b/birdnet-pipy/build.yaml
@@ -1,0 +1,4 @@
+---
+build_from:
+  aarch64: ghcr.io/linuxserver/baseimage-debian:arm64v8-bookworm
+  amd64: ghcr.io/linuxserver/baseimage-debian:amd64-bookworm

--- a/birdnet-pipy/config.yaml
+++ b/birdnet-pipy/config.yaml
@@ -1,0 +1,33 @@
+name: BirdNET-PiPy
+slug: birdnet-pipy
+description: BirdNET-PiPy bird detection with a modern web dashboard
+version: 0.1.0
+url: https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-pipy
+arch:
+  - aarch64
+  - amd64
+ingress: true
+ingress_entry: /
+ingress_stream: true
+panel_icon: mdi:bird
+init: false
+map:
+  - addon_config:rw
+ports:
+  8099/tcp: 8099
+ports_description:
+  8099/tcp: Web UI
+options:
+  TZ: Etc/UTC
+  ICECAST_PASSWORD: ""
+  STREAM_BITRATE: 320k
+  env_vars: []
+schema:
+  TZ: str?
+  ICECAST_PASSWORD: str?
+  STREAM_BITRATE: str?
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+audio: true
+image: ghcr.io/alexbelgium/birdnet-pipy-{arch}

--- a/birdnet-pipy/rootfs/etc/cont-init.d/01-structure.sh
+++ b/birdnet-pipy/rootfs/etc/cont-init.d/01-structure.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+
+DATA_ROOT="/config/birdnet-pipy"
+DATA_DIR="${DATA_ROOT}/data"
+
+mkdir -p "${DATA_DIR}"
+
+if [ -e /app/data ] && [ ! -L /app/data ]; then
+    rm -rf /app/data
+fi
+
+if [ ! -L /app/data ]; then
+    ln -s "${DATA_DIR}" /app/data
+fi
+
+mkdir -p \
+    /app/data/config \
+    /app/data/db \
+    /app/data/audio/recordings \
+    /app/data/audio/extracted_songs \
+    /app/data/spectrograms \
+    /app/data/flags

--- a/birdnet-pipy/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/birdnet-pipy/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+
+#################
+# NGINX SETTING #
+#################
+
+declare ingress_interface
+declare ingress_port
+
+ingress_port="$(bashio::addon.ingress_port)"
+ingress_interface="$(bashio::addon.ip_address)"
+ingress_entry="$(bashio::addon.ingress_entry)"
+ingress_entry_modified="$(echo "$ingress_entry" | sed 's/[@_!#$%^&*()<>?/\|}{~:]//g')"
+
+sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
+sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
+sed -i "s#%%ingress_entry%%#${ingress_entry}#g" /etc/nginx/servers/ingress.conf
+sed -i "s#%%ingress_entry_modified%%#/${ingress_entry_modified}#g" /etc/nginx/servers/ingress.conf
+sed -i "s#%%ingress_entry%%#${ingress_entry}#g" /etc/nginx/servers/nginx.conf
+sed -i "s#%%ingress_entry_modified%%#/${ingress_entry_modified}#g" /etc/nginx/servers/nginx.conf
+
+# Set DNS resolver for internal requests
+sed -i "s/%%dns_host%%/127.0.0.11/g" /etc/nginx/includes/resolver.conf

--- a/birdnet-pipy/rootfs/etc/cont-init.d/99-run.sh
+++ b/birdnet-pipy/rootfs/etc/cont-init.d/99-run.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+
+export PYTHONPATH=/app
+export PULSE_SERVER=unix:/run/pulse/native
+
+cd /app
+
+bashio::log.info "Starting BirdNET-PiPy services"
+
+python3 -m model_service.inference_server &
+python3 -m core.api &
+python3 -m core.main &
+
+/usr/local/bin/start-icecast.sh &
+
+bashio::net.wait_for 5002 localhost 300
+bashio::log.info "BirdNET-PiPy API is available"
+
+exec nginx

--- a/birdnet-pipy/rootfs/etc/nginx/includes/mime.types
+++ b/birdnet-pipy/rootfs/etc/nginx/includes/mime.types
@@ -1,0 +1,96 @@
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    application/javascript                           js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                         wmlc;
+    application/x-7z-compressed                      7z;
+    application/x-cocoa                              cco;
+    application/x-java-archive-diff                  jardiff;
+    application/x-java-jnlp-file                     jnlp;
+    application/x-makeself                           run;
+    application/x-perl                               pl pm;
+    application/x-pilot                              prc pdb;
+    application/x-rar-compressed                     rar;
+    application/x-redhat-package-manager             rpm;
+    application/x-sea                                sea;
+    application/x-shockwave-flash                    swf;
+    application/x-stuffit                            sit;
+    application/x-tcl                                tcl tk;
+    application/x-x509-ca-cert                       der pem crt;
+    application/x-xpinstall                          xpi;
+    application/xhtml+xml                            xhtml;
+    application/xspf+xml                             xspf;
+    application/zip                                  zip;
+
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+
+    audio/midi                                       mid midi kar;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        ogg;
+    audio/x-m4a                                      m4a;
+    audio/x-realaudio                                ra;
+
+    video/3gpp                                       3gpp 3gp;
+    video/mp2t                                       ts;
+    video/mp4                                        mp4;
+    video/mpeg                                       mpeg mpg;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-m4v                                      m4v;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asx asf;
+    video/x-ms-wmv                                   wmv;
+    video/x-msvideo                                  avi;
+}

--- a/birdnet-pipy/rootfs/etc/nginx/includes/proxy_params.conf
+++ b/birdnet-pipy/rootfs/etc/nginx/includes/proxy_params.conf
@@ -1,0 +1,15 @@
+proxy_http_version          1.1;
+proxy_ignore_client_abort   off;
+proxy_read_timeout          86400s;
+proxy_redirect              off;
+proxy_send_timeout          86400s;
+proxy_max_temp_file_size    0;
+
+proxy_set_header Accept-Encoding "";
+proxy_set_header Connection $connection_upgrade;
+proxy_set_header Host $http_host;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-NginX-Proxy true;
+proxy_set_header X-Real-IP $remote_addr;

--- a/birdnet-pipy/rootfs/etc/nginx/includes/resolver.conf
+++ b/birdnet-pipy/rootfs/etc/nginx/includes/resolver.conf
@@ -1,0 +1,1 @@
+resolver %%dns_host%%;

--- a/birdnet-pipy/rootfs/etc/nginx/includes/server_params.conf
+++ b/birdnet-pipy/rootfs/etc/nginx/includes/server_params.conf
@@ -1,0 +1,6 @@
+root            /dev/null;
+server_name     $hostname;
+
+add_header X-Content-Type-Options nosniff;
+add_header X-XSS-Protection "1; mode=block";
+add_header X-Robots-Tag none;

--- a/birdnet-pipy/rootfs/etc/nginx/includes/ssl_params.conf
+++ b/birdnet-pipy/rootfs/etc/nginx/includes/ssl_params.conf
@@ -1,0 +1,9 @@
+ssl_protocols TLSv1.2;
+ssl_prefer_server_ciphers on;
+ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA;
+ssl_ecdh_curve secp384r1;
+ssl_session_timeout  10m;
+ssl_session_cache shared:SSL:10m;
+ssl_session_tickets off;
+ssl_stapling on;
+ssl_stapling_verify on;

--- a/birdnet-pipy/rootfs/etc/nginx/includes/upstream.conf
+++ b/birdnet-pipy/rootfs/etc/nginx/includes/upstream.conf
@@ -1,0 +1,3 @@
+upstream backend {
+    server 127.0.0.1:5001;
+}

--- a/birdnet-pipy/rootfs/etc/nginx/nginx.conf
+++ b/birdnet-pipy/rootfs/etc/nginx/nginx.conf
@@ -1,0 +1,56 @@
+# Run nginx in foreground.
+daemon off;
+
+# This is run inside Docker.
+user root;
+
+# Pid storage location.
+pid /var/run/nginx.pid;
+
+# Set number of worker processes.
+worker_processes 1;
+
+# Enables the use of JIT for regular expressions to speed-up their processing.
+pcre_jit on;
+
+# Write error log to Hass.io add-on log.
+error_log /proc/1/fd/1 error;
+
+# Load allowed environment vars
+env HASSIO_TOKEN;
+
+# Load dynamic modules.
+include /etc/nginx/modules/*.conf;
+
+# Max num of simultaneous connections by a worker process.
+events {
+    worker_connections 512;
+}
+
+http {
+    include /etc/nginx/includes/mime.types;
+
+    log_format hassio '[$time_local] $status '
+                        '$http_x_forwarded_for($remote_addr) '
+                        '$request ($http_user_agent)';
+
+    access_log              /proc/1/fd/1 hassio;
+    client_max_body_size    4G;
+    default_type            application/octet-stream;
+    gzip                    on;
+    keepalive_timeout       65;
+    sendfile                on;
+    server_tokens           off;
+    tcp_nodelay             on;
+    tcp_nopush              on;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
+    include /etc/nginx/includes/resolver.conf;
+    include /etc/nginx/includes/upstream.conf;
+
+    include /etc/nginx/servers/*.conf;
+}

--- a/birdnet-pipy/rootfs/etc/nginx/servers/ingress.conf
+++ b/birdnet-pipy/rootfs/etc/nginx/servers/ingress.conf
@@ -1,0 +1,74 @@
+server {
+    listen %%interface%%:%%port%% default_server;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    include /etc/nginx/includes/server_params.conf;
+    include /etc/nginx/includes/proxy_params.conf;
+
+    client_max_body_size 0;
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json;
+
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+
+    sub_filter_once off;
+    sub_filter_types text/html;
+    sub_filter '<head>' '<head><base href="%%ingress_entry%%/">';
+    sub_filter 'href="/' 'href="%%ingress_entry%%/';
+    sub_filter 'src="/' 'src="%%ingress_entry%%/';
+
+    location ^~ /api/ {
+        proxy_pass http://127.0.0.1:5002;
+    }
+
+    location = /internal/auth {
+        internal;
+        proxy_pass http://127.0.0.1:5002/api/auth/verify;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header X-Original-URI $request_uri;
+        proxy_set_header Cookie $http_cookie;
+    }
+
+    location @stream_unauthorized {
+        default_type application/json;
+        return 401 '{"error": "Authentication required"}';
+    }
+
+    location ^~ /stream/ {
+        auth_request /internal/auth;
+        error_page 401 = @stream_unauthorized;
+
+        proxy_pass http://127.0.0.1:8888/;
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    location /socket.io/ {
+        proxy_pass http://127.0.0.1:5002/socket.io/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    error_page 404 /index.html;
+    error_page 500 502 503 504 /index.html;
+}

--- a/birdnet-pipy/rootfs/etc/nginx/servers/nginx.conf
+++ b/birdnet-pipy/rootfs/etc/nginx/servers/nginx.conf
@@ -1,0 +1,68 @@
+server {
+    listen 8099;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    include /etc/nginx/includes/server_params.conf;
+    include /etc/nginx/includes/proxy_params.conf;
+
+    client_max_body_size 0;
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json;
+
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+
+    location ^~ /api/ {
+        proxy_pass http://127.0.0.1:5002;
+    }
+
+    location = /internal/auth {
+        internal;
+        proxy_pass http://127.0.0.1:5002/api/auth/verify;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header X-Original-URI $request_uri;
+        proxy_set_header Cookie $http_cookie;
+    }
+
+    location @stream_unauthorized {
+        default_type application/json;
+        return 401 '{"error": "Authentication required"}';
+    }
+
+    location ^~ /stream/ {
+        auth_request /internal/auth;
+        error_page 401 = @stream_unauthorized;
+
+        proxy_pass http://127.0.0.1:8888/;
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    location /socket.io/ {
+        proxy_pass http://127.0.0.1:5002/socket.io/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    error_page 404 /index.html;
+    error_page 500 502 503 504 /index.html;
+}

--- a/birdnet-pipy/updater.json
+++ b/birdnet-pipy/updater.json
@@ -1,0 +1,8 @@
+{
+  "last_update": "09-01-2025",
+  "repository": "alexbelgium/hassio-addons",
+  "slug": "birdnet-pipy",
+  "source": "github",
+  "upstream_repo": "Suncuss/BirdNET-PiPy",
+  "upstream_version": "main"
+}


### PR DESCRIPTION
### Motivation

- Package the upstream BirdNET-PiPy project as a Home Assistant add-on to provide local birdcall detection with a modern web dashboard and ingress access.
- Run backend services, Icecast audio streaming, and the Vue frontend in a single container to simplify deployment for Home Assistant users.
- Provide ingress-aware Nginx configuration and init scripts to integrate with Home Assistant PulseAudio and ingress requirements. 
- Remove binary icon assets per repository hygiene request.

### Description

- Add a new `birdnet-pipy/` add-on directory containing a multi-stage `Dockerfile` that builds the frontend, installs backend requirements, and assembles a runtime image. 
- Add metadata and packaging files: `config.yaml`, `build.yaml`, `updater.json`, `README.md`, `DOCS.md`, and `CHANGELOG.md`. 
- Add runtime `rootfs` scripts including `01-structure.sh`, `32-nginx_ingress.sh`, and `99-run.sh` to create data mounts, template ingress variables into Nginx, and start the services (`model_service`, `core.api`, `core.main`, Icecast and `nginx`).
- Add Nginx runtime configuration and includes (`includes/*.conf`, `servers/*.conf`) and a frontend asset copy from the build stage, and remove the binary `icon.png`/`logo.png` assets from the add-on tree.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a128bb39883259a4be5532a65bc7f)