### PR TITLE
aurral: v1.76.17-1 - fix config schema, add weekly_flow_folder option, clean up build.json

### DIFF
--- a/aurral/CHANGELOG.md
+++ b/aurral/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.76.17-1
+
+- Add `weekly_flow_folder` option (configurable subfolder for weekly flow files)
+- Fix addon config schema (`env_vars` -> `environment`)
+- Add image tag for alexbelgium build pipeline
+
 ## 1.76.17
 
 - Initial release

--- a/aurral/README.md
+++ b/aurral/README.md
@@ -8,6 +8,7 @@ This addon is based on the docker image <https://github.com/lklynet/aurral>
 | Option | Default | Description |
 |---|---|---|
 | `download_folder` | `/share/aurral/downloads` | Path where Aurral writes flow downloads. Must be under `/share`. |
+| `weekly_flow_folder` | `weekly-flow` | Subfolder name appended to `download_folder` for weekly flow files. The full path will be `download_folder/weekly_flow_folder`. |
 
 ## Installation
 
@@ -18,6 +19,7 @@ This addon is based on the docker image <https://github.com/lklynet/aurral>
 2. Install this add-on.
 3. Click the `Save` button to store your configuration.
 4. Set the `download_folder` option to your preferred path.
-5. Start the add-on.
-6. Check the logs of the add-on to see if everything went well.
-7. Open the webUI and complete onboarding.
+5. Optionally set `weekly_flow_folder` to customise the weekly flow subfolder name.
+6. Start the add-on.
+7. Check the logs of the add-on to see if everything went well.
+8. Open the webUI and complete onboarding.

--- a/aurral/build.json
+++ b/aurral/build.json
@@ -2,13 +2,5 @@
   "build_from": {
     "aarch64": "ghcr.io/lklynet/aurral:1.76.17",
     "amd64": "ghcr.io/lklynet/aurral:1.76.17"
-  },
-  "labels": {
-    "io.hass.name": "Aurral",
-    "io.hass.description": "Self-hosted music discovery and request management for Lidarr",
-    "io.hass.arch": "{arch}",
-    "io.hass.type": "addon",
-    "io.hass.version": "dev",
-    "maintainer": "petruknw"
   }
 }

--- a/aurral/build.json
+++ b/aurral/build.json
@@ -3,7 +3,6 @@
     "aarch64": "ghcr.io/lklynet/aurral:1.76.17",
     "amd64": "ghcr.io/lklynet/aurral:1.76.17"
   },
-  "squash": false,
   "labels": {
     "io.hass.name": "Aurral",
     "io.hass.description": "Self-hosted music discovery and request management for Lidarr",

--- a/aurral/config.yaml
+++ b/aurral/config.yaml
@@ -25,11 +25,10 @@ map:
   - share:rw
   - media:rw
 
-environment:
-  WEEKLY_FLOW_FOLDER: "/share/aurral/downloads/weekly-flow"
-
 options:
   download_folder: /share/aurral/downloads
+  weekly_flow_folder: weekly-flow
 
 schema:
   download_folder: str
+  weekly_flow_folder: str

--- a/aurral/config.yaml
+++ b/aurral/config.yaml
@@ -1,5 +1,5 @@
 name: Aurral
-version: "1.76.17"
+version: "1.76.17-1"
 slug: aurral
 description: >-
   Self-hosted music discovery, request management, flows, and playlist

--- a/aurral/config.yaml
+++ b/aurral/config.yaml
@@ -9,6 +9,8 @@ arch:
   - aarch64
   - amd64
 
+image: ghcr.io/alexbelgium/aurral-{arch}
+
 init: false
 
 ports:
@@ -23,10 +25,8 @@ map:
   - share:rw
   - media:rw
 
-env_vars:
-  - name: WEEKLY_FLOW_FOLDER
-    description: "Path for Navidrome smart playlist files (weekly flow)"
-    required: false
+environment:
+  WEEKLY_FLOW_FOLDER: "/share/aurral/downloads/weekly-flow"
 
 options:
   download_folder: /share/aurral/downloads

--- a/aurral/rootfs/usr/local/bin/docker-entrypoint.sh
+++ b/aurral/rootfs/usr/local/bin/docker-entrypoint.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
 set -e
 
-# Create the real directories in HA persistent storage that the symlinks point to
+DOWNLOAD_FOLDER=$(bashio::config 'download_folder')
+WEEKLY_FLOW_SUFFIX=$(bashio::config 'weekly_flow_folder')
+
+export DOWNLOAD_FOLDER
+export WEEKLY_FLOW_FOLDER="${DOWNLOAD_FOLDER}/${WEEKLY_FLOW_SUFFIX}"
+
+# Create persistent directories in HA volumes
 mkdir -p /config/data
-mkdir -p "${DOWNLOAD_FOLDER:-/share/aurral/downloads}"
-mkdir -p "${WEEKLY_FLOW_FOLDER:-/share/aurral/downloads/weekly-flow}"
+mkdir -p "${DOWNLOAD_FOLDER}"
+mkdir -p "${WEEKLY_FLOW_FOLDER}"
 
 exec "$@"


### PR DESCRIPTION
Follow-up to #2723 addressing the issues flagged after merge.

## Changes

- `env_vars` → `environment` (correct HA addon config schema)
- Remove `squash: false` from `build.json` (default value)
- Remove redundant `labels` block from `build.json`
- Add `image: ghcr.io/alexbelgium/aurral-{arch}` to `config.yaml` to trigger build pipeline
- Add `weekly_flow_folder` option (configurable subfolder suffix appended to `download_folder` for weekly flow files, default: `weekly-flow`)
- Fix data/downloads paths to match upstream volume layout (`/app/backend/data`, `/app/downloads`)
- Version bump to `1.76.17-1`
- README and CHANGELOG updated