### PR TITLE
[SignalK] Add I2C device mappings to SignalK AddOn configuration

### DIFF
--- a/signalk/config.yaml
+++ b/signalk/config.yaml
@@ -11,6 +11,10 @@ devices:
   - /dev/ttyUSB1
   - /dev/ttyACM0
   - /dev/ttyACM1
+  - /dev/i2c-0
+  - /dev/i2c-1
+  - /dev/i2c-13
+  - /dev/i2c-14
 environment:
   HOME: /config
   NMEA0183PORT: "10110"


### PR DESCRIPTION
Add I2C device mappings to configuration. There are SignalK Plugins that can access i2c-devices, but without the device mapping the container does not have permission to open the devices.