### PR TITLE
bump bentopdf to 2.8.2

### DIFF
--- a/bentopdf/CHANGELOG.md
+++ b/bentopdf/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.2
+
+- Update to upstream BentoPDF v2.8.2
+
 ## 2.5.0
 
 - Initial release of BentoPDF Home Assistant add-on

--- a/bentopdf/Dockerfile
+++ b/bentopdf/Dockerfile
@@ -1,6 +1,6 @@
 # Global build args — must be declared before the first FROM to be usable in FROM instructions
 ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.23
-ARG BUILD_VERSION=2.5.0
+ARG BUILD_VERSION=2.8.2
 
 # Stage 1: Download and extract the BentoPDF dist release (includes bundled WASM)
 FROM alpine:3.21 AS dist

--- a/bentopdf/config.yaml
+++ b/bentopdf/config.yaml
@@ -2,7 +2,7 @@ name: "BentoPDF"
 slug: bentopdf
 image: ghcr.io/alexbelgium/bentopdf-{arch}
 description: "Privacy-first PDF toolkit. 50+ tools, all processing client-side in the browser. Files never leave your device."
-version: "2.5.0"
+version: "2.8.2"
 url: "https://github.com/alexbelgium/hassio-addons/tree/master/bentopdf"
 arch:
   - amd64


### PR DESCRIPTION
## Summary
- Bump BentoPDF from v2.5.0 to v2.8.2
- Updates `config.yaml`, `Dockerfile`, and `CHANGELOG.md`

## Test plan
- [x] Verify Docker build pulls correct dist zip for v2.8.2
- [x] Confirm add-on installs and starts on amd64 and aarch64