### PR TITLE
aurral: fix CMD path server.js -> backend/server.js

### DIFF
--- a/aurral/Dockerfile
+++ b/aurral/Dockerfile
@@ -29,4 +29,4 @@ COPY rootfs /
 RUN chmod a+x /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
-CMD ["node", "server.js"]
+CMD ["node", "backend/server.js"]


### PR DESCRIPTION
## Problem

As of v1.76.42, aurral fails to start with:
```
Error: Cannot find module '/app/server.js'
```

## Root cause

Upstream restructured the project — `server.js` moved from `/app/server.js` to `/app/backend/server.js` (see [upstream Dockerfile](https://github.com/lklynet/aurral/blob/main/Dockerfile)). Our addon's `Dockerfile` has a hardcoded `CMD ["node", "server.js"]` that overrides the upstream entrypoint and now points to the wrong path.

## Fix

Update `CMD` to `["node", "backend/server.js"]` to match the upstream path.