### PR TITLE
fix(birdnet-pipy): fix icecast crash and Live Feed broken in ingress mode

### DIFF
--- a/birdnet-pipy/CHANGELOG.md
+++ b/birdnet-pipy/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ## 0.6.2 (2026-04-11)
 - Update to latest version from Suncuss/BirdNET-PiPy (changelog : https://github.com/Suncuss/BirdNET-PiPy/releases)
+- Fix Icecast crashing on startup due to log directory permissions (502 Bad Gateway on Live Feed)
+- Fix Live Feed broken in ingress mode — stream config request was double-prefixed by sub_filter
 
 ## 0.6.1 (2026-04-06)
 - Update to latest version from Suncuss/BirdNET-PiPy (changelog : https://github.com/Suncuss/BirdNET-PiPy/releases)

--- a/birdnet-pipy/rootfs/etc/nginx/includes/ingress_params.conf
+++ b/birdnet-pipy/rootfs/etc/nginx/includes/ingress_params.conf
@@ -15,9 +15,11 @@ sub_filter 'src="/' 'src="%%ingress_entry%%/';
 sub_filter '"/api' '"%%ingress_entry%%/api';
 sub_filter "'/api" "'%%ingress_entry%%/api";
 
-# Rewrite stream paths
-sub_filter '"/stream/' '"%%ingress_entry%%/stream/';
-sub_filter "'/stream/" "'%%ingress_entry%%/stream/";
+# Do NOT rewrite "/stream/" — LiveFeed.vue strips the leading slash from
+# stream URLs returned by /api/stream/config so they resolve relative to
+# <base href="%%ingress_entry%%/"> (injected above). Adding a sub_filter
+# for '/stream/' would also rewrite the literal 'api.get("/stream/config")'
+# inside the JS bundle, producing a double-prefixed request.
 
 # Rewrite Socket.IO default path in the client library
 sub_filter '"/socket.io' '"%%ingress_entry%%/socket.io';

--- a/birdnet-pipy/rootfs/etc/services.d/icecast/run
+++ b/birdnet-pipy/rootfs/etc/services.d/icecast/run
@@ -2,4 +2,15 @@
 # shellcheck shell=bash
 set -euo pipefail
 export PULSE_SERVER="${PULSE_SERVER:-unix:/run/pulse/native}"
+
+# Ensure the log directory and file are writable by the icecast2 user.
+# /app/data/logs is created as root by 01-structure.sh, but start-icecast.sh
+# runs via gosu icecast2 and would otherwise fail with "Permission denied"
+# on the first log write, taking icecast down before it can boot.
+mkdir -p /app/data/logs
+touch /app/data/logs/icecast.log
+# Use `icecast2:` (trailing colon) so chown picks the user's primary group,
+# which is `icecast` on Debian, not `icecast2`.
+chown icecast2: /app/data/logs /app/data/logs/icecast.log
+
 gosu icecast2 /usr/local/bin/start-icecast.sh


### PR DESCRIPTION
## Summary

Two fixes for issues introduced by upstream BirdNET-PiPy features (file-based logging in v0.5.8, multi-source audio in v0.6.0) that only surface in the HA single-container environment.

### 1. Icecast crashes on startup (502 Bad Gateway)

`01-structure.sh` creates `/app/data/logs` as root, but icecast runs as `icecast2` via `gosu`. First log write fails → `set -e` kills the script → restart loop.

**Fix:** `chown icecast2:` the log dir/file in `services.d/icecast/run` before dropping privileges. Trailing colon picks the correct primary group (`icecast` on Debian, not `icecast2`).

### 2. Live Feed broken in ingress mode (404)

The `"/stream/"` sub_filter rule also matches `api.get("/stream/config")` in the JS bundle, double-prefixing the request: `/hassio_ingress/TOKEN/api/hassio_ingress/TOKEN/stream/config`.

**Fix:** Remove the `"/stream/"` sub_filter rules. Upstream (>= 0.6.2) now uses relative stream URLs that resolve via the existing `<base href>`.