### PR TITLE
Manyfold version bump

### DIFF
--- a/manyfold/CHANGELOG.md
+++ b/manyfold/CHANGELOG.md
@@ -1,10 +1,20 @@
-## 0.139.3 (11-05-2026)
-- Minor bugs fixed
-## 0.138.0 (24-04-2026)
-- Minor bugs fixed
-## 0.137.0 (13-04-2026)
-- Minor bugs fixed
 # Changelog
+
+## 0.140.1
+ - Bump version to 0.140.1
+ - Detailed changes https://github.com/manyfold3d/manyfold/compare/v0.139.3...v0.140.1
+
+## 0.139.3 (11-05-2026)
+
+- Minor bugs fixed
+
+## 0.138.0 (24-04-2026)
+
+- Minor bugs fixed
+
+## 0.137.0 (13-04-2026)
+
+- Minor bugs fixed
 
 ## 0.137.0
 

--- a/manyfold/README.md
+++ b/manyfold/README.md
@@ -65,20 +65,33 @@ Local development alternative on the HA host:
 - `max_file_upload_size`: Max uploaded archive size in bytes.
 - `max_file_extract_size`: Max extracted archive size in bytes.
 
-## Small server tuning
+### Raspberry Pi (single-user) example
 
-For low-memory HAOS hosts, start with:
+For a Raspberry Pi 4 or Pi 5 running a single-user Manyfold instance with modest library sizes:
 
 ```yaml
+puid: 1000
+pgid: 1000
+multiuser: false
+library_path: /share/manyfold/models
+thumbnails_path: /config/thumbnails
+log_level: info
 web_concurrency: 1
-rails_max_threads: 5
-default_worker_concurrency: 2
+rails_max_threads: 4
+default_worker_concurrency: 1
 performance_worker_concurrency: 1
-max_file_upload_size: 268435456
-max_file_extract_size: 536870912
+max_file_upload_size: 134217728
+max_file_extract_size: 268435456
 ```
 
-Then restart the add-on and increase gradually only if needed.
+**Rationale:**
+- `web_concurrency: 1` — Single Puma worker (one process) saves RAM on Pi.
+- `rails_max_threads: 4` — Four threads per worker is sufficient for single-user browsing.
+- `default_worker_concurrency: 1` — Serial background job processing (indexing, thumbnail generation).
+- `performance_worker_concurrency: 1` — Single performance worker to avoid CPU thrashing during STL processing.
+- `multiuser: false` — Disable authentication/multiuser features for personal use.
+- `max_file_upload_size: 128 MB` — Reasonable limit for Pi storage and network.
+- `max_file_extract_size: 256 MB` — Extracted archives stay manageable.
 
 ## Fix root warning (PUID/PGID)
 

--- a/manyfold/config.yaml
+++ b/manyfold/config.yaml
@@ -1,7 +1,7 @@
 name: "Manyfold"
 slug: manyfold
 description: "Manyfold 3D model manager as a Home Assistant add-on, using the upstream image with configurable library/index paths."
-version: "0.139.3"
+version: "0.140.1"
 url: "https://github.com/alexbelgium/hassio-addons/tree/master/manyfold"
 image: ghcr.io/alexbelgium/manyfold-{arch}
 arch:


### PR DESCRIPTION
- bump version to 0.140.1
- better readme example for configuration in small systems. In my case RPi5 2 GB ram