### PR TITLE
birdnet-pipy: wait for upstream API in nginx run instead of sleep

### DIFF
--- a/birdnet-pipy/CHANGELOG.md
+++ b/birdnet-pipy/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.6.6-4 (2026-05-02)
+- Fix nginx startup: wait for the upstream API on `127.0.0.1:5002` before starting nginx, instead of the prior `sleep 5` workaround. Under s6-overlay all `services.d/*` services start concurrently, so nginx could begin accepting requests before `core.api` had bound its port — `/api/`, `/socket.io/`, and `/internal/auth` would then return 502, and that 502 could be cached by an upstream service worker / edge cache (e.g. behind Cloudflare-fronted HA), leaving the UI stuck blank. Uses `bashio::net.wait_for` to match the pattern in sister addons (`bazarr`, `jellyfin`, `radarr`).
 ## 0.6.6-3 (23-04-2026)
 - Minor bugs fixed
 ## 0.6.6-2 (23-04-2026)

--- a/birdnet-pipy/config.yaml
+++ b/birdnet-pipy/config.yaml
@@ -96,4 +96,4 @@ schema:
   ssl: bool?
 slug: birdnet-pipy
 url: https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-pipy
-version: "0.6.6-3"
+version: "0.6.6-4"

--- a/birdnet-pipy/rootfs/etc/services.d/nginx/run
+++ b/birdnet-pipy/rootfs/etc/services.d/nginx/run
@@ -2,13 +2,13 @@
 # shellcheck shell=bash
 set -euo pipefail
 
-# Wait for ingress configuration to be generated
-while [ ! -f /etc/nginx/servers/ingress.conf ]; do
-    bashio::log.info "Waiting for /etc/nginx/servers/ingress.conf..."
-    sleep 1
-done
+# Wait for the upstream API service (Python core.api) to bind 127.0.0.1:5002
+# before starting nginx, so nginx never serves a 502 for the API/auth/socket
+# paths during boot. A boot-time 502 can be cached by an upstream cache layer
+# (HA's own PWA service worker, a Cloudflare edge worker, etc.), leaving the
+# UI in a stuck blank state until the cache is purged.
+bashio::log.info "Waiting for upstream API on 127.0.0.1:5002..."
+bashio::net.wait_for 5002 127.0.0.1 900
 
-# Wait to be sure the script fully executed
-sleep 5
-
-nginx
+bashio::log.info "Starting NGinx..."
+exec nginx


### PR DESCRIPTION
## Summary
- Replace the `0.6.6-3` `sleep 5` + ingress-file-loop in `services.d/nginx/run` with `bashio::net.wait_for 5002 127.0.0.1` — gate nginx on the `core.api` upstream binding instead of a fixed delay. Prevents boot-time 502s on `/api/`, `/socket.io/`, `/internal/auth` (visible as a stuck blank UI when an upstream cache layer caches the 502).
- Matches the pattern in `bazarr`, `jellyfin`, `radarr`; also switches to `exec nginx` for s6 supervision.
- Version `0.6.6-4`.