### PR TITLE
Bump Immich OpenVINO add-on revision to 2.5.6-3

### DIFF
--- a/immich_openvino/CHANGELOG.md
+++ b/immich_openvino/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 2.5.6-3 (2026-02-22)
+- Increment add-on revision.
+
 ## 2.5.6-2 (2026-02-14)
 - Add `VIPS_NOVECTOR` add-on option to set `VIPS_NOVECTOR=1` for thumbnail generation workaround on aarch64 (issue #2460)
 

--- a/immich_openvino/config.yaml
+++ b/immich_openvino/config.yaml
@@ -142,6 +142,6 @@ slug: immich_openvino
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "2.5.6-2"
+version: "2.5.6-3"
 video: true
 webui: http://[HOST]:[PORT:8080]


### PR DESCRIPTION
### Motivation
- Increment the Immich OpenVINO add-on revision to publish a new add-on build and reflect the latest upstream OpenVINO-based release.

### Description
- Updated `version` in `immich_openvino/config.yaml` from `2.5.6-2` to `2.5.6-3`.
- Added a top entry to `immich_openvino/CHANGELOG.md` documenting `2.5.6-3` with the note `Increment add-on revision`.

### Testing
- Verified the upstream release tag with `curl -fsSL https://api.github.com/repos/imagegenius/docker-immich/releases/latest` and extracted the tag successfully.
- Validated file changes with `rg`/`sed` and `git status` to confirm `immich_openvino/config.yaml` and `immich_openvino/CHANGELOG.md` were updated; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b363e4d3c8325b545537414400281)