### PR TITLE
aurral: sync build.json to 1.76.40 to fix updater bot

### DIFF
--- a/aurral/build.json
+++ b/aurral/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/lklynet/aurral:1.76.17",
-    "amd64": "ghcr.io/lklynet/aurral:1.76.17"
+    "aarch64": "ghcr.io/lklynet/aurral:1.76.40",
+    "amd64": "ghcr.io/lklynet/aurral:1.76.40"
   }
 }


### PR DESCRIPTION
## Problem

The updater bot bumped `config.yaml` to `1.76.40` (see c0d398e) but `build.json` still references `1.76.17`, causing HA to show an "Update available: 1.76.17 → 1.76.40" notification immediately after updating.

## Root cause

The bot's `sed` replaces the old version string across `config.yaml`, `build.json`, etc. simultaneously. A previous manual version bump used a `-1` suffix in `config.yaml`, causing the version strings in both files to diverge — so when the bot ran, it found no match in `build.json` and silently skipped it.

## Fix

Sync `build.json` to `1.76.40` to match `config.yaml`. Both files now share the same version string so the bot's find/replace will keep them in lockstep going forward.