### PR TITLE
fix qbittorrent upnp

### DIFF
--- a/qbittorrent/rootfs/etc/services.d/vpn-upnp/run
+++ b/qbittorrent/rootfs/etc/services.d/vpn-upnp/run
@@ -152,7 +152,7 @@ _pnat_set_firewall() {
 # --- qBittorrent Specific Logic ---
 
 _qbt_login() {
-    config["SID"]=$(_cmd "curl -s -k -i --header \"Referer: ${config["Schema"]}://${config["Server"]}:${config["Port"]}\" --data \"username=${config["User"]}\" --data-urlencode \"password=${config["Pass"]}\" \"${config["Schema"]}://${config["Server"]}:${config["Port"]}/api/v2/auth/login\" | grep -oP '(?!set-cookie:.)SID=.*(?=\;.HttpOnly\;)'")
+    config["SID"]=$(_cmd "curl -s -k -i --header \"Referer: ${config["Schema"]}://${config["Server"]}:${config["Port"]}\" --data \"username=${config["User"]}\" --data-urlencode \"password=${config["Pass"]}\" \"${config["Schema"]}://${config["Server"]}:${config["Port"]}/api/v2/auth/login\" | grep -oiP 'set-cookie:.*SID[^=]*=\K[^;]+'")
     return $?
 }
 


### PR DESCRIPTION
in the latest 5.2.0-17 version of qbittorent upnp is not working:

```
[23:21:00] INFO: VPN external IP: XXXXXXX
[23:22:30] INFO: qBittorrent SessionID not set, getting new SessionID
[23:22:30] ERROR: Failed getting new SessionID from qBittorrent
[23:22:30] ERROR: NAT-PMP/UPnP Failed
```

this was due to the cookie SID parsing where qbittorent returns:

```
HTTP/1.1 204 OK
connection: keep-alive
content-length: 0
date: Thu, 14 May 2026 21:30:37 GMT
set-cookie: QBT_SID_8080=V6BvlRl87UaAHDHROrWESNIMbyh8RXJg; HttpOnly; expires=Thu, 14-May-2026 22:30:37 GMT; path=/
x-content-type-options: nosniff
x-xss-protection: 1; mode=block
```

and the implemented grep parsing:

`grep -oP '(?!set-cookie:.)SID=.*(?=\;.HttpOnly\;)'`

is confused by the new cookie ID `QBT_SID_8080`

Proposed fix shall be able to parse both SID and QBT_SID_PORT variants more generously.





