### PR TITLE
fix(birdnet-pipy): serve API via gunicorn + gevent worker

### DIFF
--- a/birdnet-pipy/CHANGELOG.md
+++ b/birdnet-pipy/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 0.7.0-1 (2026-05-19)
+- Serve the API via gunicorn + a gevent-websocket worker instead of the Werkzeug development server
+
 ## 0.7.0 (2026-05-19)
 - Update to latest version from Suncuss/BirdNET-PiPy (changelog : https://github.com/Suncuss/BirdNET-PiPy/releases)
 

--- a/birdnet-pipy/config.yaml
+++ b/birdnet-pipy/config.yaml
@@ -96,4 +96,4 @@ schema:
   ssl: bool?
 slug: birdnet-pipy
 url: https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-pipy
-version: "0.7.0"
+version: "0.7.0-1"

--- a/birdnet-pipy/rootfs/etc/services.d/api/run
+++ b/birdnet-pipy/rootfs/etc/services.d/api/run
@@ -4,4 +4,16 @@ set -euo pipefail
 export PYTHONPATH=/app
 bashio::net.wait_for 5001 127.0.0.1 300
 cd /app
-exec python3 -m core.api
+# Single gevent-websocket worker is mandatory: live detections fan out via an
+# in-process socketio.emit (no Redis message_queue), so >1 worker would
+# silently drop Live Feed broadcasts. Bind 127.0.0.1 (single container; nginx
+# and core.main reach the API locally, satisfying the wait_for in nginx/run +
+# main/run). Heavy admin jobs cooperatively yield to keep this worker live.
+exec gunicorn wsgi:application \
+  --worker-class geventwebsocket.gunicorn.workers.GeventWebSocketWorker \
+  --workers 1 \
+  --bind 127.0.0.1:5002 \
+  --timeout 120 \
+  --graceful-timeout 30 \
+  --keep-alive 65 \
+  --error-logfile -

--- a/birdnet-pipy/rootfs/etc/services.d/nginx/run
+++ b/birdnet-pipy/rootfs/etc/services.d/nginx/run
@@ -2,7 +2,7 @@
 # shellcheck shell=bash
 set -euo pipefail
 
-# Wait for the upstream API service (Python core.api) to bind 127.0.0.1:5002
+# Wait for the upstream API service (gunicorn / wsgi:application) to bind 127.0.0.1:5002
 # before starting nginx, so nginx never serves a 502 for the API/auth/socket
 # paths during boot. A boot-time 502 can be cached by an upstream cache layer
 # (HA's own PWA service worker, a Cloudflare edge worker, etc.), leaving the


### PR DESCRIPTION
## Summary

Switches the `birdnet-pipy` add-on's API service from the bundled Werkzeug
development server (`python -m core.api`) to **gunicorn** with a single
gevent-websocket worker, matching upstream BirdNET-PiPy 0.7.0's
production-server migration (the add-on already builds 0.7.0 source).

- Bound to `127.0.0.1:5002` for single-container use; the existing `wait_for`
  startup ordering in `nginx/run` / `main/run` is unaffected.
- Tested in Home Assistant, direct and ingress modes (dashboard, navigation,
  Live Feed audio + websocket detections).
- Add-on packaging change only → version `0.7.0` → `0.7.0-1`.
