### PR TITLE
Fix SignalK add-on boot hang when node UID/GID remap fails

### DIFF
--- a/signalk/CHANGELOG.md
+++ b/signalk/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.22.1-1 (2026-02-25)
+- Fix startup hang by handling node UID/GID remap failures gracefully in init script
+
 
 ## 2.22.1 (2026-02-21)
 - Update to latest version from SignalK/signalk-server (changelog : https://github.com/SignalK/signalk-server/releases)

--- a/signalk/config.yaml
+++ b/signalk/config.yaml
@@ -57,5 +57,5 @@ uart: true
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "2.22.1"
+version: "2.22.1-1"
 webui: http://[HOST]:[PORT:3000]

--- a/signalk/rootfs/etc/cont-init.d/99-run.sh
+++ b/signalk/rootfs/etc/cont-init.d/99-run.sh
@@ -16,8 +16,24 @@ chown -R "$USER:$USER" /config
 
 # Set permissions
 echo "... setting permissions for node user"
-usermod -o -u 0 node
-groupmod -o -g 0 node
+if id "$USER" &>/dev/null; then
+    current_uid="$(id -u "$USER")"
+    current_gid="$(id -g "$USER")"
+
+    if [[ "$current_uid" != "0" ]]; then
+        if ! usermod -o -u 0 "$USER"; then
+            bashio::log.warning "Failed to set UID 0 for $USER; continuing with UID $current_uid"
+        fi
+    fi
+
+    if [[ "$current_gid" != "0" ]]; then
+        if ! groupmod -o -g 0 "$USER"; then
+            bashio::log.warning "Failed to set GID 0 for $USER; continuing with GID $current_gid"
+        fi
+    fi
+else
+    bashio::log.warning "User $USER does not exist; continuing without UID/GID remap"
+fi
 
 # Ensure 600 for SSL files
 echo "... specifying security files permissions"


### PR DESCRIPTION
### Motivation
- The SignalK add-on init script ran `usermod`/`groupmod` under `set -e`, causing startup to abort if remapping the `node` user failed and resulting in a hang during boot. 
- The change is intended to allow startup to continue when UID/GID remap commands cannot be applied on some systems while still attempting the remap when appropriate.

### Description
- Updated `signalk/rootfs/etc/cont-init.d/99-run.sh` to check whether the `node` user exists and to read the current UID/GID before attempting remap, and to only call `usermod`/`groupmod` when needed. 
- Each remap command is now guarded so failures do not abort startup; the script logs a warning if `usermod`/`groupmod` fail and continues. 
- Bumped the add-on version in `signalk/config.yaml` to `2.22.1-1` and added an entry to `signalk/CHANGELOG.md` documenting the fix.

### Testing
- Ran a syntax check with `bash -n signalk/rootfs/etc/cont-init.d/99-run.sh`, which completed successfully. 
- Reviewed the resulting diff for the init script, version bump and changelog updates with `git diff` to validate intended changes. 
- The modified init logic prevents early exit on remap failures and preserves normal startup flow (manual review of script control flow).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f6f07552883259d1fd0fad559d0e8)