### PR TITLE
birdnet-pipy: disable nginx service when ingress is unavailable

### DIFF
--- a/birdnet-pipy/CHANGELOG.md
+++ b/birdnet-pipy/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.0-4 (2026-02-15)
+- Disable nginx service when ingress is not active
+
+## 0.5.0-3 (2026-02-15)
+- Fix nginx startup without ingress by removing templated resolver dependency
 
 ## 0.5.0-2 (2026-02-14)
 - Skip ingress nginx configuration when ingress is not active (empty/invalid ingress port)

--- a/birdnet-pipy/config.yaml
+++ b/birdnet-pipy/config.yaml
@@ -99,5 +99,5 @@ schema:
   ssl: bool?
 slug: birdnet-pipy
 url: https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-pipy
-version: "0.5.0-2"
+version: "0.5.0-4"
 webui: "[PROTO:ssl]://[HOST]:[PORT:80]"

--- a/birdnet-pipy/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/birdnet-pipy/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -14,9 +14,12 @@ ingress_interface="$(bashio::addon.ip_address)"
 ingress_entry="$(bashio::addon.ingress_entry)"
 
 if ! [[ "${ingress_port}" =~ ^[0-9]+$ ]] || [[ "${ingress_port}" -le 0 ]]; then
-    bashio::log.info "Ingress not active, skipping ingress nginx configuration"
+    bashio::log.info "Ingress not active, disabling nginx service"
+    touch /run/nginx-disabled
     exit 0
 fi
+
+rm -f /run/nginx-disabled
 
 sed -i \
     -e "s|proxy_pass http://api|proxy_pass http://127.0.0.1|g" \
@@ -31,6 +34,3 @@ sed -i \
     /etc/nginx/servers/ingress.conf
 
 sed -i "s#%%ingress_entry%%#${ingress_entry}#g" /etc/nginx/includes/ingress_params.conf
-
-# Set DNS resolver for internal requests
-sed -i "s/%%dns_host%%/127.0.0.11/g" /etc/nginx/includes/resolver.conf

--- a/birdnet-pipy/rootfs/etc/nginx/includes/resolver.conf
+++ b/birdnet-pipy/rootfs/etc/nginx/includes/resolver.conf
@@ -1,1 +1,1 @@
-resolver %%dns_host%%;
+resolver 127.0.0.11 ipv6=off;

--- a/birdnet-pipy/rootfs/etc/services.d/nginx/run
+++ b/birdnet-pipy/rootfs/etc/services.d/nginx/run
@@ -1,4 +1,10 @@
 #!/usr/bin/with-contenv bashio
 # shellcheck shell=bash
 set -euo pipefail
+
+if [ -f /run/nginx-disabled ]; then
+  bashio::log.info "Nginx disabled because ingress is not active"
+  exec sleep infinity
+fi
+
 nginx


### PR DESCRIPTION
### Motivation
- Nginx must not be started when Home Assistant ingress is not active to avoid startup failures and unnecessary services. 
- Ensure the add-on starts cleanly regardless of ingress state and avoid unresolved runtime substitutions for the DNS resolver.

### Description
- Mark nginx as disabled by creating `/run/nginx-disabled` when the ingress port is missing/invalid in `birdnet-pipy/rootfs/etc/cont-init.d/32-nginx_ingress.sh`. 
- Remove the marker when ingress becomes active so nginx can run normally. 
- Update `birdnet-pipy/rootfs/etc/services.d/nginx/run` to no-op (`exec sleep infinity`) when the disabled marker is present instead of launching nginx. 
- Replace the templated resolver with a static Docker resolver (`resolver 127.0.0.11 ipv6=off;`) and remove the runtime `%%dns_host%%` replacement. 
- Bump add-on `version` to `0.5.0-4` and add a short `CHANGELOG.md` entry documenting the change.

### Testing
- Ran `bash -n birdnet-pipy/rootfs/etc/cont-init.d/32-nginx_ingress.sh` and it succeeded. 
- Ran `bash -n birdnet-pipy/rootfs/etc/services.d/nginx/run` and it succeeded. 
- Ran `rg -n "nginx-disabled|Ingress not active, disabling nginx service|Nginx disabled because ingress is not active" birdnet-pipy/rootfs/etc -S` to verify the marker logic and it returned matches as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69916b7f49648325993d0c7ee9c49620)