### PR TITLE
birdnet-pipy: skip ingress config when inactive and use 0.5.0-2

### DIFF
--- a/birdnet-pipy/CHANGELOG.md
+++ b/birdnet-pipy/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 0.5.0-2 (2026-02-14)
+- Skip ingress nginx configuration when ingress is not active (empty/invalid ingress port)
+
 ## 0.5.0 (2026-02-14)
 - Update to latest version from Suncuss/BirdNET-PiPy (changelog : https://github.com/Suncuss/BirdNET-PiPy/releases)
 

--- a/birdnet-pipy/config.yaml
+++ b/birdnet-pipy/config.yaml
@@ -99,5 +99,5 @@ schema:
   ssl: bool?
 slug: birdnet-pipy
 url: https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-pipy
-version: "0.5.0"
+version: "0.5.0-2"
 webui: "[PROTO:ssl]://[HOST]:[PORT:80]"

--- a/birdnet-pipy/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/birdnet-pipy/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -13,6 +13,11 @@ ingress_port="$(bashio::addon.ingress_port)"
 ingress_interface="$(bashio::addon.ip_address)"
 ingress_entry="$(bashio::addon.ingress_entry)"
 
+if ! [[ "${ingress_port}" =~ ^[0-9]+$ ]] || [[ "${ingress_port}" -le 0 ]]; then
+    bashio::log.info "Ingress not active, skipping ingress nginx configuration"
+    exit 0
+fi
+
 sed -i \
     -e "s|proxy_pass http://api|proxy_pass http://127.0.0.1|g" \
     -e "s|proxy_pass http://icecast|proxy_pass http://127.0.0.1|g" \


### PR DESCRIPTION
### Motivation
- Prevent generation of an invalid `listen` directive when ingress is not active by skipping ingress nginx configuration. 
- Use the requested `-2` version suffix for the add-on version. 
- Ensure a `webui` top-level field exists so frontends and the supervisor can locate the UI. 
- Keep the changelog entry consistent with the new version string. 

### Description
- Add an early-exit guard to `rootfs/etc/cont-init.d/32-nginx_ingress.sh` that checks `ingress_port` is a positive integer and exits when ingress is inactive. 
- Update `config.yaml` to set `version: "0.5.0-2"`. 
- Ensure `webui: "[PROTO:ssl]://[HOST]:[PORT:80]"` is present at the top level of `config.yaml`. 
- Update `CHANGELOG.md` header to `## 0.5.0-2 (2026-02-14)` and preserve the ingress note under that header. 

### Testing
- Ran `bash -n birdnet-pipy/rootfs/etc/cont-init.d/32-nginx_ingress.sh` to validate shell syntax and it succeeded. 
- Ran `rg -n "^webui:" birdnet-pipy/config.yaml` to confirm the `webui` field is present and it returned the expected entry.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69903de39fdc8325814c420d4b4c3eef)