### PR TITLE
sonarr: add ffmpeg (provides ffprobe) and bump version

### DIFF
--- a/sonarr/CHANGELOG.md
+++ b/sonarr/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 4.0.16.2946-2 (2026-02-06)
+- Add ffmpeg to provide ffprobe for runtime detection (fixes https://github.com/alexbelgium/hassio-addons/issues/2451)
+
 ## 4.0.16.2946-1 (2026-01-08)
 - ⚠ MAJOR CHANGE : switch to the new config logic from homeassistant. Your configuration files will have migrated from /config/addons_config/sonarr to a folder only accessible from my Filebrowser addon called /addon_configs/xxx-sonarr_nas. This avoids the addon to mess with your homeassistant configuration folder, and allows to backup the options. Migration of data should be automatic. Please be sure to update all your links however ! For more information, see here : https://developers.home-assistant.io/blog/2023/11/06/public-addon-config/
 

--- a/sonarr/Dockerfile
+++ b/sonarr/Dockerfile
@@ -57,7 +57,9 @@ RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_auto
 ENV PACKAGES="jq \
     curl \
     cifs-utils \
-    keyutils nginx"
+    keyutils \
+    ffmpeg \
+    nginx"
 
 # Automatic apps & bashio
 ADD "https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.templates/ha_autoapps.sh" "/ha_autoapps.sh"

--- a/sonarr/config.yaml
+++ b/sonarr/config.yaml
@@ -110,4 +110,4 @@ schema:
 slug: sonarr_nas
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/sonarr
-version: "4.0.16.2946-1"
+version: "4.0.16.2946-2"


### PR DESCRIPTION
### Motivation
- Provide `ffprobe` to Sonarr by installing `ffmpeg` in the add-on image to fix runtime detection failures (see issue link below).

### Description
- Add `ffmpeg` to the `ENV PACKAGES` list in `sonarr/Dockerfile` so the image includes `ffprobe`.
- Bump the add-on version in `sonarr/config.yaml` to `4.0.16.2946-2`.
- Add a `sonarr/CHANGELOG.md` entry referencing `https://github.com/alexbelgium/hassio-addons/issues/2451` noting the fix.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698596555b9c8325a8a0699aaac5b812)