### PR TITLE
Fix browserless_chrome Dockerfile RUN syntax

### DIFF
--- a/browserless_chrome/Dockerfile
+++ b/browserless_chrome/Dockerfile
@@ -70,7 +70,7 @@ RUN chmod 777 /ha_entrypoint.sh
 ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templates/bashio-standalone.sh" "/usr/local/lib/bashio-standalone.sh"
 RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
 
-RUN \ sed -i "2a /./ha_entrypoint.sh" ./scripts/start.sh
+RUN sed -i "2a /./ha_entrypoint.sh" ./scripts/start.sh
 
 ############
 # 5 Labels #


### PR DESCRIPTION
### Motivation
- The `Build aarch64 browserless_chrome add-on` job failed due to a malformed `RUN \ sed -i ...` instruction in the Dockerfile that breaks the Docker build step.

### Description
- Replace the invalid `RUN \ sed -i "2a /./ha_entrypoint.sh" ./scripts/start.sh` with the correct `RUN sed -i "2a /./ha_entrypoint.sh" ./scripts/start.sh` in `browserless_chrome/Dockerfile`.

### Testing
- Verified the change and absence of the bad pattern using `rg` and inspected the diff with `git` (success); attempted `docker --version` but Docker is not available in this environment so a local image build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698439ff5d80832599b3f23540904ce6)