### PR TITLE
fix(seafile): seed admin credentials so first-run setup completes

### DIFF
--- a/seafile/CHANGELOG.md
+++ b/seafile/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 12.0.18-4 (2026-05-10)
+- Fix admin account creation by writing `conf/admin.txt` and seeding `seafile.env` with `SEAFILE_ADMIN_EMAIL`/`SEAFILE_ADMIN_PASSWORD` so the upstream `check_init_admin.py` no longer falls back to an interactive prompt (#2685)
+
 ## 12.0.18-3 (2026-05-10)
 - Fix MariaDB connection on HAOS >=17.3 by forcing IPv4 host resolution (#2688)
 

--- a/seafile/config.yaml
+++ b/seafile/config.yaml
@@ -128,5 +128,5 @@ services:
 slug: seafile
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/seafile
-version: "12.0.18-3"
+version: "12.0.18-4"
 webui: http://[HOST]:[PORT:8000]

--- a/seafile/rootfs/etc/cont-init.d/99-run.sh
+++ b/seafile/rootfs/etc/cont-init.d/99-run.sh
@@ -124,9 +124,22 @@ if [[ -n "${ADMIN_EMAIL_VAL}" && "${ADMIN_EMAIL_VAL}" != "null" \
     touch "${SEAFILE_ENV_FILE}"
     sed -i '/^SEAFILE_ADMIN_EMAIL=/d' "${SEAFILE_ENV_FILE}"
     sed -i '/^SEAFILE_ADMIN_PASSWORD=/d' "${SEAFILE_ENV_FILE}"
+
+    case "${ADMIN_EMAIL_VAL}" in
+        *$'\n'*|*$'\r'*)
+            bashio::exit.nok "SEAFILE_ADMIN_EMAIL must not contain newlines"
+            ;;
+    esac
+
+    case "${ADMIN_PASSWORD_VAL}" in
+        *$'\n'*|*$'\r'*)
+            bashio::exit.nok "SEAFILE_ADMIN_PASSWORD must not contain newlines"
+            ;;
+    esac
+
     {
-        printf 'SEAFILE_ADMIN_EMAIL=%q\n' "${ADMIN_EMAIL_VAL}"
-        printf 'SEAFILE_ADMIN_PASSWORD=%q\n' "${ADMIN_PASSWORD_VAL}"
+        printf 'SEAFILE_ADMIN_EMAIL=%s\n' "${ADMIN_EMAIL_VAL}"
+        printf 'SEAFILE_ADMIN_PASSWORD=%s\n' "${ADMIN_PASSWORD_VAL}"
     } >> "${SEAFILE_ENV_FILE}"
     chown seafile:seafile "${SEAFILE_ENV_FILE}"
     chmod 600 "${SEAFILE_ENV_FILE}"

--- a/seafile/rootfs/etc/cont-init.d/99-run.sh
+++ b/seafile/rootfs/etc/cont-init.d/99-run.sh
@@ -94,6 +94,43 @@ sed -i "s|/shared|$DATA_LOCATION|g" /docker_entrypoint.sh
 sed -i "s|/shared|$DATA_LOCATION|g" /home/seafile/*.sh
 #sed -i "s=cp -r ./media $DATA_LOCATION/=chown -R seafile:seafile $DATA_LOCATION/* && chmod -R 777 $DATA_LOCATION/media && cp -rnf ./media/. $DATA_LOCATION/media ||true=g" /home/seafile/*.sh
 
+#####################
+# Admin credentials #
+#####################
+
+# Seafile's check_init_admin.py looks for SEAFILE_ADMIN_EMAIL and
+# SEAFILE_ADMIN_PASSWORD in the env, then falls back to conf/admin.txt, and
+# only prompts interactively if neither is available. The upstream init.sh
+# writes admin.txt, but it is skipped when conf/ccnet.conf or conf/revision
+# already exist (e.g. after a partial previous install) and the env vars do
+# not always reach the seahub subprocess via su. Write admin.txt directly and
+# inject the values into seafile.env so admin creation succeeds (#2685).
+ADMIN_EMAIL_VAL="$(bashio::config 'SEAFILE_ADMIN_EMAIL')"
+ADMIN_PASSWORD_VAL="$(bashio::config 'SEAFILE_ADMIN_PASSWORD')"
+
+if [[ -n "${ADMIN_EMAIL_VAL}" && "${ADMIN_EMAIL_VAL}" != "null" \
+    && -n "${ADMIN_PASSWORD_VAL}" && "${ADMIN_PASSWORD_VAL}" != "null" ]]; then
+    bashio::log.info "Seeding admin credentials"
+
+    mkdir -p "${DATA_LOCATION}/conf"
+
+    ADMIN_FILE="${DATA_LOCATION}/conf/admin.txt"
+    jq -n --arg email "${ADMIN_EMAIL_VAL}" --arg password "${ADMIN_PASSWORD_VAL}" \
+        '{email: $email, password: $password}' > "${ADMIN_FILE}"
+    chown seafile:seafile "${ADMIN_FILE}"
+    chmod 600 "${ADMIN_FILE}"
+
+    SEAFILE_ENV_FILE="${DATA_LOCATION}/conf/seafile.env"
+    touch "${SEAFILE_ENV_FILE}"
+    sed -i '/^SEAFILE_ADMIN_EMAIL=/d' "${SEAFILE_ENV_FILE}"
+    sed -i '/^SEAFILE_ADMIN_PASSWORD=/d' "${SEAFILE_ENV_FILE}"
+    {
+        printf 'SEAFILE_ADMIN_EMAIL=%q\n' "${ADMIN_EMAIL_VAL}"
+        printf 'SEAFILE_ADMIN_PASSWORD=%q\n' "${ADMIN_PASSWORD_VAL}"
+    } >> "${SEAFILE_ENV_FILE}"
+    chown seafile:seafile "${SEAFILE_ENV_FILE}"
+fi
+
 #############################################
 # Configure service URL and file server root #
 #############################################

--- a/seafile/rootfs/etc/cont-init.d/99-run.sh
+++ b/seafile/rootfs/etc/cont-init.d/99-run.sh
@@ -129,6 +129,7 @@ if [[ -n "${ADMIN_EMAIL_VAL}" && "${ADMIN_EMAIL_VAL}" != "null" \
         printf 'SEAFILE_ADMIN_PASSWORD=%q\n' "${ADMIN_PASSWORD_VAL}"
     } >> "${SEAFILE_ENV_FILE}"
     chown seafile:seafile "${SEAFILE_ENV_FILE}"
+    chmod 600 "${SEAFILE_ENV_FILE}"
 fi
 
 #############################################


### PR DESCRIPTION
Seafile's check_init_admin.py looks for SEAFILE_ADMIN_EMAIL/PASSWORD
in the env, then falls back to conf/admin.txt, and only prompts
interactively if neither is available. The upstream init.sh writes
admin.txt, but it is skipped when conf/ccnet.conf or conf/revision
already exist (e.g. after a partial previous install) and the env
vars do not always reach the seahub subprocess via su. Write
admin.txt directly and inject the values into seafile.env so admin
creation succeeds (#2685).

https://claude.ai/code/session_01EwuoFH7aHJMySr9J775XQP