### PR TITLE
Allow Mealie addon usage for non-admins

### DIFF
--- a/mealie/config.yaml
+++ b/mealie/config.yaml
@@ -92,6 +92,7 @@ options:
   certfile: fullchain.pem
   keyfile: privkey.pem
   ssl: false
+panel_admin: false
 panel_icon: mdi:silverware-fork-knife
 ports:
   9001/tcp: 9090


### PR DESCRIPTION
It would be cool to share this add-on with non-admin users in HA. Luckily there is a config option to allow it.