### PR TITLE
Remove TRANSMISSION_V3_UPDATE from config

### DIFF
--- a/transmission_openvpn/config.yaml
+++ b/transmission_openvpn/config.yaml
@@ -91,7 +91,6 @@ options:
   TRANSMISSION_DOWNLOAD_DIR: /share/downloads
   TRANSMISSION_HOME: /config/addons_config/transmission
   TRANSMISSION_INCOMPLETE_DIR: /share/incomplete
-  TRANSMISSION_V3_UPDATE: "true"
   TRANSMISSION_WATCH_DIR: /share/watch_dir
   TRANSMISSION_WEB_UI: flood-for-transmission
   WEBPROXY_ENABLED: "true"


### PR DESCRIPTION
This option keeps creating the following error in Supervisor:
WARNING (MainThread) [supervisor.addons.options] Option 'TRANSMISSION_V3_UPDATE' does not exist in the schema for Transmission Openvpn (db21ed7f_transmission_openvpn)