### PR TITLE
ente: fix apparmor name, expose accounts/auth/cast ports, harden DB config

### DIFF
--- a/ente/CHANGELOG.md
+++ b/ente/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.4.22-5 (04-06-2026)
+- Fix AppArmor profile name (was copied from qbittorrent, could collide with that add-on)
+- Expose Accounts (3001), Auth (3003) and Cast (3004) ports so the login/2FA web apps are reachable
+- Default external Postgres port to 5432 when DB_PORT is left blank
+- Write the correct DB host/port to museum.yaml when using an external database
+- Exclude minio-data and postgres folders from Home Assistant backups
 ## 4.4.22-4 (04-06-2026)
 - Minor bugs fixed
 ## 4.4.22-3 (04-06-2026)

--- a/ente/apparmor.txt
+++ b/ente/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile db21ed7f_qbittorrent flags=(attach_disconnected,mediate_deleted) {
+profile ente_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   capability chown,
@@ -43,7 +43,6 @@ profile db21ed7f_qbittorrent flags=(attach_disconnected,mediate_deleted) {
   /init rix,
   /var/run/** mrwkl,
   /var/run/ mrwkl,
-  /dev/i2c-1 mrwkl,
   # Files required
   /dev/fuse mrwkl,
   /dev/sda1 mrwkl,

--- a/ente/config.yaml
+++ b/ente/config.yaml
@@ -1,6 +1,9 @@
 arch:
   - aarch64
   - amd64
+backup_exclude:
+  - "**/minio-data/**"
+  - "**/postgres/**"
 description:
   Self-hosted, end-to-end-encrypted photo & video storage (Ente server
   + MinIO)
@@ -83,7 +86,10 @@ options:
   USE_EXTERNAL_DB: false
 ports:
   3000/tcp: 8300
+  3001/tcp: 8301
   3002/tcp: 8302
+  3003/tcp: 8303
+  3004/tcp: 8304
   3005/tcp: 8305
   3006/tcp: 8306
   3007/tcp: 8307
@@ -92,7 +98,10 @@ ports:
   8080/tcp: 8280
 ports_description:
   3000/tcp: Ente web UI
+  3001/tcp: Ente Accounts
   3002/tcp: Ente Albums
+  3003/tcp: Ente Auth
+  3004/tcp: Ente Cast
   3005/tcp: Ente Share
   3006/tcp: Ente Embed
   3007/tcp: Ente Paste
@@ -122,6 +131,6 @@ schema:
 slug: ente
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "4.4.22-4"
+version: "4.4.22-5"
 video: true
 webui: http://[HOST]:[PORT:3000]

--- a/ente/rootfs/etc/cont-init.d/99-run.sh
+++ b/ente/rootfs/etc/cont-init.d/99-run.sh
@@ -51,6 +51,8 @@ DB_PASS="$(bashio::config 'DB_PASSWORD' || echo ente)"
 # External DB opts (may be blank)
 DB_HOST_EXT="$(bashio::config 'DB_HOSTNAME' || echo '')"
 DB_PORT_EXT="$(bashio::config 'DB_PORT' || echo '')"
+# Default external Postgres port when unset
+[ -z "$DB_PORT_EXT" ] && DB_PORT_EXT=5432
 
 USE_EXTERNAL_DB=false
 if bashio::config.true 'USE_EXTERNAL_DB'; then
@@ -108,8 +110,8 @@ jwt:
   secret: $(_rand_b64url 32)
 
 db:
-  host:     ${DB_HOST_INTERNAL}
-  port:     ${DB_PORT_INTERNAL}
+  host:     ${DB_HOST}
+  port:     ${DB_PORT}
   name:     ${DB_NAME}
   user:     ${DB_USER}
   password: ${DB_PASS}


### PR DESCRIPTION
- Rename AppArmor profile from the leftover qbittorrent name to ente_addon
  to avoid colliding with the qbittorrent add-on's profile
- Map the Accounts (3001), Auth (3003) and Cast (3004) ports so the login,
  2FA and cast web apps served by nginx are actually reachable
- Default the external Postgres port to 5432 when DB_PORT is left blank
- Write the resolved DB host/port to museum.yaml so external databases are
  configured correctly on disk, not just via env overrides
- Exclude minio-data and postgres from Home Assistant backups to avoid
  pulling the whole photo library and database into every backup

https://claude.ai/code/session_01MaLKhb2CJiF9Fb3Dyr585r