### PR TITLE
fix(birdnet-pipy): simplify ingress to single <base href> rewrite

### DIFF
--- a/birdnet-pipy/CHANGELOG.md
+++ b/birdnet-pipy/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.3 (2026-04-13)
+- Simplify ingress nginx to a single `<base href>` rewrite. Upstream now declares `<base href="/">` in `index.html` with Vite `base: './'` and uses relative paths for all internal URLs (built assets, axios `baseURL`, socket.io `path`). The previous seven `sub_filter` rules (href/src/`/api`/`/socket.io`) are no longer needed — one `<base href>` replacement is sufficient.
+- Removes incidental brittleness from byte-level `sub_filter` matches in minified JS bundles (the old `/stream/` rule had inadvertently double-prefixed the literal `api.get("/stream/config")` string).
+- Update to latest version from Suncuss/BirdNET-PiPy (changelog : https://github.com/Suncuss/BirdNET-PiPy/releases)
+
 ## 0.6.2-2 (11-04-2026)
 - Minor bugs fixed
 

--- a/birdnet-pipy/config.yaml
+++ b/birdnet-pipy/config.yaml
@@ -97,4 +97,4 @@ schema:
   ssl: bool?
 slug: birdnet-pipy
 url: https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-pipy
-version: "0.6.2-2"
+version: "0.6.3"

--- a/birdnet-pipy/rootfs/etc/nginx/includes/ingress_params.conf
+++ b/birdnet-pipy/rootfs/etc/nginx/includes/ingress_params.conf
@@ -1,26 +1,12 @@
 absolute_redirect off;
 rewrite ^%%ingress_entry%%/(.*)$ /$1 break;
-sub_filter_once off;
-sub_filter_types *;
+sub_filter_once on;
+sub_filter_types text/html;
 
-# Inject <base href> for Vue Router history mode and static asset loading
-sub_filter '<head>' '<head><base href="%%ingress_entry%%/">';
-
-# Rewrite absolute href/src attributes in HTML
-sub_filter 'href="/' 'href="%%ingress_entry%%/';
-sub_filter 'src="/' 'src="%%ingress_entry%%/';
-
-# Rewrite API paths in JS bundles (axios baseURL and fetch calls)
-# Pattern includes baseURL:"/api" (no trailing slash) so "/api" is needed
-sub_filter '"/api' '"%%ingress_entry%%/api';
-sub_filter "'/api" "'%%ingress_entry%%/api";
-
-# Do NOT rewrite "/stream/" — LiveFeed.vue strips the leading slash from
-# stream URLs returned by /api/stream/config so they resolve relative to
-# <base href="%%ingress_entry%%/"> (injected above). Adding a sub_filter
-# for '/stream/' would also rewrite the literal 'api.get("/stream/config")'
-# inside the JS bundle, producing a double-prefixed request.
-
-# Rewrite Socket.IO default path in the client library
-sub_filter '"/socket.io' '"%%ingress_entry%%/socket.io';
-sub_filter "'/socket.io" "'%%ingress_entry%%/socket.io";
+# Rewrite the frontend's default <base href="/" /> to the ingress prefix so
+# all relative URLs (assets, axios baseURL, socket.io path) resolve under
+# ingress. The frontend declares BASE once via this tag; no other rewrites
+# are needed. Pattern deliberately omits the closing bracket so it matches
+# both self-closing (<base href="/" />) and non-self-closing (<base href="/">)
+# forms. sub_filter_once above ensures only the first occurrence is touched.
+sub_filter '<base href="/"' '<base href="%%ingress_entry%%/"';

--- a/birdnet-pipy/updater.json
+++ b/birdnet-pipy/updater.json
@@ -1,8 +1,8 @@
 {
-  "last_update": "2026-04-11",
+  "last_update": "2026-04-13",
   "repository": "alexbelgium/hassio-addons",
   "slug": "birdnet-pipy",
   "source": "github",
   "upstream_repo": "Suncuss/BirdNET-PiPy",
-  "upstream_version": "0.6.2"
+  "upstream_version": "0.6.3"
 }


### PR DESCRIPTION
## Summary

- Aligns with upstream [Suncuss/BirdNET-PiPy v0.6.3](https://github.com/Suncuss/BirdNET-PiPy/releases/tag/v0.6.3), which declares `<base href="/">` in `index.html` and makes all internal URLs relative (Vite `base: './'`, axios `baseURL = BASE + 'api'`, socket.io `path = BASE + 'socket.io'`).
- Replaces seven `sub_filter` rules with one `<base href>` rewrite — removes the byte-match-in-JS-bundle brittleness that caused the `/stream/` double-prefix bug in 0.6.2.
- Version bumped to `0.6.3` to trigger CI.