### PR TITLE
Bump Immich add-on versions (standard, CUDA, NoML, OpenVINO)

### DIFF
--- a/immich/CHANGELOG.md
+++ b/immich/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 2.5.2-3 (2026-02-02)
+- Minor bugs fixed
+
 ## 2.5.2-2 (2026-02-01)
 - Ensure docker mods (Redis) run by keeping the container in root mode.
 

--- a/immich/config.yaml
+++ b/immich/config.yaml
@@ -141,6 +141,6 @@ slug: immich
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "2.5.2-2"
+version: "2.5.2-3"
 video: true
 webui: http://[HOST]:[PORT:8080]

--- a/immich_cuda/CHANGELOG.md
+++ b/immich_cuda/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 2.5.2-3 (2026-02-02)
+- Minor bugs fixed
+
 ## 2.5.2-2 (2026-02-01)
 - Ensure docker mods (Redis) run by keeping the container in root mode.
 

--- a/immich_cuda/config.yaml
+++ b/immich_cuda/config.yaml
@@ -139,6 +139,6 @@ slug: immich_cuda
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "2.5.2-2"
+version: "2.5.2-3"
 video: true
 webui: http://[HOST]:[PORT:8080]

--- a/immich_noml/CHANGELOG.md
+++ b/immich_noml/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 2.5.2-3 (2026-02-02)
+- Minor bugs fixed
+
 ## 2.5.2-2 (2026-02-01)
 - Ensure docker mods (Redis) run by keeping the container in root mode.
 

--- a/immich_noml/config.yaml
+++ b/immich_noml/config.yaml
@@ -140,6 +140,6 @@ slug: immich_noml
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "2.5.2-2"
+version: "2.5.2-3"
 video: true
 webui: http://[HOST]:[PORT:8080]

--- a/immich_openvino/CHANGELOG.md
+++ b/immich_openvino/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.5.2-4 (2026-02-02)
+- Minor bugs fixed
+
 ## 2.5.2-3 (31-01-2026)
 - Minor bugs fixed
 

--- a/immich_openvino/config.yaml
+++ b/immich_openvino/config.yaml
@@ -140,6 +140,6 @@ slug: immich_openvino
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "2.5.2-3"
+version: "2.5.2-4"
 video: true
 webui: http://[HOST]:[PORT:8080]


### PR DESCRIPTION
### Motivation
- Bump Immich add-on versions for standard, CUDA, NoML and OpenVINO to publish a minor bugfix release.
- Keep `CHANGELOG.md` entries in each variant in sync with the new version numbers.

### Description
- Updated the `version` field in `immich/config.yaml` to `2.5.2-3`, in `immich_cuda/config.yaml` to `2.5.2-3`, in `immich_noml/config.yaml` to `2.5.2-3`, and in `immich_openvino/config.yaml` to `2.5.2-4`.
- Prepended a short entry for the new release to `immich/CHANGELOG.md`, `immich_cuda/CHANGELOG.md`, `immich_noml/CHANGELOG.md`, and `immich_openvino/CHANGELOG.md` describing the minor bugfix.
- Changes were staged and committed with the message `Bump Immich add-on versions`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e1a46aab08325b9658086ed66f3a2)