### PR TITLE
Use build-provided base image for netbird-server (multi-arch fix)

### DIFF
--- a/netbird-server/Dockerfile
+++ b/netbird-server/Dockerfile
@@ -27,7 +27,7 @@ FROM netbirdio/dashboard:${DASHBOARD_VERSION} AS netbird-dashboard
 #################
 
 ARG BUILD_FROM
-FROM ghcr.io/hassio-addons/base/amd64:stable
+FROM ${BUILD_FROM}
 ENV BASHIO_VERSION=0.14.3
 
 ##################


### PR DESCRIPTION
### Motivation
- CI showed the netbird-server aarch64 build failing because the Dockerfile used a hardcoded amd64 base image, so switch to the build-provided image to enable correct multi-arch builds.

### Description
- Replace the hardcoded base image in `netbird-server/Dockerfile` with the build argument by using `FROM ${BUILD_FROM}` so the job-provided image is used for each architecture.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988e19f061c8325b7d60450dae7355e)