### PR TITLE
aurral: v1.76.17-2 - fix entrypoint, restore mkdirs, clean up build.json

### DIFF
--- a/aurral/CHANGELOG.md
+++ b/aurral/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.76.17-2
+
+- Fix entrypoint: use HA-injected env vars instead of bashio (not available in upstream image)
+- Restore mkdir for persistent data/download directories
+
 ## 1.76.17-1
 
 - Add `weekly_flow_folder` option (configurable subfolder for weekly flow files)

--- a/aurral/config.yaml
+++ b/aurral/config.yaml
@@ -1,5 +1,5 @@
 name: Aurral
-version: "1.76.17-1"
+version: "1.76.17-2"
 slug: aurral
 description: >-
   Self-hosted music discovery, request management, flows, and playlist

--- a/aurral/rootfs/usr/local/bin/docker-entrypoint.sh
+++ b/aurral/rootfs/usr/local/bin/docker-entrypoint.sh
@@ -1,15 +1,12 @@
 #!/bin/sh
 set -e
 
-DOWNLOAD_FOLDER=$(jq -r '.download_folder // "/share/aurral/downloads"' /data/options.json)
-WEEKLY_FLOW_SUFFIX=$(jq -r '.weekly_flow_folder // "weekly-flow"' /data/options.json)
+# HA Supervisor injects addon options as env vars automatically.
+# DOWNLOAD_FOLDER and WEEKLY_FLOW_FOLDER are set by HA from options.json,
+# with the Dockerfile ENV values as fallbacks.
 
-export DOWNLOAD_FOLDER
-export WEEKLY_FLOW_FOLDER="${DOWNLOAD_FOLDER}/${WEEKLY_FLOW_SUFFIX}"
-
-# Create persistent directories in HA volumes
 mkdir -p /config/data
-mkdir -p "${DOWNLOAD_FOLDER}"
-mkdir -p "${WEEKLY_FLOW_FOLDER}"
+mkdir -p "${DOWNLOAD_FOLDER:-/share/aurral/downloads}"
+mkdir -p "${WEEKLY_FLOW_FOLDER:-/share/aurral/downloads/weekly-flow}"
 
 exec "$@"

--- a/aurral/rootfs/usr/local/bin/docker-entrypoint.sh
+++ b/aurral/rootfs/usr/local/bin/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-DOWNLOAD_FOLDER=$(bashio::config 'download_folder')
-WEEKLY_FLOW_SUFFIX=$(bashio::config 'weekly_flow_folder')
+DOWNLOAD_FOLDER=$(jq -r '.download_folder // "/share/aurral/downloads"' /data/options.json)
+WEEKLY_FLOW_SUFFIX=$(jq -r '.weekly_flow_folder // "weekly-flow"' /data/options.json)
 
 export DOWNLOAD_FOLDER
 export WEEKLY_FLOW_FOLDER="${DOWNLOAD_FOLDER}/${WEEKLY_FLOW_SUFFIX}"

--- a/aurral/rootfs/usr/local/bin/docker-entrypoint.sh
+++ b/aurral/rootfs/usr/local/bin/docker-entrypoint.sh
@@ -1,12 +1,8 @@
 #!/bin/sh
 set -e
 
-# HA Supervisor injects addon options as env vars automatically.
-# DOWNLOAD_FOLDER and WEEKLY_FLOW_FOLDER are set by HA from options.json,
-# with the Dockerfile ENV values as fallbacks.
-
 mkdir -p /config/data
-mkdir -p "${DOWNLOAD_FOLDER:-/share/aurral/downloads}"
-mkdir -p "${WEEKLY_FLOW_FOLDER:-/share/aurral/downloads/weekly-flow}"
+mkdir -p "${DOWNLOAD_FOLDER}"
+mkdir -p "${WEEKLY_FLOW_FOLDER}"
 
 exec "$@"


### PR DESCRIPTION
Follow-up to #2725.

## Changes

- Fix entrypoint: replace `bashio::config` (not available in upstream node image) with HA-injected env vars
- Restore `mkdir` for persistent data and download directories
- Remove redundant `labels` block from `build.json`
- Version bump to `1.76.17-2`