### PR TITLE
Update NetBird Server addon metadata: remove ingress and align config fields

### DIFF
--- a/netbird-server/config.yaml
+++ b/netbird-server/config.yaml
@@ -4,14 +4,11 @@ arch:
 description: "\U0001F426 NetBird self-hosted server stack (management, signal, relay, dashboard, Caddy)"
 image: ghcr.io/alexbelgium/netbird-server-{arch}
 init: false
-ingress: false
 map:
   - addon_config:rw
 name: NetBird Server
 options:
   domain: netbird.example.com
-schema:
-  domain: str
 slug: netbird-server
 ports:
   80/tcp: 80
@@ -23,5 +20,8 @@ ports_description:
   443/tcp: Caddy HTTPS (dashboard + APIs)
   443/udp: Caddy HTTP/3 (optional)
   3478/udp: NetBird Relay STUN
-url: https://github.com/alexbelgium/hassio-addons
+schema:
+  domain: str
+url: https://github.com/alexbelgium/hassio-addons/tree/master/netbird-server
 version: 0.64.5-2
+webui: "[PROTO:ssl]://[HOST]:[PORT:443]"


### PR DESCRIPTION
### Motivation
- Remove the explicit `ingress` setting because the add-on should rely on the default behavior instead of an explicit false value.
- Align NetBird Server configuration metadata with other add-ons by adding the `webui` link and updating the `url` to the specific add-on path.
- Reorder and tidy the config fields for consistency with the repository's other `config.yaml` files.

### Description
- Removed the `ingress: false` line from `netbird-server/config.yaml` so the default ingress behavior is used.
- Repositioned and restored the `schema` section under the ports block for consistent structure.
- Updated the `url` to `https://github.com/alexbelgium/hassio-addons/tree/master/netbird-server` to match other add-ons.
- Added a `webui` entry set to `"[PROTO:ssl]://[HOST]:[PORT:443]"` to expose the dashboard link like other add-ons.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988db11dd588325beffa7dd24277536)