### PR TITLE
ente: fix SIGPIPE (exit 141) on startup from tr|head -c /dev/urandom …

### DIFF
--- a/ente/CHANGELOG.md
+++ b/ente/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.4.22-6 (04-06-2026)
+- Fix SIGPIPE (exit 141) on startup: tr piped to head -c against /dev/urandom
+  now suppresses the expected SIGPIPE under set -o pipefail
 ## 4.4.22-5 (04-06-2026)
 - Fix AppArmor profile name (was copied from qbittorrent, could collide with that add-on)
 - Expose Accounts (3001), Auth (3003) and Cast (3004) ports so the login/2FA web apps are reachable

--- a/ente/config.yaml
+++ b/ente/config.yaml
@@ -131,6 +131,6 @@ schema:
 slug: ente
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "4.4.22-5"
+version: "4.4.22-6"
 video: true
 webui: http://[HOST]:[PORT:3000]

--- a/ente/rootfs/etc/cont-init.d/99-run.sh
+++ b/ente/rootfs/etc/cont-init.d/99-run.sh
@@ -10,14 +10,14 @@ if [ -f "$MINIO_CRED_FILE" ]; then
     MINIO_PASS="$(sed -n '2p' "$MINIO_CRED_FILE")"
     # Regenerate if file is corrupted
     if [ -z "$MINIO_USER" ] || [ -z "$MINIO_PASS" ]; then
-        MINIO_USER="minio_$(tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c 8)"
+        MINIO_USER="minio_$(tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c 8 || true)"
         MINIO_PASS="$(head -c 24 /dev/urandom | base64 | tr -d '\n')"
         printf '%s\n%s\n' "$MINIO_USER" "$MINIO_PASS" > "$MINIO_CRED_FILE"
         chmod 600 "$MINIO_CRED_FILE"
     fi
 else
     # Generate random credentials on first run
-    MINIO_USER="minio_$(tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c 8)"
+    MINIO_USER="minio_$(tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c 8 || true)"
     MINIO_PASS="$(head -c 24 /dev/urandom | base64 | tr -d '\n')"
     printf '%s\n%s\n' "$MINIO_USER" "$MINIO_PASS" > "$MINIO_CRED_FILE"
     chmod 600 "$MINIO_CRED_FILE"


### PR DESCRIPTION
…pattern

tr reads from the infinite /dev/urandom stream; head exits after N bytes, closing the pipe, which sends SIGPIPE to tr (exit 141). With set -euo pipefail at the top of 99-run.sh, pipefail surfaces that as the script exit code and the container never starts. Suppress it with || true on both occurrences in the MinIO credential generation block.

https://claude.ai/code/session_01MaLKhb2CJiF9Fb3Dyr585r