### PR TITLE
Fix qbittorrent startup loop on aarch64: drop s6-notifyoncheck

### DIFF
--- a/qbittorrent/CHANGELOG.md
+++ b/qbittorrent/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 5.2.0-2 (2026-05-10)
+- Fix startup loop on aarch64: drop s6-notifyoncheck wrapper so s6 supervises qbittorrent-nox directly (LSIO arm64 image has no notification-fd, causing EBADF restart loop)
+
 ## 5.2.0-1 (2026-05-10)
 - Fix qbittorrent-nox path (/usr/bin → /app) after LSIO image update
 

--- a/qbittorrent/config.yaml
+++ b/qbittorrent/config.yaml
@@ -143,4 +143,4 @@ schema:
 slug: qbittorrent
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "5.2.0-1"
+version: "5.2.0-2"

--- a/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
+++ b/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
@@ -37,21 +37,13 @@ fi
 # --- Launch qBittorrent ---
 
 # Determine log output based on silent mode
-QB_OUTPUT="/dev/stdout"
+QB_OUTPUT="/proc/1/fd/1"
 if bashio::config.true 'silent'; then
     QB_OUTPUT="/dev/null"
 fi
 
 bashio::log.info "Starting qBittorrent..."
 
-# s6-notifyoncheck writes to fd 3 when its readiness check passes. s6-rc only
-# opens fd 3 when the service directory contains a notification-fd file. Without
-# it (LSIO arm64 images), s6-notifyoncheck exits with EBADF and s6 restarts the
-# service in a loop. Fall back to running qbittorrent-nox directly in that case.
-if [ -f /etc/s6-overlay/s6-rc.d/svc-qbittorrent/notification-fd ]; then
-    exec \
-        s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost ${WEBUI_PORT}" \
-        s6-setuidgid abc /app/qbittorrent-nox --webui-port="${WEBUI_PORT}" > "${QB_OUTPUT}"
-else
-    exec s6-setuidgid abc /app/qbittorrent-nox --webui-port="${WEBUI_PORT}" > "${QB_OUTPUT}"
-fi
+exec \
+    s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost ${WEBUI_PORT}" \
+    s6-setuidgid abc /app/qbittorrent-nox --webui-port="${WEBUI_PORT}" > "${QB_OUTPUT}"

--- a/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
+++ b/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
@@ -44,6 +44,10 @@ fi
 
 bashio::log.info "Starting qBittorrent..."
 
-exec \
-    s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost ${WEBUI_PORT}" \
-    s6-setuidgid abc /app/qbittorrent-nox --webui-port="${WEBUI_PORT}" > "${QB_OUTPUT}"
+if [ -f /etc/s6-overlay/s6-rc.d/svc-qbittorrent/notification-fd ]; then
+    exec \
+        s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost ${WEBUI_PORT}" \
+        s6-setuidgid abc /app/qbittorrent-nox --webui-port="${WEBUI_PORT}" > "${QB_OUTPUT}"
+else
+    exec s6-setuidgid abc /app/qbittorrent-nox --webui-port="${WEBUI_PORT}" > "${QB_OUTPUT}"
+fi

--- a/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
+++ b/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
@@ -36,14 +36,22 @@ fi
 
 # --- Launch qBittorrent ---
 
-bashio::log.info "Starting qBittorrent..."
-
-# On aarch64 LSIO images svc-qbittorrent has no notification-fd, so fd 3 is never
-# opened by s6-rc. s6-notifyoncheck then exits with EBADF after its check passes,
-# s6 sees the supervised process die and restarts it — causing the startup loop.
-# Run qbittorrent-nox directly so s6 supervises the actual process.
+# Determine log output based on silent mode
+QB_OUTPUT="/dev/stdout"
 if bashio::config.true 'silent'; then
-    exec > /dev/null 2>&1
+    QB_OUTPUT="/dev/null"
 fi
 
-exec s6-setuidgid abc /app/qbittorrent-nox --webui-port="${WEBUI_PORT}"
+bashio::log.info "Starting qBittorrent..."
+
+# s6-notifyoncheck writes to fd 3 when its readiness check passes. s6-rc only
+# opens fd 3 when the service directory contains a notification-fd file. Without
+# it (LSIO arm64 images), s6-notifyoncheck exits with EBADF and s6 restarts the
+# service in a loop. Fall back to running qbittorrent-nox directly in that case.
+if [ -f /etc/s6-overlay/s6-rc.d/svc-qbittorrent/notification-fd ]; then
+    exec \
+        s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost ${WEBUI_PORT}" \
+        s6-setuidgid abc /app/qbittorrent-nox --webui-port="${WEBUI_PORT}" > "${QB_OUTPUT}"
+else
+    exec s6-setuidgid abc /app/qbittorrent-nox --webui-port="${WEBUI_PORT}" > "${QB_OUTPUT}"
+fi

--- a/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
+++ b/qbittorrent/rootfs/etc/s6-overlay/s6-rc.d/svc-qbittorrent/run
@@ -36,14 +36,14 @@ fi
 
 # --- Launch qBittorrent ---
 
-# Determine log output based on silent mode
-QB_OUTPUT="/dev/stdout"
-if bashio::config.true 'silent'; then
-    QB_OUTPUT="/dev/null"
-fi
-
 bashio::log.info "Starting qBittorrent..."
 
-exec \
-    s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost ${WEBUI_PORT}" \
-    s6-setuidgid abc /app/qbittorrent-nox --webui-port="${WEBUI_PORT}" > "${QB_OUTPUT}"
+# On aarch64 LSIO images svc-qbittorrent has no notification-fd, so fd 3 is never
+# opened by s6-rc. s6-notifyoncheck then exits with EBADF after its check passes,
+# s6 sees the supervised process die and restarts it — causing the startup loop.
+# Run qbittorrent-nox directly so s6 supervises the actual process.
+if bashio::config.true 'silent'; then
+    exec > /dev/null 2>&1
+fi
+
+exec s6-setuidgid abc /app/qbittorrent-nox --webui-port="${WEBUI_PORT}"


### PR DESCRIPTION
s6-notifyoncheck writes to fd 3 when its readiness check passes, but
the LSIO aarch64 image's svc-qbittorrent service has no notification-fd
file so s6-rc never opens fd 3. s6-notifyoncheck exits with EBADF, s6
sees the supervised process die and immediately restarts it, producing
the infinite "Starting qBittorrent..." loop seen on odroid-c2 and other
aarch64 boards.

Drop s6-notifyoncheck entirely and exec qbittorrent-nox directly under
s6-setuidgid so s6 supervises the real process. Silent mode is handled
by redirecting the shell's fds before exec rather than passing a
/dev/stdout path (avoids a separate class of ARM container fd issues).

https://claude.ai/code/session_01F16ThtZyfXj6ZKFPkrSAAq