### PR TITLE
aurral: switch build.json to :latest tag

### DIFF
--- a/aurral/build.json
+++ b/aurral/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/lklynet/aurral:1.76.40",
-    "amd64": "ghcr.io/lklynet/aurral:1.76.40"
+    "aarch64": "ghcr.io/lklynet/aurral:latest",
+    "amd64": "ghcr.io/lklynet/aurral:latest"
   }
 }


### PR DESCRIPTION
## Problem

`build.json` has been pinned to a specific upstream version (`1.76.40`) which has never been updated by the bot. This causes the addon to always build from a stale image regardless of what version `config.yaml` is on.

## Fix

Switch to `:latest`, consistent with the overwhelming majority of addons in this repo (e.g. emby, radarr, bazarr, tdarr, netalertx, autobrr, maintainerr, etc). The bot will continue to update `config.yaml`, `updater.json`, and `CHANGELOG.md` as normal — `build.json` no longer needs to be touched.