### PR TITLE
Document add-on options and configuration for BirdNET-PiPy

### DIFF
--- a/birdnet-pipy/DOCS.md
+++ b/birdnet-pipy/DOCS.md
@@ -12,6 +12,17 @@
 - **Ingress:** Use the Home Assistant sidebar entry.
 - **Direct:** `http://<host>:8099`
 
+## Options
+
+```yaml
+TZ: Etc/UTC # Timezone, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
+ICECAST_PASSWORD: "" # Optional: set a persistent password for the audio stream
+STREAM_BITRATE: 320k # Bitrate for the mp3 stream
+RECORDING_MODE: rtsp # pulseaudio | http_stream | rtsp
+RTSP_URL: "" # Required if RECORDING_MODE is rtsp
+data_location: /config/data # Persistent data location for BirdNET-PiPy
+```
+
 ## Audio
 
 The add-on expects audio via PulseAudio (default) or an RTSP stream configured in the BirdNET-PiPy settings.

--- a/birdnet-pipy/README.md
+++ b/birdnet-pipy/README.md
@@ -9,13 +9,41 @@ BirdNET-PiPy is a self-hosted system that uses the BirdNET deep-learning model t
 
 ## Configuration
 
+Install, then start the add-on a first time. Open the Web UI from Home Assistant (Ingress) or directly at `http://<host>:8099`.
+Configure location, audio source, and other settings in the BirdNET-PiPy UI after the container starts.
+
+Options can be configured through three ways:
+
+- Add-on options
+
 ```yaml
-TZ: Etc/UTC
+TZ: Etc/UTC # Timezone, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
 ICECAST_PASSWORD: "" # Optional: set a persistent password for the audio stream
 STREAM_BITRATE: 320k # Bitrate for the mp3 stream
+RECORDING_MODE: rtsp # pulseaudio | http_stream | rtsp
+RTSP_URL: "" # Required if RECORDING_MODE is rtsp
+data_location: /config/data # Persistent data location for BirdNET-PiPy
 ```
 
-After starting, open the add-on web UI. Use the BirdNET-PiPy settings page to configure location, audio source, and other options.
+- Config.yaml
+Additional variables can be configured using the config.yaml file found in `/config/birdnet-pipy/config.yaml` using the Filebrowser add-on.
+
+- Config_env.yaml
+Additional environment variables can be configured there.
+
+### Mounting Drives
+
+This add-on supports mounting both local drives and remote SMB shares:
+
+- **Local drives**: See [Mounting Local Drives in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Mounting-Local-Drives-in-Addons)
+- **Remote shares**: See [Mounting Remote Shares in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Mounting-remote-shares-in-Addons)
+
+### Custom Scripts and Environment Variables
+
+This add-on supports custom scripts and environment variables through the `addon_config` mapping:
+
+- **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## Notes
 


### PR DESCRIPTION
### Motivation

- Align BirdNET-PiPy documentation with the other birdnet add-ons by exposing the same add-on options and standard configuration guidance.
- Make intent and required settings explicit for users who want to use PulseAudio, HTTP streams, or RTSP by documenting `RECORDING_MODE` and `RTSP_URL` and where persistent data is stored.
- Provide consistent guidance for mounting drives and passing custom environment variables to match other add-ons in the repository.

### Description

- Added an `Options` block to `birdnet-pipy/DOCS.md` documenting `TZ`, `ICECAST_PASSWORD`, `STREAM_BITRATE`, `RECORDING_MODE`, `RTSP_URL`, and `data_location` with example YAML.
- Expanded `birdnet-pipy/README.md` with usage notes about opening the Web UI, where to configure settings, and an options example that includes `RECORDING_MODE`, `RTSP_URL`, and `data_location`.
- Added standard sections for `Config.yaml`, `Config_env.yaml`, `Mounting Drives`, and `Custom Scripts and Environment Variables` in `birdnet-pipy/README.md` with links to the repository guidance used by other add-ons.

### Testing

- No automated tests were run because this change updates documentation only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b38c29dec8325914ab359faccc709)