### PR TITLE
fix(immich): stop find from stomping node_modules, guard missing s6 service

### DIFF
--- a/immich/Dockerfile
+++ b/immich/Dockerfile
@@ -37,18 +37,18 @@ RUN chmod 744 /ha_lsio.sh && if grep -qr "lsio" /etc; then /ha_lsio.sh "$CONFIGL
 # Install REDIS
 ENV DOCKER_MODS="imagegenius/mods:universal-redis"
 
-#    && chmod 777 -R /docker-mods \
-#        && /./docker-mods/* || ls / \
-#    && if [ !-f /defaults/redis.conf ]; then echo "Not installed" && exit 1; fi
-#ENV DOCKER_MODS=""
-
 ##################
 # 3 Install apps #
 ##################
 
 # Add rootfs
 COPY rootfs/ /
-RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+# FIX BUG 1: scope find to HA-owned directories only, never the whole filesystem.
+# Running `find .` from WORKDIR=/ hits node_modules inside /app/immich and fails chmod (exit 1).
+RUN find /etc /usr/local/bin /usr/local/lib /usr/local/share \
+    -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) \
+    -exec chmod +x {} \; 2>/dev/null || true
 
 # Uses /bin for compatibility purposes
 # hadolint ignore=DL4005
@@ -82,10 +82,16 @@ RUN chmod 777 /ha_entrypoint.sh
 COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
 RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
 
-RUN apt-get update && apt-get install -y --no-install-recommends sed \
-    && sed -i "s|postgresql-16|postgresql-15|g" /etc/s6-overlay/s6-rc.d/init-test-run/run
+# FIX BUG 2: /etc/s6-overlay/s6-rc.d/init-test-run/run no longer exists in the
+# imagegenius base image (service was removed). Guard with file existence check.
+# The base image already ships postgresql-client-14 through 18, so the redundant
+# install is removed. Only the conditional sed is kept for backward compatibility
+# in case a future base image re-introduces the file.
+RUN if [ -f /etc/s6-overlay/s6-rc.d/init-test-run/run ]; then \
+        sed -i "s|postgresql-16|postgresql-15|g" /etc/s6-overlay/s6-rc.d/init-test-run/run; \
+    fi
 
-# Install dependencies
+# Install dependencies (postgresql-client for psql CLI used in 99-run.sh)
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && apt-get install -y --no-install-recommends \
     lsb-release \


### PR DESCRIPTION
## What broke

Two bugs in `immich/Dockerfile` caused the Docker image build to fail completely, leaving users stuck with a hard 404 on `ghcr.io/alexbelgium/immich-aarch64:2026.0.0` (image was never pushed).

---

## Bug 1 — `find .` from WORKDIR=`/` hits node_modules (primary failure)

```dockerfile
# BROKEN
RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
```

The base image sets `WORKDIR=/`. Running `find .` from there descends into `/app/immich/server/node_modules/` and hits files it cannot `chmod` — exit code 1 at step 5/17, build aborted.

**Fix:** scope `find` to only the directories that `COPY rootfs/ /` actually populates:

```dockerfile
RUN find /etc /usr/local/bin /usr/local/lib /usr/local/share \
    -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) \
    -exec chmod +x {} \; 2>/dev/null || true
```

---

## Bug 2 — `sed -i` on a file that no longer exists in the base image

```dockerfile
# BROKEN
RUN apt-get install sed \
    && sed -i "s|postgresql-16|postgresql-15|g" /etc/s6-overlay/s6-rc.d/init-test-run/run
```

`/etc/s6-overlay/s6-rc.d/init-test-run/` was removed from `ghcr.io/imagegenius/immich` in an earlier upstream update. `sed -i` on a missing file exits 1.

**Fix:** guard with a file existence check:

```dockerfile
RUN if [ -f /etc/s6-overlay/s6-rc.d/init-test-run/run ]; then \
        sed -i "s|postgresql-16|postgresql-15|g" /etc/s6-overlay/s6-rc.d/init-test-run/run; \
    fi
```

---

## Verified

- Both bugs **reproduced** with `docker build` against the current base image
- Fixed Dockerfile **builds cleanly** — all 17 steps passed on a bare-metal VPS (Docker 29.2.1)
- `psql --version` available in the built image
- `init-test-run` guard correctly no-ops (file absent as expected)

---

Closes #2718