### PR TITLE
Add ingress panel icon for Prowlarr addon

### DIFF
--- a/prowlarr/config.yaml
+++ b/prowlarr/config.yaml
@@ -80,6 +80,7 @@ map:
   - media:rw
   - ssl
 name: Prowlarr NAS
+panel_icon: mdi:magnify
 options:
   env_vars: []
   PGID: 0


### PR DESCRIPTION
### Motivation
- Provide a Material Design Icon for the Prowlarr Home Assistant ingress panel so the sidebar shows a proper icon.

### Description
- Inserted `panel_icon: mdi:magnify` under the `name` key in `prowlarr/config.yaml` to set the ingress panel icon.

### Testing
- Verified the change by running `rg -n "panel_icon" prowlarr/config.yaml` and inspecting the file snippet with `nl -ba prowlarr/config.yaml | sed -n '76,90p'`, both showing `panel_icon: mdi:magnify`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad2522a96c8325ba05999dee1d4475)