### PR TITLE
Run docker mods during PID1 startup

### DIFF
--- a/.templates/ha_entrypoint.sh
+++ b/.templates/ha_entrypoint.sh
@@ -190,6 +190,11 @@ if [ -d /etc/cont-init.d ]; then
 fi
 
 if $PID1; then
+  if [ -f /docker-mods ]; then
+    echo "Running docker mods"
+    /docker-mods
+  fi
+
   shopt -s nullglob
   for runfile in /etc/services.d/*/run /etc/s6-overlay/s6-rc.d/*/run; do
     [ -f "$runfile" ] || continue


### PR DESCRIPTION
### Motivation
- When the addon runs as PID1 (for example with `init: false`) the entrypoint previously only ran `/docker-mods` in the non-PID1 path, so Docker modifications never applied and the `[mod-init]` logs were missing.

### Description
- Add a PID1-path check in `.templates/ha_entrypoint.sh` to execute `/docker-mods` (with an informational `"Running docker mods"` echo) after running `/etc/cont-init.d` scripts and before launching service runfiles.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697defc6effc8325a9c75a3bbec4c993)