### PR TITLE
birdnet-pipy: bump to 0.6.6

### DIFF
--- a/birdnet-pipy/CHANGELOG.md
+++ b/birdnet-pipy/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 0.6.6 (2026-04-21)
+- Update to latest version from Suncuss/BirdNET-PiPy (changelog : https://github.com/Suncuss/BirdNET-PiPy/releases)
+
 ## 0.6.4 (2026-04-18)
 - Update to latest version from Suncuss/BirdNET-PiPy (changelog : https://github.com/Suncuss/BirdNET-PiPy/releases)
 ## 0.6.3-3 (2026-04-17)
@@ -13,7 +16,7 @@
 - Removes incidental brittleness from byte-level `sub_filter` matches in minified JS bundles (the old `/stream/` rule had inadvertently double-prefixed the literal `api.get("/stream/config")` string).
 - Update to latest version from Suncuss/BirdNET-PiPy (changelog : https://github.com/Suncuss/BirdNET-PiPy/releases)
 
-## 0.6.2-2 (11-04-2026)
+## 0.6.2-2 (2026-04-11)
 - Minor bugs fixed
 
 ## 0.6.2 (2026-04-11)
@@ -39,21 +42,21 @@
 
 ## 0.5.6 (2026-03-07)
 - Update to latest version from Suncuss/BirdNET-PiPy (changelog : https://github.com/Suncuss/BirdNET-PiPy/releases)
-## 0.5.5-2 (04-03-2026)
+## 0.5.5-2 (2026-03-04)
 - Minor bugs fixed
 
 ## 0.5.5 (2026-03-02)
 - Update to latest version from Suncuss/BirdNET-PiPy (changelog : https://github.com/Suncuss/BirdNET-PiPy/releases)
-## 0.5.4-3 (26-02-2026)
+## 0.5.4-3 (2026-02-26)
 - Minor bugs fixed
-## 0.5.4-2 (23-02-2026)
+## 0.5.4-2 (2026-02-23)
 - Fix Icecast service failing to connect to PulseAudio on HAOS by respecting PULSE_SERVER env var and setting up socket symlink and auth cookie for icecast2 user
 
 ## 0.5.4 (2026-02-21)
 - Update to latest version from Suncuss/BirdNET-PiPy (changelog : https://github.com/Suncuss/BirdNET-PiPy/releases)
-## 0.5.0-6 (15-02-2026)
+## 0.5.0-6 (2026-02-15)
 - Minor bugs fixed
-## 0.5.0-5 (15-02-2026)
+## 0.5.0-5 (2026-02-15)
 - Minor bugs fixed
 ## 0.5.0-4 (2026-02-15)
 - Disable nginx service when ingress is not active
@@ -69,31 +72,20 @@
 
 ## 0.4.0 (2026-02-07)
 - Update to latest version from Suncuss/BirdNET-PiPy (changelog : https://github.com/Suncuss/BirdNET-PiPy/releases)
-## 0.3.2-6 (01-02-2026)
+## 0.3.2-6 (2026-02-01)
 - Minor bugs fixed
-## 0.3.2-5 (01-02-2026)
+## 0.3.2-5 (2026-02-01)
 - Minor bugs fixed
-## 0.3.2-4 (31-01-2026)
+## 0.3.2-4 (2026-01-31)
 - Minor bugs fixed
-## 0.3.2-2 (31-01-2026)
+## 0.3.2-2 (2026-01-31)
 - Minor bugs fixed
 
 ## 0.3.2-3 (2026-01-30)
 - Build frontend with /birdnet/ base path and serve under /birdnet/ for ingress compatibility.
 ## 0.3.2 (2026-01-30)
 - Update to latest version from Suncuss/BirdNET-PiPy (changelog : https://github.com/Suncuss/BirdNET-PiPy/releases)
-## 0.6.6 (30-01-2026)
-- Minor bugs fixed
-## 0.6.5 (30-01-2026)
-- Minor bugs fixed
-## 0.6.3 (29-01-2026)
-- Minor bugs fixed
-## 0.6.2 (29-01-2026)
-- Use upstream nginx.conf and generate ingress config at startup
-## 0.6.1 (29-01-2026)
-- Minor bugs fixed
-## 0.2 (29-01-2026)
-- Minor bugs fixed
+
 # Changelog
 
 ## 0.1.0

--- a/birdnet-pipy/config.yaml
+++ b/birdnet-pipy/config.yaml
@@ -96,4 +96,4 @@ schema:
   ssl: bool?
 slug: birdnet-pipy
 url: https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-pipy
-version: "0.6.4"
+version: "0.6.6"

--- a/birdnet-pipy/updater.json
+++ b/birdnet-pipy/updater.json
@@ -1,8 +1,8 @@
 {
-  "last_update": "2026-04-18",
+  "last_update": "2026-04-21",
   "repository": "alexbelgium/hassio-addons",
   "slug": "birdnet-pipy",
   "source": "github",
   "upstream_repo": "Suncuss/BirdNET-PiPy",
-  "upstream_version": "0.6.4"
+  "upstream_version": "0.6.6"
 }


### PR DESCRIPTION
## Summary
- Bump birdnet-pipy to 0.6.6 (upstream tags v0.6.5 + v0.6.6; skipping 0.6.5 same as the updater bot would)
- Minor CHANGELOG.md cleanup while here: normalize 10 entries from DD-MM-YYYY → YYYY-MM-DD, and remove a stale pre-ingress block (0.2, 0.6.1–0.6.6 dated Jan 2026) that was colliding with real version numbers further up the file

