### PR TITLE
Fix qBittorrent restart loop: dynamic binary discovery and remove s6-notifyoncheck

### DIFF
--- a/qbittorrent/CHANGELOG.md
+++ b/qbittorrent/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 5.2.0-2 (2026-05-10)
+- Fix qBittorrent restart loop: remove s6-notifyoncheck (avoids notification-fd EBADF crash) and discover binary path dynamically across LSIO image layouts
+
 ## 5.2.0-1 (2026-05-10)
 - Fix qbittorrent-nox path (/usr/bin → /app) after LSIO image update
 

--- a/qbittorrent/config.yaml
+++ b/qbittorrent/config.yaml
@@ -143,4 +143,4 @@ schema:
 slug: qbittorrent
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "5.2.0-1"
+version: "5.2.0-2"

--- a/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
+++ b/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
@@ -42,8 +42,20 @@ if bashio::config.true 'silent'; then
     QB_OUTPUT="/dev/null"
 fi
 
+# Find qbittorrent-nox binary across different LSIO image layouts
+QB_BIN=""
+for candidate in /app/qbittorrent-nox /usr/bin/qbittorrent-nox /usr/local/bin/qbittorrent-nox; do
+    if [[ -x "${candidate}" ]]; then
+        QB_BIN="${candidate}"
+        break
+    fi
+done
+
+if [[ -z "${QB_BIN}" ]]; then
+    bashio::log.fatal "qbittorrent-nox binary not found"
+    exit 1
+fi
+
 bashio::log.info "Starting qBittorrent..."
 
-exec \
-    s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost ${WEBUI_PORT}" \
-    s6-setuidgid abc /app/qbittorrent-nox --webui-port="${WEBUI_PORT}" > "${QB_OUTPUT}"
+exec s6-setuidgid abc "${QB_BIN}" --webui-port="${WEBUI_PORT}" > "${QB_OUTPUT}"


### PR DESCRIPTION
s6-notifyoncheck exits with EBADF when notification-fd 3 isn't opened by
s6-rc (can happen depending on LSIO image layer order), killing the supervised
qBittorrent process and causing the 2-second restart loop. Dropping it lets
s6 supervise qBittorrent directly without the fragile fd notification path.

Also probe /app, /usr/bin, and /usr/local/bin for the binary so the addon
works across LSIO image builds that place qbittorrent-nox in different spots.

https://claude.ai/code/session_015eiGSjWjSVtKbBFhBHUeDt