### PR TITLE
Document community-submitted add-ons and auto-mention submitters on issues

### DIFF
--- a/.github/addon_submitters.json
+++ b/.github/addon_submitters.json
@@ -1,0 +1,4 @@
+{
+  "whatsapper": "baldarn",
+  "spotweb": "woutercoppens"
+}

--- a/.github/workflows/on_issues_ping_submitter.yml
+++ b/.github/workflows/on_issues_ping_submitter.yml
@@ -1,0 +1,52 @@
+---
+name: Issue add-on submitter ping
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  ping_submitter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Ping mapped submitter when add-on is mentioned
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          TEXT="${ISSUE_TITLE} ${ISSUE_BODY}"
+          TEXT_LOWER="$(printf '%s' "$TEXT" | tr '[:upper:]' '[:lower:]')"
+
+          while IFS= read -r addon; do
+            [ -z "$addon" ] && continue
+
+            if [[ "$TEXT_LOWER" == *"$addon"* ]]; then
+              user="$(jq -r --arg addon "$addon" '.[$addon]' .github/addon_submitters.json)"
+              [ -z "$user" ] && continue
+
+              marker="<!-- addon-submitter-ping:${addon} -->"
+              comments_url="https://api.github.com/repos/${REPO}/issues/${ISSUE_NUMBER}/comments"
+
+              existing="$(curl -sS -H "Authorization: Bearer ${GITHUB_TOKEN}" -H 'Accept: application/vnd.github+json' "$comments_url" | jq -r --arg marker "$marker" '[ .[] | select(.body | contains($marker)) ] | length')"
+
+              if [ "$existing" -eq 0 ]; then
+                body=$(jq -cn --arg marker "$marker" --arg addon "$addon" --arg user "$user" '{body: ($marker + "\nHeads up @" + $user + ": this issue appears to mention `" + $addon + "`.")}')
+                curl -sS -X POST \
+                  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                  -H 'Accept: application/vnd.github+json' \
+                  "$comments_url" \
+                  -d "$body" > /dev/null
+              fi
+            fi
+          done < <(jq -r 'keys[]' .github/addon_submitters.json)

--- a/COMMUNITY_SUBMITTED_ADDONS.md
+++ b/COMMUNITY_SUBMITTED_ADDONS.md
@@ -1,0 +1,17 @@
+# Community-submitted add-ons
+
+This repository tracks add-ons that were initially proposed/submitted by community members.
+
+When an issue mentions one of these add-ons (in the title or body), a GitHub Action automatically posts a mention to notify the corresponding person.
+
+## Current list
+
+| Add-on folder | Initial submitter |
+| --- | --- |
+| `whatsapper` | [@baldarn](https://github.com/baldarn) |
+| `spotweb` | [@woutercoppens](https://github.com/woutercoppens) |
+
+## How to update this list
+
+1. Add or update an entry in `.github/addon_submitters.json` with the add-on folder name as key and the GitHub username as value.
+2. Keep this markdown table in sync so it remains visible to users.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ _Thanks to all contributors !_
 
 [![contributors](https://contrib.rocks/image?repo=alexbelgium/hassio-addons)](https://github.com/alexbelgium/hassio-addons/graphs/contributors)
 
+Community-submitted add-ons (and who to ping when related issues are opened): [COMMUNITY_SUBMITTED_ADDONS.md](COMMUNITY_SUBMITTED_ADDONS.md)
+
 Stargazers locations :
 
 ![map](https://raw.githubusercontent.com/alexbelgium/hassio-addons/refs/heads/master/.github/stargazer_map.png)


### PR DESCRIPTION
### Motivation

- Make it visible which add-ons were originally submitted by community members so users know who to contact or credit. 
- Provide an explicit, maintainable source of truth for mapping add-on folders to the original submitter. 
- Automatically notify the mapped submitter when an issue mentions their add-on to improve triage and attribution.

### Description

- Add `COMMUNITY_SUBMITTED_ADDONS.md` as a visible document listing community-submitted add-ons and how to keep the list in sync. 
- Add `.github/addon_submitters.json` as a simple JSON mapping of `addon folder -> GitHub username` (initial entries: `whatsapper`, `spotweb`). 
- Add a GitHub Actions workflow `.github/workflows/on_issues_ping_submitter.yml` that listens for issue `opened`, `edited`, and `reopened` events and posts a one-time mention comment to the mapped submitter when an add-on is detected in the issue title/body, using a hidden marker (`<!-- addon-submitter-ping:<addon> -->`) to avoid duplicate pings. 
- Link the new `COMMUNITY_SUBMITTED_ADDONS.md` from the main `README.md` to make the information easy to find.

### Testing

- Validated the mapping JSON with `jq empty .github/addon_submitters.json` which succeeded. 
- Verified the workflow file contains the expected `issues:` trigger with a small Python check that confirmed the trigger is present. 
- Confirmed repository files were updated and the new workflow and docs exist by inspecting the added files (`COMMUNITY_SUBMITTED_ADDONS.md`, `.github/addon_submitters.json`, `.github/workflows/on_issues_ping_submitter.yml`, and the `README.md` link).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a954d1562c8325ab56a1edc97729e9)