### PR TITLE
fix: force IPv4 host resolution for MariaDB addon connections (#2688)

### DIFF
--- a/fireflyiii/CHANGELOG.md
+++ b/fireflyiii/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 6.6.2-1 (2026-05-10)
+- Fix MariaDB connection on HAOS >=17.3 by forcing IPv4 host resolution (#2688)
+
 ## 6.6.2 (2026-05-02)
 - Update to latest version from firefly-iii/firefly-iii (changelog : https://github.com/firefly-iii/firefly-iii/releases)
 

--- a/fireflyiii/config.yaml
+++ b/fireflyiii/config.yaml
@@ -104,5 +104,5 @@ slug: fireflyiii
 startup: services
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "6.6.2"
+version: "6.6.2-1"
 webui: "[PROTO:ssl]://[HOST]:[PORT:8080]"

--- a/fireflyiii/rootfs/etc/cont-init.d/99-run.sh
+++ b/fireflyiii/rootfs/etc/cont-init.d/99-run.sh
@@ -86,9 +86,18 @@ case $(bashio::config 'DB_CONNECTION') in
                 "Please ensure it is installed and started"
         fi
 
+        # Resolve MariaDB hostname to IPv4: on HAOS >=17.3 the Supervisor network
+        # gained IPv6, but the MariaDB addon only grants its user from the IPv4
+        # subnet (issue #2688). Fall back to the raw hostname if resolution fails.
+        mariadb_host_raw="$(bashio::services "mysql" "host")"
+        mariadb_host_ipv4="$(getent ahostsv4 "$mariadb_host_raw" 2> /dev/null | awk '{print $1; exit}')"
+        DB_HOST="${mariadb_host_ipv4:-$mariadb_host_raw}"
+        if [ "$DB_HOST" != "$mariadb_host_raw" ]; then
+            bashio::log.info "Resolved ${mariadb_host_raw} -> ${DB_HOST} (forcing IPv4)"
+        fi
+
         # Use values
         DB_CONNECTION=mysql
-        DB_HOST=$(bashio::services "mysql" "host")
         DB_PORT=$(bashio::services "mysql" "port")
 
         # Always fetch service discovery credentials for bootstrap operations (CREATE DATABASE)

--- a/monica/CHANGELOG.md
+++ b/monica/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.0b5-3 (2026-05-10)
+- Fix MariaDB connection on HAOS >=17.3 by forcing IPv4 host resolution (#2688)
+
 ## 5.0.0b5-2 (26-02-2026)
 - Minor bugs fixed
 

--- a/monica/config.yaml
+++ b/monica/config.yaml
@@ -108,5 +108,5 @@ services:
   - mysql:want
 slug: monica
 url: https://github.com/alexbelgium/hassio-addons/tree/master/monica
-version: "5.0.0b5-2"
+version: "5.0.0b5-3"
 webui: "[PROTO:ssl]://[HOST]:[PORT:80]"

--- a/monica/rootfs/etc/cont-init.d/99-run.sh
+++ b/monica/rootfs/etc/cont-init.d/99-run.sh
@@ -45,8 +45,18 @@ case "$database" in
             bashio::exit.nok "Please ensure it is installed and started"
         fi
 
+        # Resolve MariaDB hostname to IPv4: on HAOS >=17.3 the Supervisor network
+        # gained IPv6, but the MariaDB addon only grants its user from the IPv4
+        # subnet (issue #2688). Fall back to the raw hostname if resolution fails.
+        mariadb_host_raw="$(bashio::services "mysql" "host")"
+        mariadb_host_ipv4="$(getent ahostsv4 "$mariadb_host_raw" 2> /dev/null | awk '{print $1; exit}')"
+        DB_HOST="${mariadb_host_ipv4:-$mariadb_host_raw}"
+        if [ "$DB_HOST" != "$mariadb_host_raw" ]; then
+            bashio::log.info "Resolved ${mariadb_host_raw} -> ${DB_HOST} (forcing IPv4)"
+        fi
+
         # Use values
-        DB_HOST=$(bashio::services "mysql" "host") && bashio::log.blue "DB_HOST=$DB_HOST" && sed -i "1a export DB_HOST=$DB_HOST" /usr/local/bin/entrypoint.sh
+        bashio::log.blue "DB_HOST=$DB_HOST" && sed -i "1a export DB_HOST=$DB_HOST" /usr/local/bin/entrypoint.sh
         DB_PORT=$(bashio::services "mysql" "port") && bashio::log.blue "DB_PORT=$DB_PORT" && sed -i "1a export DB_PORT=$DB_PORT" /usr/local/bin/entrypoint.sh
         DB_DATABASE=monica && bashio::log.blue "DB_DATABASE=$DB_DATABASE" && sed -i "1a export DB_DATABASE=$DB_DATABASE" /usr/local/bin/entrypoint.sh
         DB_USERNAME=$(bashio::services "mysql" "username") && bashio::log.blue "DB_USERNAME=$DB_USERNAME" && sed -i "1a export DB_USERNAME=$DB_USERNAME" /usr/local/bin/entrypoint.sh

--- a/photoprism/CHANGELOG.md
+++ b/photoprism/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## ubuntu-2026-03-05-1 (2026-05-10)
+- Fix MariaDB connection on HAOS >=17.3 by forcing IPv4 host resolution (#2688)
+
 ## ubuntu-2026-03-05 (2026-03-05)
 - Update to latest version from photoprism/photoprism
 ## ubuntu-2025-11-30-4 (26-02-2026)

--- a/photoprism/config.yaml
+++ b/photoprism/config.yaml
@@ -131,5 +131,5 @@ services:
 slug: photoprism
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "ubuntu-2026-03-05"
+version: "ubuntu-2026-03-05-1"
 video: true

--- a/photoprism/rootfs/etc/cont-init.d/99-run.sh
+++ b/photoprism/rootfs/etc/cont-init.d/99-run.sh
@@ -28,9 +28,20 @@ case $(bashio::config 'DB_TYPE') in
         # Install mysqlclient
         pip install pymysql &> /dev/null || true
 
+        # Resolve MariaDB hostname to IPv4: on HAOS >=17.3 the Supervisor network
+        # gained IPv6, but the MariaDB addon only grants its user from the IPv4
+        # subnet (issue #2688). Fall back to the raw hostname if resolution fails.
+        mariadb_host_raw="$(bashio::services 'mysql' 'host')"
+        mariadb_host_ipv4="$(getent ahostsv4 "$mariadb_host_raw" 2> /dev/null | awk '{print $1; exit}')"
+        mariadb_host="${mariadb_host_ipv4:-$mariadb_host_raw}"
+        if [ "$mariadb_host" != "$mariadb_host_raw" ]; then
+            bashio::log.info "Resolved ${mariadb_host_raw} -> ${mariadb_host} (forcing IPv4)"
+        fi
+        mariadb_port="$(bashio::services 'mysql' 'port')"
+
         # Use values
         PHOTOPRISM_DATABASE_DRIVER="mysql"
-        PHOTOPRISM_DATABASE_SERVER="$(bashio::services 'mysql' 'host'):$(bashio::services 'mysql' 'port')"
+        PHOTOPRISM_DATABASE_SERVER="${mariadb_host}:${mariadb_port}"
         PHOTOPRISM_DATABASE_NAME="photoprism"
         PHOTOPRISM_DATABASE_USER="$(bashio::services 'mysql' 'username')"
         PHOTOPRISM_DATABASE_PASSWORD="$(bashio::services 'mysql' 'password')"
@@ -58,9 +69,9 @@ case $(bashio::config 'DB_TYPE') in
         bashio::log.warning "Uninstalling the MariaDB addon will remove any data"
 
         # Create database
-        mysql --skip-ssl --host="$(bashio::services 'mysql' 'host')" --port="$(bashio::services 'mysql' 'port')" --user="$PHOTOPRISM_DATABASE_USER" --password="$PHOTOPRISM_DATABASE_PASSWORD" -e"CREATE DATABASE IF NOT EXISTS $PHOTOPRISM_DATABASE_NAME;"
+        mysql --skip-ssl --host="${mariadb_host}" --port="${mariadb_port}" --user="$PHOTOPRISM_DATABASE_USER" --password="$PHOTOPRISM_DATABASE_PASSWORD" -e"CREATE DATABASE IF NOT EXISTS $PHOTOPRISM_DATABASE_NAME;"
         # Force character set
-        mysql --skip-ssl --host="$(bashio::services 'mysql' 'host')" --port="$(bashio::services 'mysql' 'port')" --user="$PHOTOPRISM_DATABASE_USER" --password="$PHOTOPRISM_DATABASE_PASSWORD" -e"ALTER DATABASE $PHOTOPRISM_DATABASE_NAME CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;" || true
+        mysql --skip-ssl --host="${mariadb_host}" --port="${mariadb_port}" --user="$PHOTOPRISM_DATABASE_USER" --password="$PHOTOPRISM_DATABASE_PASSWORD" -e"ALTER DATABASE $PHOTOPRISM_DATABASE_NAME CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;" || true
         ;;
 esac
 

--- a/seafile/CHANGELOG.md
+++ b/seafile/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 12.0.18-3 (2026-05-10)
+- Fix MariaDB connection on HAOS >=17.3 by forcing IPv4 host resolution (#2688)
+
 ## 12.0.18-2 (2026-02-22)
 - Fix download URLs containing incorrect `/seafhttp` prefix on first run by re-applying URL configuration after upstream init scripts complete.
 

--- a/seafile/config.yaml
+++ b/seafile/config.yaml
@@ -128,5 +128,5 @@ services:
 slug: seafile
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/seafile
-version: "12.0.18-2"
+version: "12.0.18-3"
 webui: http://[HOST]:[PORT:8000]

--- a/seafile/rootfs/etc/cont-init.d/99-run.sh
+++ b/seafile/rootfs/etc/cont-init.d/99-run.sh
@@ -206,8 +206,18 @@ case "${DATABASE_SELECTION}" in
                 "Please ensure it is installed and started"
         fi
 
+        # Resolve MariaDB hostname to IPv4: on HAOS >=17.3 the Supervisor network
+        # gained IPv6, but the MariaDB addon only grants its user from the IPv4
+        # subnet (issue #2688). Fall back to the raw hostname if resolution fails.
+        mariadb_host_raw="$(bashio::services 'mysql' 'host')"
+        mariadb_host_ipv4="$(getent ahostsv4 "$mariadb_host_raw" 2> /dev/null | awk '{print $1; exit}')"
+        MYSQL_HOST_RESOLVED="${mariadb_host_ipv4:-$mariadb_host_raw}"
+        if [ "$MYSQL_HOST_RESOLVED" != "$mariadb_host_raw" ]; then
+            bashio::log.info "Resolved ${mariadb_host_raw} -> ${MYSQL_HOST_RESOLVED} (forcing IPv4)"
+        fi
+
         # Use values
-        export MYSQL_HOST="$(bashio::services 'mysql' 'host')" && sed -i "1a export MYSQL_HOST=$(bashio::services 'mysql' 'host')" /home/seafile/*.sh
+        export MYSQL_HOST="$MYSQL_HOST_RESOLVED" && sed -i "1a export MYSQL_HOST=${MYSQL_HOST_RESOLVED}" /home/seafile/*.sh
         export MYSQL_PORT="$(bashio::services 'mysql' 'port')" && sed -i "1a export MYSQL_PORT=$(bashio::services 'mysql' 'port')" /home/seafile/*.sh
         export MYSQL_USER="$(bashio::services "mysql" "username")" && sed -i "1a export MYSQL_USER=$(bashio::services 'mysql' 'username')" /home/seafile/*.sh
         export MYSQL_USER_PASSWD="$(bashio::services "mysql" "password")" && sed -i "1a export MYSQL_USER_PASSWD=$(bashio::services 'mysql' 'password')" /home/seafile/*.sh

--- a/zoneminder/CHANGELOG.md
+++ b/zoneminder/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 1.38.1-1 (2026-05-10)
+- Fix MariaDB connection on HAOS >=17.3 by forcing IPv4 host resolution (#2688)
+
 ## 1.38.1 (2026-02-21)
 - Update to latest version from zoneminder-containers/zoneminder-base (changelog : https://github.com/zoneminder-containers/zoneminder-base/releases)
 

--- a/zoneminder/config.yaml
+++ b/zoneminder/config.yaml
@@ -95,5 +95,5 @@ services:
 slug: zoneminder
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "1.38.1"
+version: "1.38.1-1"
 webui: "[PROTO:ssl]://[HOST]:[PORT:80]/zm"

--- a/zoneminder/rootfs/etc/cont-init.d/99-run.sh
+++ b/zoneminder/rootfs/etc/cont-init.d/99-run.sh
@@ -36,7 +36,7 @@ case "$(bashio::config "DB_CONNECTION")" in
         # gained IPv6, but the MariaDB addon only grants its user from the IPv4
         # subnet (issue #2688). Fall back to the raw hostname if resolution fails.
         mariadb_host_raw="$(bashio::services "mysql" "host")"
-        mariadb_host_ipv4="$(getent ahostsv4 "$mariadb_host_raw" 2> /dev/null | awk '{print $1; exit}')"
+        mariadb_host_ipv4="$({ getent ahostsv4 "$mariadb_host_raw" 2> /dev/null || true; } | awk '{print $1; exit}')"
         ZM_DB_HOST="${mariadb_host_ipv4:-$mariadb_host_raw}"
         if [ "$ZM_DB_HOST" != "$mariadb_host_raw" ]; then
             bashio::log.info "Resolved ${mariadb_host_raw} -> ${ZM_DB_HOST} (forcing IPv4)"

--- a/zoneminder/rootfs/etc/cont-init.d/99-run.sh
+++ b/zoneminder/rootfs/etc/cont-init.d/99-run.sh
@@ -31,7 +31,16 @@ case "$(bashio::config "DB_CONNECTION")" in
 
         DB_CONNECTION="mysql"
         remoteDB="1"
-        ZM_DB_HOST="$(bashio::services "mysql" "host")"
+
+        # Resolve MariaDB hostname to IPv4: on HAOS >=17.3 the Supervisor network
+        # gained IPv6, but the MariaDB addon only grants its user from the IPv4
+        # subnet (issue #2688). Fall back to the raw hostname if resolution fails.
+        mariadb_host_raw="$(bashio::services "mysql" "host")"
+        mariadb_host_ipv4="$(getent ahostsv4 "$mariadb_host_raw" 2> /dev/null | awk '{print $1; exit}')"
+        ZM_DB_HOST="${mariadb_host_ipv4:-$mariadb_host_raw}"
+        if [ "$ZM_DB_HOST" != "$mariadb_host_raw" ]; then
+            bashio::log.info "Resolved ${mariadb_host_raw} -> ${ZM_DB_HOST} (forcing IPv4)"
+        fi
         ZM_DB_PORT="$(bashio::services "mysql" "port")"
         ZM_DB_NAME="zm"
         ZM_DB_USER="$(bashio::services "mysql" "username")"


### PR DESCRIPTION
On HAOS >=17.3 the Supervisor Docker network gained IPv6, so
core-mariadb resolves to an IPv6 address first. The official MariaDB
addon only grants its service user from the IPv4 supervisor subnet, so
connections from IPv6 fail with "Access denied".

Resolve the hostname to its IPv4 address before connecting in every
addon that consumes bashio::services 'mysql' 'host': photoprism,
monica, fireflyiii, seafile, zoneminder. Fall back to the raw hostname
if resolution fails so IPv4-only setups keep working unchanged.