### PR TITLE
Install `sed` before s6 patch in Immich Dockerfiles

### DIFF
--- a/immich_cuda/Dockerfile
+++ b/immich_cuda/Dockerfile
@@ -83,7 +83,8 @@ RUN chmod 777 /ha_entrypoint.sh
 ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templates/bashio-standalone.sh" "/usr/local/lib/bashio-standalone.sh"
 RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
 
-RUN \ sed -i "s|postgresql-16|postgresql-15|g" /etc/s6-overlay/s6-rc.d/init-test-run/run
+RUN apt-get update && apt-get install -y --no-install-recommends sed \
+    && sed -i "s|postgresql-16|postgresql-15|g" /etc/s6-overlay/s6-rc.d/init-test-run/run
 
 # Install dependencies
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/immich_noml/Dockerfile
+++ b/immich_noml/Dockerfile
@@ -83,7 +83,8 @@ RUN chmod 777 /ha_entrypoint.sh
 ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templates/bashio-standalone.sh" "/usr/local/lib/bashio-standalone.sh"
 RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
 
-RUN \ sed -i "s|postgresql-16|postgresql-15|g" /etc/s6-overlay/s6-rc.d/init-test-run/run
+RUN apt-get update && apt-get install -y --no-install-recommends sed \
+    && sed -i "s|postgresql-16|postgresql-15|g" /etc/s6-overlay/s6-rc.d/init-test-run/run
 
 # Install dependencies
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/immich_openvino/Dockerfile
+++ b/immich_openvino/Dockerfile
@@ -83,7 +83,8 @@ RUN chmod 777 /ha_entrypoint.sh
 ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templates/bashio-standalone.sh" "/usr/local/lib/bashio-standalone.sh"
 RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
 
-RUN sed -i "s|postgresql-16|postgresql-15|g" /etc/s6-overlay/s6-rc.d/init-test-run/run
+RUN apt-get update && apt-get install -y --no-install-recommends sed \
+    && sed -i "s|postgresql-16|postgresql-15|g" /etc/s6-overlay/s6-rc.d/init-test-run/run
 
 # Install dependencies
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
### Motivation
- Fix build failures where `sed` is invoked before it is available in the image when patching the s6 init-run file, which causes the Immich variants to fail to build.

### Description
- Add `apt-get update && apt-get install -y --no-install-recommends sed` before the `sed -i "s|postgresql-16|postgresql-15|g" /etc/s6-overlay/s6-rc.d/init-test-run/run` patch in `immich_cuda/Dockerfile`.
- Add the same `sed` install step before the s6 patch in `immich_noml/Dockerfile`.
- Add the same `sed` install step before the s6 patch in `immich_openvino/Dockerfile`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697daf4f8a508325a8758d95a636df8c)