### PR TITLE
Fallback to Home Assistant external/internal URL for NetBird domain

### DIFF
--- a/netbird-server/DOCS.md
+++ b/netbird-server/DOCS.md
@@ -16,7 +16,7 @@ NetBird relies on gRPC. The built-in Caddy configuration is pre-wired to proxy b
 This add-on generates the standard quickstart configuration files in `/config/netbird` and reuses them on subsequent starts.
 
 ### Required options
-- `domain`: Public domain that resolves to your Home Assistant host (e.g., `netbird.example.com`).
+- `domain`: Public domain that resolves to your Home Assistant host (e.g., `netbird.example.com`). If left at the default placeholder, the add-on will try to use the host from Home Assistant's `external_url` or `internal_url` instead.
 
 ### Dashboard environment overrides
 Edit `/config/netbird/dashboard/env` to configure the dashboard UI:


### PR DESCRIPTION
### Motivation
- The add-on failed to generate runtime configs and refused to start when the `domain` option was left at the placeholder `netbird.example.com`, so provide an automatic fallback to recover and allow configuration generation.

### Description
- Update `netbird-server/rootfs/etc/cont-init.d/00-config.sh` to query the Supervisor API and use the host from Home Assistant's `external_url` or `internal_url` when `domain` is empty or set to the placeholder, emitting a warning when the fallback is used.
- Update `netbird-server/DOCS.md` to document that if the `domain` option is left at the default placeholder the add-on will attempt to use Home Assistant's `external_url` or `internal_url`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a01754f188325bdbb762a161e67cf)