### PR TITLE
Refine Plex `data_location` migration and document behavior

### DIFF
--- a/plex/CHANGELOG.md
+++ b/plex/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 1.42.2.10156-f737b826c-ls289-1 (2026-01-30)
+- Add configurable data_location for Plex storage (default /share/plex) with migration support when the target folder is empty.
+
 ## 1.42.2.10156-f737b826c-ls289 (2026-01-21)
 - Update to latest version from linuxserver/docker-plex (changelog : https://github.com/linuxserver/docker-plex/releases)
 

--- a/plex/README.md
+++ b/plex/README.md
@@ -61,6 +61,9 @@ Webui can be found at `<your-ip>:32400`.
 | `cifsdomain` | str | | SMB domain for network shares |
 | `smbv1` | bool | `false` | Enable SMB v1 protocol |
 | `skip_permissions_check` | bool | `false` | Skip file permissions checking |
+| `data_location` | str | `/share/plex` | Path where Plex data is stored |
+
+When `data_location` is changed and the target folder is empty, the add-on copies data from the previous Plex location (detected via the `/config/Library` symlink, or `/share/plex` on first migration).
 
 ### Example Configuration
 
@@ -74,6 +77,7 @@ networkdisks: "//192.168.1.100/media,//nas.local/movies"
 cifsusername: "mediauser"
 cifspassword: "password123"
 cifsdomain: "workgroup"
+data_location: "/share/plex"
 ```
 
 ### Mounting Drives
@@ -96,5 +100,3 @@ comparison to installing any other Hass.io add-on.
 1. Carefully configure the add-on to your preferences, see the official documentation for for that.
 
 [repository]: https://github.com/alexbelgium/hassio-addons
-
-

--- a/plex/config.yaml
+++ b/plex/config.yaml
@@ -126,6 +126,7 @@ options:
   PGID: 0
   PUID: 0
   claim: Get_from_https://www.plex.tv/claim
+  data_location: /share/plex
 ports:
   1900/udp: 1900
   3005/tcp: 3005
@@ -165,6 +166,7 @@ schema:
   cifsusername: str?
   claim: str
   clear_codecs_folder: bool?
+  data_location: str
   localdisks: str?
   networkdisks: str?
   skip_permissions_check: bool?
@@ -173,6 +175,6 @@ slug: plex_nas
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/plex
 usb: true
-version: "1.42.2.10156-f737b826c-ls289"
+version: "1.42.2.10156-f737b826c-ls289-1"
 video: true
 webui: "[PROTO:ssl]://[HOST]:[PORT:32400]/web"

--- a/plex/rootfs/etc/cont-init.d/21-folders.sh
+++ b/plex/rootfs/etc/cont-init.d/21-folders.sh
@@ -4,36 +4,38 @@
 # SYMLINK CONFIG #
 ##################
 
-echo "Database stored in /share/plex"
+DATA_LOCATION="$(bashio::config 'data_location')"
 
-if [ ! -d "/share/plex/Plex Media Server" ]; then
-    echo "... creating /share/plex/Plex Media Server"
-    mkdir -p "/share/plex/Plex Media Server"
+echo "Database stored in ${DATA_LOCATION}"
+
+if [ ! -d "${DATA_LOCATION}/Plex Media Server" ]; then
+    echo "... creating ${DATA_LOCATION}/Plex Media Server"
+    mkdir -p "${DATA_LOCATION}/Plex Media Server"
 fi
 
 if [ -d "/config/Library/Application Support/Plex Media Server" ]; then
     echo "... creating /symlink"
     rm -r "/config/Library/Application Support/*"
-    ln -s "/share/plex/Plex Media Server" "/config/Library/Application Support"
+    ln -s "${DATA_LOCATION}/Plex Media Server" "/config/Library/Application Support"
 fi
 
 if [ ! -d "/config/Library/Application Support" ]; then
     echo "... creating /symlink"
     mkdir -p "/config/Library/Application Support"
-    ln -s "/share/plex/Plex Media Server" "/config/Library/Application Support"
+    ln -s "${DATA_LOCATION}/Plex Media Server" "/config/Library/Application Support"
 fi
 
 # Adapt permissions if needed
 if ! bashio::config.true "skip_permissions_check" && [ "${PUID:-0}" != "0" ] && [ "${PGID:-0}" != "0" ]; then
     echo "... setting permissions, this might take a long time. If it takes too long at each boot, you could instead activate skip_permissions_check in the addon options"
-    chmod -R 755 /share/plex
-    chown -R "$PUID:$PGID" /share/plex
+    chmod -R 755 "${DATA_LOCATION}"
+    chown -R "$PUID:$PGID" "${DATA_LOCATION}"
 elif bashio::config.true "skip_permissions_check"; then
     bashio::log.warning "... skipping permissions check as 'skip_permissions_check' is set"
 fi
 
 # Clear Codecs folder if checked
-if bashio::config.true "clear_codecs_folder" && [[ -d "/share/plex/Plex Media Server/Codecs" ]]; then
+if bashio::config.true "clear_codecs_folder" && [[ -d "${DATA_LOCATION}/Plex Media Server/Codecs" ]]; then
     echo "... deleting codecs folder"
-    rm -r "/share/plex/Plex Media Server/Codecs"
+    rm -r "${DATA_LOCATION}/Plex Media Server/Codecs"
 fi

--- a/plex/rootfs/etc/cont-init.d/90-create_links.sh
+++ b/plex/rootfs/etc/cont-init.d/90-create_links.sh
@@ -4,25 +4,49 @@
 # SYMLINK CONFIG #
 ##################
 
-if [ ! -d /share/plex ]; then
-    echo "Creating /share/plex"
-    mkdir -p /share/plex
+DATA_LOCATION="$(bashio::config 'data_location')"
+OLD_LOCATION=""
+
+if [ -L /config/Library ]; then
+    old_library_path="$(readlink -f /config/Library)"
+    if [ -n "$old_library_path" ]; then
+        OLD_LOCATION="$(dirname "$old_library_path")"
+    fi
 fi
 
-if [ ! -d /share/plex/Library ]; then
+if [ -z "$OLD_LOCATION" ] && [ -d "/share/plex" ]; then
+    OLD_LOCATION="/share/plex"
+fi
+
+if [ -n "$OLD_LOCATION" ] && [ "$DATA_LOCATION" != "$OLD_LOCATION" ] && [ -d "$OLD_LOCATION" ]; then
+    if [ -d "${DATA_LOCATION}" ] && [ "$(ls -A "${DATA_LOCATION}" 2>/dev/null)" ]; then
+        echo "Skipping migration: ${DATA_LOCATION} already contains data"
+    else
+        echo "Migrating existing ${OLD_LOCATION} data to ${DATA_LOCATION}"
+        mkdir -p "${DATA_LOCATION}"
+        cp -a "${OLD_LOCATION}/." "${DATA_LOCATION}/" || true
+    fi
+fi
+
+if [ ! -d "${DATA_LOCATION}" ]; then
+    echo "Creating ${DATA_LOCATION}"
+    mkdir -p "${DATA_LOCATION}"
+fi
+
+if [ ! -d "${DATA_LOCATION}/Library" ]; then
     echo "moving Library folder"
-    mv /config/Library /share/plex
-    ln -s /share/plex/Library /config
+    mv /config/Library "${DATA_LOCATION}"
+    ln -s "${DATA_LOCATION}/Library" /config
     echo "links done"
 else
     rm -r /config/Library
-    ln -s /share/plex/Library /config
+    ln -s "${DATA_LOCATION}/Library" /config
     echo "Using existing config"
 fi
 
 # Adapt permissions if needed
 if ! bashio::config.true "skip_permissions_check" && [ "${PUID:-0}" != "0" ] && [ "${PGID:-0}" != "0" ]; then
     bashio::log.info "Updating permissions"
-    chown -R "$PUID:$PGID" /share/plex
-    chmod -R 777 /share/plex
+    chown -R "$PUID:$PGID" "${DATA_LOCATION}"
+    chmod -R 777 "${DATA_LOCATION}"
 fi


### PR DESCRIPTION
### Motivation
- Make changing the Plex `data_location` safer by detecting the previous data location and only migrating when the target is empty.
- Remove duplicate migration logic across init scripts and centralize migration in the links creation step.
- Clarify expected behavior in docs and changelog so users know when automatic migration will occur.

### Description
- Update `plex/rootfs/etc/cont-init.d/90-create_links.sh` to detect the previous Plex location via the `/config/Library` symlink (fallback to `/share/plex`) and copy data to `DATA_LOCATION` only when the target is empty, and to skip migration when the target already contains data.
- Simplify `plex/rootfs/etc/cont-init.d/21-folders.sh` to remove redundant migration logic and use `DATA_LOCATION` for folder creation, permission handling, and codec cleanup.
- Document the migration behavior in `plex/README.md` describing that migration runs only when the new target folder is empty and how the previous location is detected.
- Update `plex/CHANGELOG.md` to clarify the migration conditions and bump the add-on `version`/`config.yaml` entries to include the new `data_location` option and schema.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979dcfbd8a48325a723a7d0e6360fda)