### PR TITLE
[SignalK] Use Ingress

### DIFF
--- a/signalk/config.yaml
+++ b/signalk/config.yaml
@@ -59,4 +59,3 @@ udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
 version: "2.23.0"
-webui: http://[HOST]:[PORT:3000]


### PR DESCRIPTION
Hi,

I suggest to use ingress with SignalK. The advantage is, that ingress allows to access the addon using ingress that works as a HA built in proxy. This is specifically helpful when integrating a SignalK webapp in a HomeAssistant instance that is used locally and remotely over VPN. 
If using webui with `[HOST]`, that host will not necessarily be reachable through VPN. 
