### PR TITLE
Migrate bashio::addon.* to bashio::app.* (deprecated API)

### DIFF
--- a/.templates/00-banner.sh
+++ b/.templates/00-banner.sh
@@ -26,14 +26,14 @@ if ! bashio::supervisor.ping 2>/dev/null; then
     done
 else
     bashio::log.blue '-----------------------------------------------------------'
-    bashio::log.blue " Add-on: $(bashio::addon.name)"
-    bashio::log.blue " $(bashio::addon.description)"
+    bashio::log.blue " Add-on: $(bashio::app.name)"
+    bashio::log.blue " $(bashio::app.description)"
     bashio::log.blue '-----------------------------------------------------------'
 
-    bashio::log.blue " Add-on version: $(bashio::addon.version)"
-    if bashio::var.true "$(bashio::addon.update_available)"; then
+    bashio::log.blue " Add-on version: $(bashio::app.version)"
+    if bashio::var.true "$(bashio::app.update_available)"; then
         bashio::log.magenta " There is an update available!"
-        bashio::log.magenta " Latest version: $(bashio::addon.version_latest)"
+        bashio::log.magenta " Latest version: $(bashio::app.version_latest)"
     else
         bashio::log.green " You are running the latest version."
     fi

--- a/.templates/00-local_mounts.sh
+++ b/.templates/00-local_mounts.sh
@@ -105,7 +105,7 @@ if bashio::config.has_value 'localdisks'; then
             || (
                 bashio::log.fatal "Unable to mount local drives! Please check the name."
                 rmdir /mnt/"$disk"
-                bashio::addon.stop
+                bashio::app.stop
             )
     done
 

--- a/.templates/00-smb_mounts.sh
+++ b/.templates/00-smb_mounts.sh
@@ -327,7 +327,7 @@ if bashio::config.has_value 'networkdisks'; then
             bashio::log.fatal "...... incorrect Username, Password, or Domain! Script will stop."
             cleanup_cred
             rm -f "$ERRORCODE_FILE" 2>/dev/null || true
-            bashio::addon.stop
+            bashio::app.stop
           elif echo "$OUTPUT" | grep -q "tree connect failed" || echo "$OUTPUT" | grep -q "NT_STATUS_CONNECTION_DISCONNECTED"; then
             echo "... using SMBv1"
             bashio::log.warning "...... share reachable only with legacy SMBv1 (NT1) negotiation. Forcing SMBv1 options."
@@ -467,7 +467,7 @@ if bashio::config.has_value 'networkdisks'; then
       cleanup_cred
       rm -f "$ERRORCODE_FILE" 2>/dev/null || true
 
-      bashio::addon.stop
+      bashio::app.stop
     fi
   done
 fi

--- a/.templates/01-config_yaml.sh
+++ b/.templates/01-config_yaml.sh
@@ -62,7 +62,7 @@ if [[ "$CONFIGLOCATION" == "/config" ]]; then
     fi
     # Migrate option
     if [[ "$(bashio::config "CONFIG_LOCATION")" == "/config/addons_config"* ]] && [ -f /config/config.yaml ]; then
-        bashio::addon.option "CONFIG_LOCATION" "/config/config.yaml"
+        bashio::app.option "CONFIG_LOCATION" "/config/config.yaml"
         CONFIGSOURCE="/config/config.yaml"
     fi
 fi

--- a/.templates/01-custom_script.sh
+++ b/.templates/01-custom_script.sh
@@ -50,7 +50,7 @@ SHEBANG_ERRORS=()
 probe_script_content='
 set -e
 
-if ! command -v bashio::addon.version >/dev/null 2>&1; then
+if ! command -v bashio::app.version >/dev/null 2>&1; then
   for f in \
     /usr/lib/bashio/bashio.sh \
     /usr/lib/bashio/lib.sh \
@@ -66,7 +66,7 @@ if ! command -v bashio::addon.version >/dev/null 2>&1; then
 fi
 
 set +e
-_bv="$(bashio::addon.version 2>/dev/null)"
+_bv="$(bashio::app.version 2>/dev/null)"
 _rc=$?
 set -e
 
@@ -75,7 +75,7 @@ if [ "$_rc" -ne 0 ] || [ -z "$_bv" ] || [ "$_bv" = "null" ]; then
     if [ -f "$_sf" ]; then
       # shellcheck disable=SC1090
       . "$_sf"
-      _bv="$(bashio::addon.version 2>/dev/null || true)"
+      _bv="$(bashio::app.version 2>/dev/null || true)"
       break
     fi
   done
@@ -147,7 +147,7 @@ if [ -z "$shebang" ]; then
   exit 1
 fi
 
-if ! command -v bashio::addon.version >/dev/null 2>&1; then
+if ! command -v bashio::app.version >/dev/null 2>&1; then
   for f in /usr/lib/bashio/bashio.sh /usr/lib/bashio/lib.sh /usr/src/bashio/bashio.sh /usr/local/lib/bashio/bashio.sh /usr/local/lib/bashio-standalone.sh; do
     if [ -f "$f" ]; then
       # shellcheck disable=SC1090

--- a/.templates/bashio-standalone.sh
+++ b/.templates/bashio-standalone.sh
@@ -202,6 +202,13 @@ bashio::addon.port() {
   fi
 }
 
+# addon.ingress_url : HA Supervisor provides this; in standalone mode return empty
+bashio::addon.ingress_url() { printf '%s' "${ADDON_INGRESS_URL:-}"; }
+
+# addon.restart / addon.stop : no-ops in standalone (no Supervisor to call)
+bashio::addon.restart() { bashio::log.warning "bashio::app.restart called in standalone mode – no-op"; }
+bashio::addon.stop()    { bashio::log.warning "bashio::app.stop called in standalone mode – no-op"; }
+
 # addon.option : write/delete option in JSON when possible; fallback export env
 bashio::addon.option() {
   local key="${1:-}" value="${2-__BASHIO_UNSET__}" file="${STANDALONE_OPTIONS_JSON:-}"
@@ -432,3 +439,22 @@ bashio::core.check() {
     return 0
   fi
 }
+
+# -----------------------------------------------------------------------------
+# bashio::app.* — forward-compat aliases for the new API (replaces addon.*)
+# Scripts should use bashio::app.* going forward; bashio::addon.* is kept for
+# backward compatibility with older bashio installations.
+# -----------------------------------------------------------------------------
+bashio::app.name()            { bashio::addon.name "$@"; }
+bashio::app.description()     { bashio::addon.description "$@"; }
+bashio::app.version()         { bashio::addon.version "$@"; }
+bashio::app.version_latest()  { bashio::addon.version_latest "$@"; }
+bashio::app.update_available(){ bashio::addon.update_available "$@"; }
+bashio::app.ingress_port()    { bashio::addon.ingress_port "$@"; }
+bashio::app.ingress_entry()   { bashio::addon.ingress_entry "$@"; }
+bashio::app.ingress_url()     { bashio::addon.ingress_url "$@"; }
+bashio::app.ip_address()      { bashio::addon.ip_address "$@"; }
+bashio::app.port()            { bashio::addon.port "$@"; }
+bashio::app.option()          { bashio::addon.option "$@"; }
+bashio::app.restart()         { bashio::addon.restart "$@"; }
+bashio::app.stop()            { bashio::addon.stop "$@"; }

--- a/.templates/ha_entrypoint.sh
+++ b/.templates/ha_entrypoint.sh
@@ -68,7 +68,7 @@ SHEBANG_ERRORS=()
 probe_script_content='
 set -e
 
-if ! command -v bashio::addon.version >/dev/null 2>&1; then
+if ! command -v bashio::app.version >/dev/null 2>&1 && ! command -v bashio::addon.version >/dev/null 2>&1; then
   for f in \
     /usr/lib/bashio/bashio.sh \
     /usr/lib/bashio/lib.sh \
@@ -83,9 +83,13 @@ if ! command -v bashio::addon.version >/dev/null 2>&1; then
   done
 fi
 
-# Try regular bashio, fallback to standalone if unavailable or fails
+# Try bashio::app.version (new API), fall back to bashio::addon.version (old API)
 set +e
-_bv="$(bashio::addon.version 2>/dev/null)"
+if command -v bashio::app.version >/dev/null 2>&1; then
+  _bv="$(bashio::app.version 2>/dev/null)"
+else
+  _bv="$(bashio::addon.version 2>/dev/null)"
+fi
 _rc=$?
 set -e
 
@@ -94,7 +98,11 @@ if [ "$_rc" -ne 0 ] || [ -z "$_bv" ] || [ "$_bv" = "null" ]; then
     if [ -f "$_sf" ]; then
       # shellcheck disable=SC1090
       . "$_sf"
-      _bv="$(bashio::addon.version 2>/dev/null || true)"
+      if command -v bashio::app.version >/dev/null 2>&1; then
+        _bv="$(bashio::app.version 2>/dev/null || true)"
+      else
+        _bv="$(bashio::addon.version 2>/dev/null || true)"
+      fi
       break
     fi
   done
@@ -158,7 +166,7 @@ for candidate in "${candidate_shebangs[@]}"; do
 done
 
 if [ -z "$shebang" ]; then
-  echo "ERROR: No valid shebang found (unable to execute bashio::addon.version via candidates)." >&2
+  echo "ERROR: No valid shebang found (unable to execute bashio::app.version / bashio::addon.version via candidates)." >&2
   echo "Tried:" >&2
   printf ' - %s\n' "${candidate_shebangs[@]}" >&2
   if [ "${#SHEBANG_ERRORS[@]}" -gt 0 ]; then
@@ -192,6 +200,15 @@ fi
 # Starting scripts #
 ####################
 
+# Inject a backward-compat shim after the shebang so scripts using bashio::app.*
+# also work on older bashio installations that only provide bashio::addon.*.
+# On new bashio the guard (command -v bashio::app.version) is true and the block is skipped.
+_BASHIO_COMPAT_SHIM='command -v bashio::app.version >/dev/null 2>&1 || { bashio::app.version(){ bashio::addon.version "$@"; }; bashio::app.name(){ bashio::addon.name "$@"; }; bashio::app.description(){ bashio::addon.description "$@"; }; bashio::app.version_latest(){ bashio::addon.version_latest "$@"; }; bashio::app.update_available(){ bashio::addon.update_available "$@"; }; bashio::app.ingress_port(){ bashio::addon.ingress_port "$@"; }; bashio::app.ingress_entry(){ bashio::addon.ingress_entry "$@"; }; bashio::app.ingress_url(){ bashio::addon.ingress_url "$@"; }; bashio::app.ip_address(){ bashio::addon.ip_address "$@"; }; bashio::app.port(){ bashio::addon.port "$@"; }; bashio::app.option(){ bashio::addon.option "$@"; }; bashio::app.restart(){ bashio::addon.restart "$@"; }; bashio::app.stop(){ bashio::addon.stop "$@"; }; }'
+
+_inject_bashio_compat() {
+  sed -i "1a $_BASHIO_COMPAT_SHIM" "$1"
+}
+
 run_one_script() {
   local script="$1"
 
@@ -207,6 +224,7 @@ run_one_script() {
   fi
 
   sed -i "1s|^.*|#!$shebang|" "$script"
+  _inject_bashio_compat "$script"
   chmod +x "$script"
 
   if [ "${ha_entry_source:-null}" = "true" ]; then
@@ -251,6 +269,7 @@ if $PID1; then
     [ -f "$runfile" ] || continue
     echo "Starting: $runfile"
     sed -i "1s|^.*|#!$shebang|" "$runfile"
+    _inject_bashio_compat "$runfile"
     chmod +x "$runfile"
     (
       restart_count=0

--- a/autobrr/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/autobrr/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -8,9 +8,9 @@ set -e
 declare ingress_interface
 declare ingress_port
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
-ingress_entry=$(bashio::addon.ingress_entry)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
+ingress_entry=$(bashio::app.ingress_entry)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf

--- a/bazarr/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/bazarr/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -8,9 +8,9 @@ set -e
 declare ingress_interface
 declare ingress_port
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
-ingress_entry=$(bashio::addon.ingress_entry)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
+ingress_entry=$(bashio::app.ingress_entry)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf

--- a/bazarr/rootfs/etc/services.d/nginx/run
+++ b/bazarr/rootfs/etc/services.d/nginx/run
@@ -18,7 +18,7 @@ if [ -f "$CONFIG_LOCATION" ]; then
             if ! grep -q "base_url.*$slug" "$CONFIG_LOCATION"; then
                 bashio::log.warning "BaseUrl not set properly, restarting"
                 sed -i "s/  base_url:.*/  base_url: $slug/" "$CONFIG_LOCATION"
-                bashio::addon.restart
+                bashio::app.restart
             fi
         fi
     fi

--- a/binance-trading-bot/rootfs/etc/cont-init.d/32-ingress.sh
+++ b/binance-trading-bot/rootfs/etc/cont-init.d/32-ingress.sh
@@ -8,9 +8,9 @@ set -e
 declare ingress_interface
 declare ingress_port
 
-ingress_port="$(bashio::addon.ingress_port)"
-ingress_interface="$(bashio::addon.ip_address)"
-ingress_entry=$(bashio::addon.ingress_entry)
+ingress_port="$(bashio::app.ingress_port)"
+ingress_interface="$(bashio::app.ip_address)"
+ingress_entry=$(bashio::app.ingress_entry)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf

--- a/birdnet-go/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/birdnet-go/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -10,9 +10,9 @@ declare ingress_interface
 declare ingress_port
 
 echo "Adapting for ingress"
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
-ingress_entry=$(bashio::addon.ingress_entry)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
+ingress_entry=$(bashio::app.ingress_entry)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf

--- a/birdnet-pi/rootfs/etc/cont-init.d/31-config_checks.sh
+++ b/birdnet-pi/rootfs/etc/cont-init.d/31-config_checks.sh
@@ -47,7 +47,7 @@ done
 # CHECK PORT #
 ##############
 
-if [[ "$(bashio::addon.port "80")" == 3000 ]]; then
+if [[ "$(bashio::app.port "80")" == 3000 ]]; then
     bashio::log.fatal "This is crazy but your port is set to 3000 and streamlit doesn't accept this port! You need to change it from the addon options and restart. Thanks"
     sleep infinity
 fi

--- a/birdnet-pi/rootfs/etc/cont-init.d/81-modifications.sh
+++ b/birdnet-pi/rootfs/etc/cont-init.d/81-modifications.sh
@@ -34,7 +34,7 @@ if bashio::supervisor.ping 2> /dev/null; then
     done
 
     # Check if port 80 is correctly configured
-    if [ -n "$(bashio::addon.port "80")" ] && [ "$(bashio::addon.port "80")" != 80 ]; then
+    if [ -n "$(bashio::app.port "80")" ] && [ "$(bashio::app.port "80")" != 80 ]; then
         bashio::log.fatal "The port 80 is enabled, but should still be 80 if you want automatic SSL certificates generation to work."
     fi
 fi

--- a/birdnet-pi/rootfs/etc/cont-init.d/91-nginx_ingress.sh
+++ b/birdnet-pi/rootfs/etc/cont-init.d/91-nginx_ingress.sh
@@ -18,9 +18,9 @@ fi
 #################
 
 # Variables
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
-ingress_entry=$(bashio::addon.ingress_entry)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
+ingress_entry=$(bashio::app.ingress_entry)
 
 # Quits if ingress is not active
 if [[ "$ingress_entry" != "/api"* ]]; then

--- a/birdnet-pipy/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/birdnet-pipy/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -9,9 +9,9 @@ set -e
 declare ingress_interface
 declare ingress_port
 
-ingress_port="$(bashio::addon.ingress_port)"
-ingress_interface="$(bashio::addon.ip_address)"
-ingress_entry="$(bashio::addon.ingress_entry)"
+ingress_port="$(bashio::app.ingress_port)"
+ingress_interface="$(bashio::app.ip_address)"
+ingress_entry="$(bashio::app.ingress_entry)"
 
 sed -i \
     -e "s|proxy_pass http://api|proxy_pass http://127.0.0.1|g" \

--- a/browser_chromium/rootfs/etc/cont-init.d/80-configuration.sh
+++ b/browser_chromium/rootfs/etc/cont-init.d/80-configuration.sh
@@ -42,7 +42,7 @@ if bashio::config.has_value 'PASSWORD'; then
     PASSWORD=$(bashio::config 'PASSWORD')
     passwd -d abc
     echo -e "$PASSWORD\n$PASSWORD" | passwd abc
-elif ! bashio::config.has_value 'PASSWORD' && [[ -n "$(bashio::addon.port "3000")" ]] && [[ -n $(bashio::addon.port "3001") ]]; then
+elif ! bashio::config.has_value 'PASSWORD' && [[ -n "$(bashio::app.port "3000")" ]] && [[ -n $(bashio::app.port "3001") ]]; then
     bashio::log.warning "SEVERE RISK IDENTIFIED"
     bashio::log.warning "You are opening an external port but your password is not defined"
     bashio::log.warning "You risk being hacked ! Please disable the external ports, or use a password"

--- a/browser_chromium/rootfs/etc/cont-init.d/90-ingress.sh
+++ b/browser_chromium/rootfs/etc/cont-init.d/90-ingress.sh
@@ -4,7 +4,7 @@ set -e
 
 # nginx Path
 NGINX_CONFIG=/etc/nginx/sites-available/ingress.conf
-SUBFOLDER="$(bashio::addon.ingress_entry)/"
+SUBFOLDER="$(bashio::app.ingress_entry)/"
 
 # Copy template
 cp /defaults/default.conf "${NGINX_CONFIG}"
@@ -15,7 +15,7 @@ mv tmpfile "${NGINX_CONFIG}"
 # Remove ipv6
 sed -i '/listen \[::\]/d' "${NGINX_CONFIG}"
 # Add ingress parameters
-sed -i "s|3000|$(bashio::addon.ingress_port)|g" "${NGINX_CONFIG}"
+sed -i "s|3000|$(bashio::app.ingress_port)|g" "${NGINX_CONFIG}"
 sed -i "s|CWS|8082|g" "${NGINX_CONFIG}"
 sed -i '/proxy_buffering/a proxy_set_header Accept-Encoding "";' "${NGINX_CONFIG}"
 sed -i '/proxy_buffering/a sub_filter_once off;' "${NGINX_CONFIG}"

--- a/calibre/rootfs/etc/cont-init.d/90-ingress.sh
+++ b/calibre/rootfs/etc/cont-init.d/90-ingress.sh
@@ -3,7 +3,7 @@
 set -e
 
 NGINX_CONFIG=/etc/nginx/sites-available/ingress.conf
-SUBFOLDER="$(bashio::addon.ingress_entry)"
+SUBFOLDER="$(bashio::app.ingress_entry)"
 
 # Ensure subfolder ends with a trailing slash (except for root)
 if [[ -n "${SUBFOLDER}" && "${SUBFOLDER}" != "/" ]]; then
@@ -22,7 +22,7 @@ mv tmpfile "${NGINX_CONFIG}"
 sed -i '/listen \[::\]/d' "${NGINX_CONFIG}"
 
 # Adapt ports and upstream paths for Home Assistant ingress
-sed -i "s|3000|$(bashio::addon.ingress_port)|g" "${NGINX_CONFIG}"
+sed -i "s|3000|$(bashio::app.ingress_port)|g" "${NGINX_CONFIG}"
 sed -i "s|SUBFOLDER|/|g" "${NGINX_CONFIG}"
 sed -i "s|CWS|8082|g" "${NGINX_CONFIG}"
 sed -i "s|REPLACE_HOME|${HOME:-/root}|g" "${NGINX_CONFIG}"

--- a/calibre_web/rootfs/etc/cont-init.d/32-nginx.sh
+++ b/calibre_web/rootfs/etc/cont-init.d/32-nginx.sh
@@ -12,7 +12,7 @@ declare ingress_interface
 declare ingress_port
 #declare keyfile
 
-#port=$(bashio::addon.port 80)
+#port=$(bashio::app.port 80)
 #if bashio::var.has_value "${port}"; then
 #    bashio::config.require.ssl
 #
@@ -45,12 +45,12 @@ if bashio::config.has_value 'ingress_user'; then
     ingress_user=$(bashio::config 'ingress_user')
 fi
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
 #ha_port=$(bashio::core.port)
 
 sed -i "s/%%ingress_user%%/${ingress_user}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 #sed -i "s/%%haport%%/${ha_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
-sed -i "s|%%UIPATH%%|$(bashio::addon.ingress_entry)|g" /etc/nginx/servers/ingress.conf
+sed -i "s|%%UIPATH%%|$(bashio::app.ingress_entry)|g" /etc/nginx/servers/ingress.conf

--- a/changedetection.io/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/changedetection.io/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -9,9 +9,9 @@ declare ingress_interface
 declare ingress_port
 declare ingress_entry
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
-ingress_entry=$(bashio::addon.ingress_entry)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
+ingress_entry=$(bashio::app.ingress_entry)
 
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf

--- a/cloudcommander/rootfs/etc/cont-init.d/99-run.sh
+++ b/cloudcommander/rootfs/etc/cont-init.d/99-run.sh
@@ -51,7 +51,7 @@ declare ingress_interface
 declare ingress_port
 # declare keyfile
 
-CLOUDCMD_PREFIX=$(bashio::addon.ingress_entry)
+CLOUDCMD_PREFIX=$(bashio::app.ingress_entry)
 export CLOUDCMD_PREFIX
 
 declare ADDON_PROTOCOL=http
@@ -60,9 +60,9 @@ if bashio::config.true 'ssl'; then
     bashio::config.require.ssl
 fi
 
-# port=$(bashio::addon.port 80)
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
+# port=$(bashio::app.port 80)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
 sed -i "s|%%protocol%%|${ADDON_PROTOCOL}|g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%port%%|${ingress_port}|g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%interface%%|${ingress_interface}|g" /etc/nginx/servers/ingress.conf

--- a/codex/rootfs/etc/cont-init.d/91-csrf.sh
+++ b/codex/rootfs/etc/cont-init.d/91-csrf.sh
@@ -8,7 +8,7 @@ CSRF=""
 # Get HA Port
 result=$(bashio::api.supervisor GET /core/info true || true)
 port=$(bashio::jq "$result" ".data.port")
-addon_port=$(bashio::addon.port 9810)
+addon_port=$(bashio::app.port 9810)
 
 # Get all possible URLs
 result=$(bashio::api.supervisor GET /core/api/config true || true)
@@ -44,7 +44,7 @@ for url in "${urls[@]}"; do
     if bashio::var.has_value "${url}"; then
         if [[ "${url}" != "null" ]] && [[ "${url}" != "null.local" ]]; then
             CSRF="https://${url}:${port},http://${url}:${port},https://${url},http://${url}",${CSRF}
-            if bashio::var.has_value "$(bashio::addon.port 9810)"; then
+            if bashio::var.has_value "$(bashio::app.port 9810)"; then
                 CSRF="https://${url}:${addon_port},http://${url}:${addon_port}",${CSRF}
             fi
         fi

--- a/codex/rootfs/etc/cont-init.d/99-run.sh
+++ b/codex/rootfs/etc/cont-init.d/99-run.sh
@@ -26,7 +26,7 @@ declare ingress_interface
 declare ingress_port
 #declare keyfile
 
-FB_BASEURL="$(bashio::addon.ingress_entry)"
+FB_BASEURL="$(bashio::app.ingress_entry)"
 export FB_BASEURL
 
 declare ADDON_PROTOCOL=http
@@ -35,9 +35,9 @@ if bashio::config.true 'ssl'; then
     ADDON_PROTOCOL=https
 fi
 
-#port=$(bashio::addon.port 80)
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
+#port=$(bashio::app.port 80)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
 sed -i "s|%%protocol%%|${ADDON_PROTOCOL}|g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%port%%|${ingress_port}|g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%interface%%|${ingress_interface}|g" /etc/nginx/servers/ingress.conf

--- a/comixed/rootfs/etc/cont-init.d/99-run.sh
+++ b/comixed/rootfs/etc/cont-init.d/99-run.sh
@@ -28,7 +28,7 @@ if [[ "$INGRESS" == "true" ]]; then
     declare ingress_port
     #declare keyfile
 
-    FB_BASEURL="$(bashio::addon.ingress_entry)"
+    FB_BASEURL="$(bashio::app.ingress_entry)"
     export FB_BASEURL
 
     declare ADDON_PROTOCOL=http
@@ -37,9 +37,9 @@ if [[ "$INGRESS" == "true" ]]; then
         ADDON_PROTOCOL=https
     fi
 
-    #port=$(bashio::addon.port 80)
-    ingress_port=$(bashio::addon.ingress_port)
-    ingress_interface=$(bashio::addon.ip_address)
+    #port=$(bashio::app.port 80)
+    ingress_port=$(bashio::app.ingress_port)
+    ingress_interface=$(bashio::app.ip_address)
     sed -i "s|%%protocol%%|${ADDON_PROTOCOL}|g" /etc/nginx/servers/ingress.conf
     sed -i "s|%%port%%|${ingress_port}|g" /etc/nginx/servers/ingress.conf
     sed -i "s|%%interface%%|${ingress_interface}|g" /etc/nginx/servers/ingress.conf

--- a/emby/rootfs/etc/cont-init.d/32-nginx.sh
+++ b/emby/rootfs/etc/cont-init.d/32-nginx.sh
@@ -10,8 +10,8 @@ declare ingress_interface
 declare ingress_port
 
 echo "Adapting for ingress"
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 

--- a/emby_beta/rootfs/etc/cont-init.d/32-nginx.sh
+++ b/emby_beta/rootfs/etc/cont-init.d/32-nginx.sh
@@ -10,8 +10,8 @@ declare ingress_interface
 declare ingress_port
 
 echo "Adapting for ingress"
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 

--- a/enedisgateway2mqtt/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/enedisgateway2mqtt/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -8,9 +8,9 @@ set -e
 declare ingress_interface
 declare ingress_port
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
-ingress_entry=$(bashio::addon.ingress_entry)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
+ingress_entry=$(bashio::app.ingress_entry)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf

--- a/enedisgateway2mqtt_dev/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/enedisgateway2mqtt_dev/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -8,9 +8,9 @@ set -e
 declare ingress_interface
 declare ingress_port
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
-ingress_entry=$(bashio::addon.ingress_entry)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
+ingress_entry=$(bashio::app.ingress_entry)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf

--- a/filebrowser/rootfs/etc/cont-init.d/99-run.sh
+++ b/filebrowser/rootfs/etc/cont-init.d/99-run.sh
@@ -42,7 +42,7 @@ declare ingress_interface
 declare ingress_port
 #declare keyfile
 
-FB_BASE_URL=$(bashio::addon.ingress_entry)
+FB_BASE_URL=$(bashio::app.ingress_entry)
 export FB_BASE_URL
 
 declare ADDON_PROTOCOL=http
@@ -51,9 +51,9 @@ if bashio::config.true 'ssl'; then
     ADDON_PROTOCOL=https
 fi
 
-#port=$(bashio::addon.port 80)
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
+#port=$(bashio::app.port 80)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
 sed -i "s|%%protocol%%|${ADDON_PROTOCOL}|g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%port%%|${ingress_port}|g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%interface%%|${ingress_interface}|g" /etc/nginx/servers/ingress.conf

--- a/filebrowser_quantum/rootfs/etc/cont-init.d/99-run.sh
+++ b/filebrowser_quantum/rootfs/etc/cont-init.d/99-run.sh
@@ -43,7 +43,7 @@ declare ingress_interface
 declare ingress_port
 #declare keyfile
 
-FB_BASEURL=$(bashio::addon.ingress_entry)
+FB_BASEURL=$(bashio::app.ingress_entry)
 export FB_BASEURL
 
 declare ADDON_PROTOCOL=http
@@ -52,9 +52,9 @@ if bashio::config.true 'ssl'; then
     ADDON_PROTOCOL=https
 fi
 
-#port=$(bashio::addon.port 80)
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
+#port=$(bashio::app.port 80)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
 sed -i "s|%%protocol%%|${ADDON_PROTOCOL}|g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%port%%|${ingress_port}|g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%interface%%|${ingress_interface}|g" /etc/nginx/servers/ingress.conf

--- a/fireflyiii_data_importer/rootfs/etc/cont-init.d/20-migration_config.sh
+++ b/fireflyiii_data_importer/rootfs/etc/cont-init.d/20-migration_config.sh
@@ -6,8 +6,8 @@ slug=fireflyiii_data_importer
 
 if [[ "$(bashio::config "CONFIG_LOCATION")" == *"/addons_config/fireflyiii_data_importer"* ]]; then
     bashio::log.warning "Reset CONFIG_LOCATION to /config"
-    bashio::addon.option "CONFIG_LOCATION" "/config"
-    bashio::addon.restart
+    bashio::app.option "CONFIG_LOCATION" "/config"
+    bashio::app.restart
 fi
 
 CONFIGSOURCE="$(bashio::config "CONFIG_LOCATION")"

--- a/free_games_claimer/rootfs/etc/cont-init.d/99-run.sh
+++ b/free_games_claimer/rootfs/etc/cont-init.d/99-run.sh
@@ -82,4 +82,4 @@ done
 
 bashio::log.info "All actions concluded. Stopping in 10 seconds."
 sleep 10
-bashio::addon.stop
+bashio::app.stop

--- a/gitea/rootfs/etc/cont-init.d/99-run.sh
+++ b/gitea/rootfs/etc/cont-init.d/99-run.sh
@@ -38,7 +38,7 @@ for file in /data/gitea/conf/app.ini /etc/templates/app.ini; do
     if bashio::config.has_value 'ROOT_URL'; then
         bashio::log.blue "ROOT_URL set, using value : $(bashio::config 'ROOT_URL')"
     else
-        ROOT_URL="$PROTOCOL://$(bashio::config 'DOMAIN'):$(bashio::addon.port 3000)"
+        ROOT_URL="$PROTOCOL://$(bashio::config 'DOMAIN'):$(bashio::app.port 3000)"
         bashio::log.blue "ROOT_URL not set, using extrapolated value : $ROOT_URL"
         sed -i "/server/a ROOT_URL=$ROOT_URL" "$file"
     fi

--- a/grampsweb/rootfs/etc/cont-init.d/32-nginx_ssl.sh
+++ b/grampsweb/rootfs/etc/cont-init.d/32-nginx_ssl.sh
@@ -12,7 +12,7 @@ declare keyfile
 # General values
 port=5001
 sed -i "s|%%port%%|$port|g" /etc/nginx/servers/ssl.conf
-sed -i "s|%%interface%%|$(bashio::addon.ip_address)|g" /etc/nginx/servers/ssl.conf
+sed -i "s|%%interface%%|$(bashio::app.ip_address)|g" /etc/nginx/servers/ssl.conf
 
 # Ssl values
 if bashio::config.true 'ssl'; then
@@ -29,5 +29,5 @@ if bashio::config.true 'ssl'; then
     sed -i "s|default_server|ssl|g" /etc/nginx/servers/ssl.conf
     sed -i "/proxy_params.conf/a ssl_certificate /ssl/$certfile;" /etc/nginx/servers/ssl.conf
     sed -i "/proxy_params.conf/a ssl_certificate_key /ssl/$keyfile;" /etc/nginx/servers/ssl.conf
-    bashio::log.info "Ssl enabled, please use https for connection. UI is at https://YOURIP:$(bashio::addon.port "$port")"
+    bashio::log.info "Ssl enabled, please use https for connection. UI is at https://YOURIP:$(bashio::app.port "$port")"
 fi

--- a/grampsweb/rootfs/etc/cont-init.d/99-run.sh
+++ b/grampsweb/rootfs/etc/cont-init.d/99-run.sh
@@ -44,7 +44,7 @@ else
     bashio::log.warning "Secret key saved to addon options."
     GRAMPSWEB_SECRET_KEY="$(cat /config/secret/secret)"
     export GRAMPSWEB_SECRET_KEY
-    bashio::addon.option "GRAMPSWEB_SECRET_KEY" "$GRAMPSWEB_SECRET_KEY"
+    bashio::app.option "GRAMPSWEB_SECRET_KEY" "$GRAMPSWEB_SECRET_KEY"
 fi
 
 ##################

--- a/guacamole/rootfs/etc/cont-init.d/90-ingress.sh
+++ b/guacamole/rootfs/etc/cont-init.d/90-ingress.sh
@@ -11,7 +11,7 @@ declare ingress_interface
 declare ingress_port
 declare keyfile
 
-port=$(bashio::addon.port 80)
+port=$(bashio::app.port 80)
 if bashio::var.has_value "${port}"; then
     bashio::config.require.ssl
 
@@ -28,12 +28,12 @@ if bashio::var.has_value "${port}"; then
     fi
 fi
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 
 # Implement SUBFOLDER value
-if [ -f /etc/s6-overlay/s6-rc.d/svc-autostart/run ]; then sed -i "1a SUBFOLDER=$(bashio::addon.ingress_url)" /etc/s6-overlay/s6-rc.d/svc-autostart/run; fi
-if [ -f /etc/services.d/guacamole/run ]; then sed -i "2a SUBFOLDER=$(bashio::addon.ingress_url)" /etc/services.d/guacamole/run; fi
-if [ -f /etc/services.d/guacd/run ]; then sed -i "2a SUBFOLDER=$(bashio::addon.ingress_url)" /etc/services.d/guacd/run; fi
+if [ -f /etc/s6-overlay/s6-rc.d/svc-autostart/run ]; then sed -i "1a SUBFOLDER=$(bashio::app.ingress_url)" /etc/s6-overlay/s6-rc.d/svc-autostart/run; fi
+if [ -f /etc/services.d/guacamole/run ]; then sed -i "2a SUBFOLDER=$(bashio::app.ingress_url)" /etc/services.d/guacamole/run; fi
+if [ -f /etc/services.d/guacd/run ]; then sed -i "2a SUBFOLDER=$(bashio::app.ingress_url)" /etc/services.d/guacd/run; fi

--- a/immich/rootfs/etc/cont-init.d/99-run.sh
+++ b/immich/rootfs/etc/cont-init.d/99-run.sh
@@ -39,7 +39,7 @@ check_db_hostname() {
         bashio::log.warning "The addon will stop until this is fixed."
         bashio::log.warning "------------------------------------"
         sleep 30
-        bashio::addon.stop
+        bashio::app.stop
     else
         echo "$DB_HOSTNAME is reachable."
     fi
@@ -89,7 +89,7 @@ setup_root_user() {
     else
         bashio::log.warning "DB_ROOT_PASSWORD not set. Generating a random 12-character alphanumeric password and storing it in the addon options."
         export DB_ROOT_PASSWORD="$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c12)"
-        bashio::addon.option "DB_ROOT_PASSWORD" "${DB_ROOT_PASSWORD}"
+        bashio::app.option "DB_ROOT_PASSWORD" "${DB_ROOT_PASSWORD}"
 
         # Store generated password in the s6 environment if available
         if [ -d /var/run/s6/container_environment ]; then

--- a/jellyfin/rootfs/etc/cont-init.d/32-ingress.sh
+++ b/jellyfin/rootfs/etc/cont-init.d/32-ingress.sh
@@ -11,7 +11,7 @@ declare ingress_interface
 declare ingress_port
 declare keyfile
 
-port=$(bashio::addon.port 80)
+port=$(bashio::app.port 80)
 if bashio::var.has_value "${port}"; then
     bashio::config.require.ssl
 
@@ -28,8 +28,8 @@ if bashio::var.has_value "${port}"; then
     fi
 fi
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 

--- a/joal/rootfs/etc/cont-init.d/99-run.sh
+++ b/joal/rootfs/etc/cont-init.d/99-run.sh
@@ -63,16 +63,16 @@ declare ingress_interface
 declare ingress_port
 #declare keyfile
 
-#INGRESSURL=$(bashio::config 'local_ip_port')$(bashio::addon.ingress_url)
+#INGRESSURL=$(bashio::config 'local_ip_port')$(bashio::app.ingress_url)
 host_port=$(bashio::core.port)
-ingress_url=$(bashio::addon.ingress_entry)
-ADDONPORT=$(bashio::addon.port "8081")
+ingress_url=$(bashio::app.ingress_entry)
+ADDONPORT=$(bashio::app.port "8081")
 host_ip=$(bashio::network.ipv4_address)
 host_ip=${host_ip%/*}
 UIPATH=$(bashio::config 'ui_path')
-#port=$(bashio::addon.port 80)
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
+#port=$(bashio::app.port 80)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
 
 #################
 # NGINX SETTING #

--- a/maintainerr/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/maintainerr/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -10,9 +10,9 @@ declare ingress_port
 
 bashio::log.info "Configuring NGinx for ingress..."
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
-ingress_entry=$(bashio::addon.ingress_entry)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
+ingress_entry=$(bashio::app.ingress_entry)
 
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf

--- a/mealie/rootfs/etc/cont-init.d/31-nginx.sh
+++ b/mealie/rootfs/etc/cont-init.d/31-nginx.sh
@@ -24,9 +24,9 @@ fi
 
 bashio::log.info "Adapting for ingress"
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
-ingress_entry=$(bashio::addon.ingress_entry)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
+ingress_entry=$(bashio::app.ingress_entry)
 base_path="/mealie/"
 sed -i "s|%%port%%|${ingress_port}|g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%interface%%|${ingress_interface}|g" /etc/nginx/servers/ingress.conf
@@ -36,7 +36,7 @@ sed -i "s|%%base_subpath%%|${base_path}|g" /etc/nginx/servers/ssl.conf
 
 if bashio::config.has_value "BASE_URL"; then
     BASE_URL="$(bashio::config "BASE_URL")"
-    BASE_URL="${BASE_URL#*://}:$(bashio::addon.port 9001)"
+    BASE_URL="${BASE_URL#*://}:$(bashio::app.port 9001)"
     sed -i "s|%%BASE_URL%%|$BASE_URL|g" /etc/nginx/servers/ssl.conf
 else
     sed -i "/BASE_URL/d" /etc/nginx/servers/ssl.conf

--- a/mealie/rootfs/etc/cont-init.d/91-discovery.sh
+++ b/mealie/rootfs/etc/cont-init.d/91-discovery.sh
@@ -6,7 +6,7 @@ declare config
 config=$(
     bashio::var.json \
         host "http://127.0.0.1" \
-        port "^$(bashio::addon.port 9001)"
+        port "^$(bashio::app.port 9001)"
 )
 
 if bashio::discovery "mealie" "${config}" > /dev/null; then

--- a/mealie/rootfs/run.txt
+++ b/mealie/rootfs/run.txt
@@ -84,13 +84,13 @@ if [ -d /homeassistant/addons_config/mealie_data ] && [ ! -f /homeassistant/addo
     bashio::log.warning "Migrating data, current data will not be touched"
     cp -rnf /homeassistant/addons_config/mealie_data/* /config/ || true
     touch /homeassistant/addons_config/mealie_data/migrated
-    bashio::addon.option "DATA_DIR" "/config"
+    bashio::app.option "DATA_DIR" "/config"
 fi
 if [ -f /homeassistant/addons_config/mealie/config.yaml ] && [ ! -f /homeassistant/addons_config/mealie/migrated ]; then
     bashio::log.warning "Migrating config.yaml, current data will not be touched"
     cp -nf /homeassistant/addons_config/mealie/config.yaml /config/ || true
     touch /homeassistant/addons_config/mealie/migrated
-    bashio::addon.option "DATA_DIR" "/config"
+    bashio::app.option "DATA_DIR" "/config"
 fi
 
 # Solve issues in migration
@@ -99,8 +99,8 @@ if [ -d /config/recipes ] && [ -d /config/backups ]; then
     [ -d /config/addons_autoscripts ] && rm -r /config/addons_autoscripts && bashio::log.warning "Deleted /config/addons_autoscripts, it shouldn't be there"
 fi
 if [[ "$(bashio::config "DATA_DIR")" == "/config/addons_config/mealie_data" ]]; then
-    bashio::addon.option "DATA_DIR" "/config"
-    bashio::addon.restart
+    bashio::app.option "DATA_DIR" "/config"
+    bashio::app.restart
 fi
 
 ###############

--- a/monica/rootfs/etc/cont-init.d/99-run.sh
+++ b/monica/rootfs/etc/cont-init.d/99-run.sh
@@ -115,10 +115,10 @@ if [ -z "$APP_KEY" ] || [ ${#APP_KEY} -lt 32 ]; then
         echo -n 'base64:'
         openssl rand -base64 32
     )"
-    bashio::addon.option "APP_KEY" "${APP_KEY}"
+    bashio::app.option "APP_KEY" "${APP_KEY}"
     bashio::log.warning "The APP_KEY set was invalid, generated a random one: ${APP_KEY}. Restarting to take it into account"
     echo "${APP_KEY}" >> /config/APP_KEY
-    bashio::addon.restart
+    bashio::app.restart
 fi
 APP_KEY="$(bashio::config "APP_KEY")"
 export APP_KEY

--- a/netalertx/rootfs/etc/cont-init.d/91-configure.sh
+++ b/netalertx/rootfs/etc/cont-init.d/91-configure.sh
@@ -6,7 +6,7 @@ set -e
 
 sed -i "s|'/server'|''|g" /app/back/app.conf
 sed -i "s|gzip on|gzip off|g" /services/config/nginx/netalertx.conf.template
-sed -i "/add_header X-Forwarded-Prefix/a sub_filter '\"/server' '\"$(bashio::addon.ingress_entry)/server';" /services/config/nginx/netalertx.conf.template
+sed -i "/add_header X-Forwarded-Prefix/a sub_filter '\"/server' '\"$(bashio::app.ingress_entry)/server';" /services/config/nginx/netalertx.conf.template
 sed -i "/add_header X-Forwarded-Prefix/a sub_filter_types *;" /services/config/nginx/netalertx.conf.template
 sed -i "/add_header X-Forwarded-Prefix/a sub_filter_once off;" /services/config/nginx/netalertx.conf.template
 
@@ -113,7 +113,7 @@ wait_for_config_file() {
         sleep 1
     done
     echo "$config_file is now available. Rebooting the addon."
-    bashio::addon.restart
+    bashio::app.restart
 }
 
 # Main script logic

--- a/nextcloud/rootfs/etc/cont-init.d/01-folders.sh
+++ b/nextcloud/rootfs/etc/cont-init.d/01-folders.sh
@@ -32,7 +32,7 @@ fi
 # Is the directory valid
 if [[ "$datadirectory" == *"/mnt/"* ]] && [ ! -f "$datadirectory"/index.html ]; then
     bashio::log.fatal "Data directory does not seem to be valid. Is your drive connected? Stopping to avoid corrupting the data directory."
-    bashio::addon.stop
+    bashio::app.stop
 fi
 
 # Remove nginx conf if existing

--- a/nzbget/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/nzbget/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -6,8 +6,8 @@ set -e
 # NGINX SETTING #
 #################
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 

--- a/photoprism/rootfs/etc/cont-init.d/01-migrate.sh
+++ b/photoprism/rootfs/etc/cont-init.d/01-migrate.sh
@@ -23,7 +23,7 @@ fi
 
 if [ "$old_config_location" != "$new_config_location" ]; then
     bashio::log.info "Updating CONFIG_LOCATION to $new_config_location"
-    bashio::addon.option "CONFIG_LOCATION" "$new_config_location"
+    bashio::app.option "CONFIG_LOCATION" "$new_config_location"
 fi
 
 if [ -d /config/addons_config ]; then

--- a/photoprism/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/photoprism/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -8,9 +8,9 @@ set -e
 declare ingress_interface
 declare ingress_port
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
-ingress_entry=$(bashio::addon.ingress_entry)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
+ingress_entry=$(bashio::app.ingress_entry)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf

--- a/photoprism/rootfs/etc/cont-init.d/32-nginx_ssl.sh
+++ b/photoprism/rootfs/etc/cont-init.d/32-nginx_ssl.sh
@@ -12,7 +12,7 @@ declare keyfile
 # General values
 port=2342
 sed -i "s|%%port%%|$port|g" /etc/nginx/servers/ssl.conf
-sed -i "s|%%interface%%|$(bashio::addon.ip_address)|g" /etc/nginx/servers/ssl.conf
+sed -i "s|%%interface%%|$(bashio::app.ip_address)|g" /etc/nginx/servers/ssl.conf
 
 # Ssl values
 if bashio::config.true 'ssl'; then
@@ -29,5 +29,5 @@ if bashio::config.true 'ssl'; then
     sed -i "s|default_server|ssl|g" /etc/nginx/servers/ssl.conf
     sed -i "/proxy_params.conf/a ssl_certificate /ssl/$certfile;" /etc/nginx/servers/ssl.conf
     sed -i "/proxy_params.conf/a ssl_certificate_key /ssl/$keyfile;" /etc/nginx/servers/ssl.conf
-    bashio::log.info "Ssl enabled, please use https for connection. UI is at https://YOURIP:$(bashio::addon.port 2342)"
+    bashio::log.info "Ssl enabled, please use https for connection. UI is at https://YOURIP:$(bashio::app.port 2342)"
 fi

--- a/photoprism/rootfs/etc/cont-init.d/99-run.sh
+++ b/photoprism/rootfs/etc/cont-init.d/99-run.sh
@@ -81,12 +81,12 @@ esac
 
 if bashio::config.true "ingress_disabled"; then
     bashio::log.warning "Ingress is disabled. You'll need to connect using ip:port"
-    sed -i "s|$(bashio::addon.ingress_entry)||g" /etc/nginx/servers/ssl.conf
+    sed -i "s|$(bashio::app.ingress_entry)||g" /etc/nginx/servers/ssl.conf
     sed -i "s|location = /|location = /null|g" /etc/nginx/servers/ssl.conf
     # sed -i "7,10d" /etc/nginx/servers/ssl.conf
     # rm /etc/nginx/servers/ingress.conf
 else
-    PHOTOPRISM_SITE_URL="$(bashio::addon.ingress_entry)/"
+    PHOTOPRISM_SITE_URL="$(bashio::app.ingress_entry)/"
     export PHOTOPRISM_SITE_URL
     echo "export PHOTOPRISM_SITE_URL=\"${PHOTOPRISM_SITE_URL}\"" >> ~/.bashrc
     bashio::log.warning "Ingress is enabled. To connect, you must add $PHOTOPRISM_SITE_URL to the end of your access point. Example : http://my-url:8123$PHOTOPRISM_SITE_URL"

--- a/portainer/rootfs/etc/cont-init.d/30-nginx.sh
+++ b/portainer/rootfs/etc/cont-init.d/30-nginx.sh
@@ -24,8 +24,8 @@ else
 fi
 
 bashio::var.json \
-    interface "$(bashio::addon.ip_address)" \
-    port "^$(bashio::addon.ingress_port)" \
+    interface "$(bashio::app.ip_address)" \
+    port "^$(bashio::app.ingress_port)" \
     protocol "${portainer_protocol}" \
     certfile "$(bashio::config 'certfile')" \
     keyfile "$(bashio::config 'keyfile')" \

--- a/postgres_15/rootfs/etc/cont-init.d/99-run.sh
+++ b/postgres_15/rootfs/etc/cont-init.d/99-run.sh
@@ -349,7 +349,7 @@ main() {
     if [ "$RESTART_NEEDED" = true ]; then
         bashio::log.warning "A critical update occurred. Restarting Immich add‑on(s) after DB restart."
         touch "$RESTART_FLAG_FILE"
-        bashio::addon.restart
+        bashio::app.restart
         exit 0
     fi
 

--- a/prowlarr/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/prowlarr/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -8,9 +8,9 @@ set -e
 declare ingress_interface
 declare ingress_port
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
-ingress_entry=$(bashio::addon.ingress_entry)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
+ingress_entry=$(bashio::app.ingress_entry)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf

--- a/prowlarr/rootfs/etc/services.d/nginx/run
+++ b/prowlarr/rootfs/etc/services.d/nginx/run
@@ -23,7 +23,7 @@ if ! grep -q "<UrlBase>$slug</UrlBase>" "$CONFIG_LOCATION" && ! bashio::config.t
     bashio::log.warning "BaseUrl not set properly, restarting"
     sed -i "/UrlBase/d" "$CONFIG_LOCATION"
     sed -i "/<Config>/a <UrlBase>$slug<\/UrlBase>" "$CONFIG_LOCATION"
-    bashio::addon.restart
+    bashio::app.restart
 fi
 
 bashio::log.info "Starting NGinx..."

--- a/qbittorrent/rootfs/etc/cont-init.d/00-folders.sh
+++ b/qbittorrent/rootfs/etc/cont-init.d/00-folders.sh
@@ -59,5 +59,5 @@ fi
 if [[ "$MIGRATED" == "true" ]]; then
     bashio::log.warning "Options were changed, restarting the addon"
     sleep 5
-    bashio::addon.restart
+    bashio::app.restart
 fi

--- a/qbittorrent/rootfs/etc/cont-init.d/30-nginx.sh
+++ b/qbittorrent/rootfs/etc/cont-init.d/30-nginx.sh
@@ -24,8 +24,8 @@ fi
 cp /etc/nginx/templates/ingress.gtpl /etc/nginx/servers/ingress.conf
 
 [ "$DEBUG" = "debug" ] && echo "Before sed"
-sed -i "s|{{ .interface }}|$(bashio::addon.ip_address)|g" /etc/nginx/servers/ingress.conf
-sed -i "s|{{ .port }}|$(bashio::addon.ingress_port)|g" /etc/nginx/servers/ingress.conf
+sed -i "s|{{ .interface }}|$(bashio::app.ip_address)|g" /etc/nginx/servers/ingress.conf
+sed -i "s|{{ .port }}|$(bashio::app.ingress_port)|g" /etc/nginx/servers/ingress.conf
 sed -i "s|{{ .protocol }}|${qbittorrent_protocol}|g" /etc/nginx/servers/ingress.conf
 sed -i "s|{{ .certfile }}|$(bashio::config 'certfile')|g" /etc/nginx/servers/ingress.conf
 sed -i "s|{{ .keyfile }}|$(bashio::config 'keyfile')|g" /etc/nginx/servers/ingress.conf

--- a/qbittorrent/rootfs/etc/cont-init.d/91-qbittorrent_configuration.sh
+++ b/qbittorrent/rootfs/etc/cont-init.d/91-qbittorrent_configuration.sh
@@ -172,7 +172,7 @@ fi
 if [[ "$ORIGINAL_SIZE" != "$(wc -c "$CONFIG_LOCATION"/qBittorrent.conf)" ]]; then
     bashio::log.warning "Configuration changed, rebooting"
     sleep 5
-    bashio::addon.restart
+    bashio::app.restart
 fi
 
 ################

--- a/qbittorrent/rootfs/etc/cont-init.d/93-openvpn.sh
+++ b/qbittorrent/rootfs/etc/cont-init.d/93-openvpn.sh
@@ -19,7 +19,7 @@ if ! bashio::config.true 'openvpn_enabled'; then
     bashio::exit.ok 'OpenVPN is disabled.'
 elif bashio::config.true 'wireguard_enabled'; then
     bashio::log.fatal 'OpenVPN and WireGuard cannot be enabled simultaneously. Disable one of them.'
-    bashio::addon.stop
+    bashio::app.stop
 fi
 
 mkdir -p "${OPENVPN_STATE_DIR}"
@@ -33,13 +33,13 @@ if bashio::config.has_value "openvpn_username"; then
     openvpn_username=$(bashio::config 'openvpn_username')
 else
     bashio::log.fatal "Openvpn is enabled, but openvpn_username option is empty! Exiting"
-    bashio::addon.stop
+    bashio::app.stop
 fi
 if bashio::config.has_value "openvpn_password"; then
     openvpn_password=$(bashio::config 'openvpn_password')
 else
     bashio::log.fatal "Openvpn is enabled, but openvpn_password option is empty! Exiting"
-    bashio::addon.stop
+    bashio::app.stop
 fi
 
 printf '%s\n%s\n' "${openvpn_username}" "${openvpn_password}" > "${OPENVPN_STATE_DIR}/credentials.conf"
@@ -50,7 +50,7 @@ if bashio::config.has_value "openvpn_config"; then
     openvpn_config="${openvpn_config##*/}"
     if [[ ! "${openvpn_config}" =~ ^[A-Za-z0-9._-]+\.(conf|ovpn)$ ]]; then
         bashio::log.fatal "Invalid openvpn_config filename '${openvpn_config}'. Allowed characters: letters, numbers, dot, underscore, dash. Extension must be .conf or .ovpn."
-        bashio::addon.stop
+        bashio::app.stop
     fi
 fi
 if [[ -z "${openvpn_config}" ]]; then
@@ -58,7 +58,7 @@ if [[ -z "${openvpn_config}" ]]; then
         mapfile -t configs < <(find /config/openvpn -maxdepth 1 \( -type f -name '*.conf' -o -name '*.ovpn' \) -print)
     if [ "${#configs[@]}" -eq 0 ]; then
         bashio::log.fatal 'OpenVPN is enabled but no .conf or .ovpn file was found in /config/openvpn.'
-        bashio::addon.stop
+        bashio::app.stop
     elif [ "${#configs[@]}" -eq 1 ]; then
         openvpn_config="${configs[0]}"
         bashio::log.info "OpenVPN configuration not specified. Using ${openvpn_config##*/}."
@@ -73,13 +73,13 @@ elif bashio::fs.file_exists "/config/openvpn/${openvpn_config}"; then
     openvpn_config="/config/openvpn/${openvpn_config}"
 else
     bashio::log.fatal "OpenVPN configuration '/config/openvpn/${openvpn_config}' not found."
-    bashio::addon.stop
+    bashio::app.stop
 fi
 
 interface_name="$(sed -n "/^dev tun/p" "${openvpn_config}" | awk -F' ' '{print $2}')"
 if [[ -z "${interface_name}" ]]; then
     bashio::log.fatal "OpenVPN configuration '${openvpn_config}' misses device directive."
-    bashio::addon.stop
+    bashio::app.stop
 elif [[ ${interface_name} = "tun" ]]; then
     interface_name='tun0'
 elif [[ ${interface_name} = "tap" ]]; then

--- a/qbittorrent/rootfs/etc/cont-init.d/94-wireguard.sh
+++ b/qbittorrent/rootfs/etc/cont-init.d/94-wireguard.sh
@@ -17,7 +17,7 @@ if ! bashio::config.true 'wireguard_enabled'; then
     bashio::exit.ok 'WireGuard is disabled.'
 elif bashio::config.true 'openvpn_enabled'; then
     bashio::log.fatal 'OpenVPN and WireGuard cannot be enabled simultaneously. Disable one of them.'
-    bashio::addon.stop
+    bashio::app.stop
 fi
 
 mkdir -p "${WIREGUARD_STATE_DIR}"
@@ -31,7 +31,7 @@ if bashio::config.has_value "wireguard_config"; then
     wireguard_config="${wireguard_config##*/}"
     if [[ ! "${wireguard_config}" =~ ^[A-Za-z0-9._-]+\.conf$ ]]; then
         bashio::log.fatal "Invalid wireguard_config filename '${wireguard_config}'. Allowed characters: letters, numbers, dot, underscore, dash. Extension must be .conf."
-        bashio::addon.stop
+        bashio::app.stop
     fi
 fi
 if [[ -z "${wireguard_config}" ]]; then
@@ -39,7 +39,7 @@ if [[ -z "${wireguard_config}" ]]; then
         mapfile -t configs < <(find /config/wireguard -maxdepth 1 -type f -name '*.conf' -print)
     if [ "${#configs[@]}" -eq 0 ]; then
         bashio::log.fatal 'WireGuard is enabled but no .conf file was found in /config/wireguard.'
-        bashio::addon.stop
+        bashio::app.stop
     elif [ "${#configs[@]}" -eq 1 ]; then
         wireguard_config="${configs[0]}"
         bashio::log.info "WireGuard configuration not specified. Using ${wireguard_config##*/}."
@@ -48,13 +48,13 @@ if [[ -z "${wireguard_config}" ]]; then
         bashio::log.info 'Using default WireGuard configuration config.conf.'
     else
         bashio::log.fatal "Multiple WireGuard configuration files detected. Please set the 'wireguard_config' option."
-        bashio::addon.stop
+        bashio::app.stop
     fi
 elif bashio::fs.file_exists "/config/wireguard/${wireguard_config}"; then
     wireguard_config="/config/wireguard/${wireguard_config}"
 else
     bashio::log.fatal "WireGuard configuration '/config/wireguard/${wireguard_config}' not found."
-    bashio::addon.stop
+    bashio::app.stop
 fi
 
 interface_name="$(basename "${wireguard_config}" .conf)"

--- a/qbittorrent/rootfs/etc/services.d/timer/run
+++ b/qbittorrent/rootfs/etc/services.d/timer/run
@@ -9,7 +9,7 @@ if bashio::config.has_value 'run_duration'; then
     sleep $RUNTIME || bashio::log.fatal "run_duration format is not correct. Use 5d or 5h or 5m for example"
     bashio::log.info "Timeout achieved, addon will stop !"
     sleep 60s
-    bashio::addon.stop
+    bashio::app.stop
 else
     rm -r /etc/services.d/timer
 fi

--- a/qbittorrent/rootfs/etc/services.d/vpn-monitor/run
+++ b/qbittorrent/rootfs/etc/services.d/vpn-monitor/run
@@ -140,7 +140,7 @@ fi
 
 if [[ "${vpn_openvpn}" == true && "${vpn_wireguard}" == true ]]; then
     bashio::log.error "Both OpenVPN and WireGuard are enabled. Only one VPN mode is supported."
-    bashio::addon.stop
+    bashio::app.stop
     exit 1
 fi
 
@@ -153,7 +153,7 @@ elif [[ "${vpn_wireguard}" == true ]]; then
 fi
 if [[ -z "${VPN_INTERFACE}" ]] || ! ip link show "${VPN_INTERFACE}" > /dev/null 2>&1 ; then
     bashio::log.error "VPN interface not found."
-    bashio::addon.stop
+    bashio::app.stop
     exit 1
 fi
 
@@ -169,7 +169,7 @@ bashio::log.info "VPN detected; enabling IP leak protection and periodic monitor
 
 if ! VPN_INFO_OUT="$(wait_for_vpn_ip)"; then
     bashio::log.error "Unable to obtain a VPN external IP different from real IP. Stopping add-on."
-    bashio::addon.stop
+    bashio::app.stop
     exit 1
 fi
 
@@ -191,7 +191,7 @@ while true; do
 
     if [[ -n "${REAL_IP}" ]] && [[ "${current_ip}" == "${REAL_IP}" ]]; then
         bashio::log.error "IP LEAK DETECTED: current external IP ${current_ip} matches real IP ${REAL_IP}. Stopping add-on."
-        bashio::addon.stop
+        bashio::app.stop
         exit 1
     fi
 

--- a/radarr/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/radarr/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -8,9 +8,9 @@ set -e
 declare ingress_interface
 declare ingress_port
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
-ingress_entry=$(bashio::addon.ingress_entry)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
+ingress_entry=$(bashio::app.ingress_entry)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf

--- a/radarr/rootfs/etc/services.d/nginx/run
+++ b/radarr/rootfs/etc/services.d/nginx/run
@@ -23,7 +23,7 @@ if ! grep -q "<UrlBase>$slug</UrlBase>" "$CONFIG_LOCATION" && ! bashio::config.t
     bashio::log.warning "BaseUrl not set properly, restarting"
     sed -i "/UrlBase/d" "$CONFIG_LOCATION"
     sed -i "/<Config>/a <UrlBase>$slug<\/UrlBase>" "$CONFIG_LOCATION"
-    bashio::addon.restart
+    bashio::app.restart
 fi
 
 bashio::log.info "Starting NGinx..."

--- a/readarr/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/readarr/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -8,9 +8,9 @@ set -e
 declare ingress_interface
 declare ingress_port
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
-ingress_entry=$(bashio::addon.ingress_entry)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
+ingress_entry=$(bashio::app.ingress_entry)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf

--- a/readarr/rootfs/etc/services.d/nginx/run
+++ b/readarr/rootfs/etc/services.d/nginx/run
@@ -15,7 +15,7 @@ bashio::net.wait_for "$port" localhost 900
 if grep -q "external" "$CONFIG_LOCATION"; then
     bashio::log.warning "external is set, restarting"
     sed -i "/external/d" "$CONFIG_LOCATION"
-    bashio::addon.restart
+    bashio::app.restart
 fi
 
 # Set UrlBase
@@ -23,14 +23,14 @@ if ! grep -q "<UrlBase>$slug</UrlBase>" "$CONFIG_LOCATION" && ! bashio::config.t
     bashio::log.warning "BaseUrl not set properly, restarting"
     sed -i "/UrlBase/d" "$CONFIG_LOCATION"
     sed -i "/<Config>/a <UrlBase>$slug<\/UrlBase>" "$CONFIG_LOCATION"
-    bashio::addon.restart
+    bashio::app.restart
 fi
 
 echo ""
 if bashio::config.true "ingress_disabled"; then
-    bashio::log.info "Ingress is disabled. You can connect at http://homeassistant:$(bashio::addon.port 8787)"
+    bashio::log.info "Ingress is disabled. You can connect at http://homeassistant:$(bashio::app.port 8787)"
 else
-    bashio::log.info "Ingress is enabled. You can connect from HA or at http://homeassistant:$(bashio::addon.port 8787)/readarr"
+    bashio::log.info "Ingress is enabled. You can connect from HA or at http://homeassistant:$(bashio::app.port 8787)/readarr"
 fi
 echo ""
 

--- a/resiliosync/rootfs/etc/cont-init.d/90-ingress.sh
+++ b/resiliosync/rootfs/etc/cont-init.d/90-ingress.sh
@@ -8,7 +8,7 @@ set -e
 declare ingress_interface
 declare ingress_port
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf

--- a/sabnzbd/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/sabnzbd/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -9,8 +9,8 @@ set -e
 
 exit 0
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 

--- a/scrutiny/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/scrutiny/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -11,7 +11,7 @@ declare ingress_interface
 declare ingress_port
 declare keyfile
 
-port=$(bashio::addon.port 80)
+port=$(bashio::app.port 80)
 if bashio::var.has_value "${port}"; then
     bashio::config.require.ssl
 
@@ -28,9 +28,9 @@ if bashio::var.has_value "${port}"; then
     fi
 fi
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
-ingress_entry=$(bashio::addon.ingress_entry)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
+ingress_entry=$(bashio::app.ingress_entry)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf

--- a/scrutiny_fa/Dockerfile
+++ b/scrutiny_fa/Dockerfile
@@ -70,7 +70,7 @@ RUN chmod 777 /ha_entrypoint.sh
 COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
 RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
 
-RUN sed -i "1a if ! bashio::require.unprotected; then bashio::addon.stop; fi" /etc/cont-init.d/90-run.sh
+RUN sed -i "1a if ! bashio::require.unprotected; then bashio::app.stop; fi" /etc/cont-init.d/90-run.sh
 
 ENTRYPOINT [ "/usr/bin/env" ]
 CMD [ "/ha_entrypoint.sh" ]

--- a/seerr/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/seerr/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -8,9 +8,9 @@ set -e
 
 bashio::log.info "Configuring Nginx for ingress..."
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
-ingress_entry=$(bashio::addon.ingress_entry)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
+ingress_entry=$(bashio::app.ingress_entry)
 
 # Update ingress.conf with actual values
 sed -i "s|%%port%%|${ingress_port}|g" /etc/nginx/servers/ingress.conf

--- a/signalk/Dockerfile
+++ b/signalk/Dockerfile
@@ -77,7 +77,7 @@ COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
 RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
 
 # Restart the addon on crash
-RUN echo "bashio::addon.restart" >> /ha_entrypoint.sh
+RUN echo "bashio::app.restart" >> /ha_entrypoint.sh
 
 ENTRYPOINT [ "/usr/bin/env" ]
 CMD [ "/ha_entrypoint.sh" ]

--- a/signalk/rootfs/etc/cont-init.d/99-run.sh
+++ b/signalk/rootfs/etc/cont-init.d/99-run.sh
@@ -30,7 +30,7 @@ for file in ssl-key.pem ssl-cert.pem security.json; do
 done
 
 # Rebuild npm dependency bindings on version change
-current_version="$(bashio::addon.version)"
+current_version="$(bashio::app.version)"
 if [[ ! -f /data/version || "$current_version" != "$(cat /data/version)" ]]; then
     if [[ -f /config/package.json ]]; then
         bashio::log.info "Update detected, rebuilding native node deps"

--- a/sonarr/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/sonarr/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -8,9 +8,9 @@ set -e
 declare ingress_interface
 declare ingress_port
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
-ingress_entry=$(bashio::addon.ingress_entry)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
+ingress_entry=$(bashio::app.ingress_entry)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf

--- a/sonarr/rootfs/etc/services.d/nginx/run
+++ b/sonarr/rootfs/etc/services.d/nginx/run
@@ -23,7 +23,7 @@ if ! grep -q "<UrlBase>$slug</UrlBase>" "$CONFIG_LOCATION" && ! bashio::config.t
     bashio::log.warning "BaseUrl not set properly, restarting"
     sed -i "/UrlBase/d" "$CONFIG_LOCATION"
     sed -i "/<Config>/a <UrlBase>$slug<\/UrlBase>" "$CONFIG_LOCATION"
-    bashio::addon.restart
+    bashio::app.restart
 fi
 
 bashio::log.info "Starting NGinx..."

--- a/transmission/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/transmission/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -8,9 +8,9 @@ set -e
 declare ingress_interface
 declare ingress_port
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
-ingress_entry=$(bashio::addon.ingress_entry)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
+ingress_entry=$(bashio::app.ingress_entry)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf

--- a/transmission_openvpn/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/transmission_openvpn/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -8,9 +8,9 @@ set -e
 declare ingress_interface
 declare ingress_port
 
-ingress_port=$(bashio::addon.ingress_port)
-ingress_interface=$(bashio::addon.ip_address)
-ingress_entry=$(bashio::addon.ingress_entry)
+ingress_port=$(bashio::app.ingress_port)
+ingress_interface=$(bashio::app.ip_address)
+ingress_entry=$(bashio::app.ingress_entry)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf

--- a/transmission_openvpn/rootfs/etc/cont-init.d/99-run.sh
+++ b/transmission_openvpn/rootfs/etc/cont-init.d/99-run.sh
@@ -62,13 +62,13 @@ done
 # Migrate OPENVPN_CUSTOM_PROVIDER to OPENVPN_PROVIDER
 if bashio::config.true 'OPENVPN_CUSTOM_PROVIDER'; then
     # Use new option
-    bashio::addon.option "OPENVPN_PROVIDER" "custom"
+    bashio::app.option "OPENVPN_PROVIDER" "custom"
     # Remove previous option
-    bashio::addon.option "OPENVPN_CUSTOM_PROVIDER"
+    bashio::app.option "OPENVPN_CUSTOM_PROVIDER"
     # log
     bashio::log.yellow "OPENVPN_CUSTOM_PROVIDER actived, OPENVPN_PROVIDER set to custom"
     # Restart
-    bashio::addon.restart
+    bashio::app.restart
 fi
 
 # Function to check for files path
@@ -124,8 +124,8 @@ if [ "$(bashio::config "OPENVPN_PROVIDER")" == "custom" ]; then
     # If contains *.ovpn, clean option
     if [[ "$openvpn_config" == *".ovpn" ]]; then
         bashio::log.warning "OPENVPN_CONFIG should not end by ovpn, correcting"
-        bashio::addon.option 'OPENVPN_CONFIG' "${openvpn_config%.ovpn}"
-        bashio::addon.restart
+        bashio::app.option 'OPENVPN_CONFIG' "${openvpn_config%.ovpn}"
+        bashio::app.restart
     fi
 
     # Add ovpn

--- a/transmission_openvpn/rootfs/usr/bin/restart_addon
+++ b/transmission_openvpn/rootfs/usr/bin/restart_addon
@@ -5,4 +5,4 @@ set -e
 bashio::log.fatal 'Tunnel down, addon restarting in 15 seconds'
 sleep 15
 touch /data/addonrestarted
-bashio::addon.restart
+bashio::app.restart

--- a/ubooquity/rootfs/etc/32-nginx_ingress.sh
+++ b/ubooquity/rootfs/etc/32-nginx_ingress.sh
@@ -12,12 +12,12 @@ declare port
 #declare keyfile
 
 # General values
-port=$(bashio::addon.ingress_port)
+port=$(bashio::app.ingress_port)
 # shellcheck disable=SC2210
 if [ "$port" ] > 1; then
     # Adapt nginx
     sed -i "s|%%port%%|$port|g" /etc/nginx/servers/ingress.conf
-    sed -i "s|%%interface%%|$(bashio::addon.ip_address)|g" /etc/nginx/servers/ingress.conf
+    sed -i "s|%%interface%%|$(bashio::app.ip_address)|g" /etc/nginx/servers/ingress.conf
     # Removebaseurl
     jq '.reverseProxyPrefix = ""' /config/addons_config/ubooquity/preferences.json | sponge /config/addons_config/ubooquity/preferences.json
     # Log

--- a/ubooquity/rootfs/etc/cont-init.d/32-nginx_ssl.sh
+++ b/ubooquity/rootfs/etc/cont-init.d/32-nginx_ssl.sh
@@ -14,7 +14,7 @@ declare keyfile
 # General values
 port=2205
 sed -i "s|%%port%%|$port|g" /etc/nginx/servers/ssl.conf
-sed -i "s|%%interface%%|$(bashio::addon.ip_address)|g" /etc/nginx/servers/ssl.conf
+sed -i "s|%%interface%%|$(bashio::app.ip_address)|g" /etc/nginx/servers/ssl.conf
 
 # Ssl values
 if bashio::config.true 'ssl'; then
@@ -24,5 +24,5 @@ if bashio::config.true 'ssl'; then
     sed -i "s|default_server|ssl|g" /etc/nginx/servers/ssl.conf
     sed -i "/proxy_params.conf/a ssl_certificate /ssl/$certfile;" /etc/nginx/servers/ssl.conf
     sed -i "/proxy_params.conf/a ssl_certificate_key /ssl/$keyfile;" /etc/nginx/servers/ssl.conf
-    bashio::log.info "Ssl enabled, please use https for connection. UI is at https://YOURIP:$(bashio::addon.port 2205)/ubooquity ; admin is at https://YOURIP:$(bashio::addon.port 2206)/ubooquity/admin"
+    bashio::log.info "Ssl enabled, please use https for connection. UI is at https://YOURIP:$(bashio::app.port 2205)/ubooquity ; admin is at https://YOURIP:$(bashio::app.port 2206)/ubooquity/admin"
 fi

--- a/webtop_kde/rootfs/etc/cont-init.d/80-configuration.sh
+++ b/webtop_kde/rootfs/etc/cont-init.d/80-configuration.sh
@@ -42,7 +42,7 @@ if bashio::config.has_value 'PASSWORD'; then
     PASSWORD=$(bashio::config 'PASSWORD')
     passwd -d abc
     echo -e "$PASSWORD\n$PASSWORD" | passwd abc
-elif ! bashio::config.has_value 'PASSWORD' && [[ -n "$(bashio::addon.port "3000")" ]] && [[ -n $(bashio::addon.port "3001") ]]; then
+elif ! bashio::config.has_value 'PASSWORD' && [[ -n "$(bashio::app.port "3000")" ]] && [[ -n $(bashio::app.port "3001") ]]; then
     bashio::log.warning "SEVERE RISK IDENTIFIED"
     bashio::log.warning "You are opening an external port but your password is not defined"
     bashio::log.warning "You risk being hacked ! Please disable the external ports, or use a password"

--- a/webtop_kde/rootfs/etc/cont-init.d/90-ingress.sh
+++ b/webtop_kde/rootfs/etc/cont-init.d/90-ingress.sh
@@ -4,7 +4,7 @@ set -e
 
 # nginx Path
 NGINX_CONFIG=/etc/nginx/sites-available/ingress.conf
-SUBFOLDER="$(bashio::addon.ingress_entry)"
+SUBFOLDER="$(bashio::app.ingress_entry)"
 
 # Copy template
 cp /defaults/default.conf "${NGINX_CONFIG}"
@@ -15,7 +15,7 @@ mv tmpfile "${NGINX_CONFIG}"
 # Remove ipv6
 sed -i '/listen \[::\]/d' "${NGINX_CONFIG}"
 # Add ingress parameters
-sed -i "s|3000|$(bashio::addon.ingress_port)|g" "${NGINX_CONFIG}"
+sed -i "s|3000|$(bashio::app.ingress_port)|g" "${NGINX_CONFIG}"
 sed -i "s|CWS|8082|g" "${NGINX_CONFIG}"
 sed -i "s|SUBFOLDER|/|g" "${NGINX_CONFIG}"
 sed -i '/proxy_buffering/a proxy_set_header Accept-Encoding "";' "${NGINX_CONFIG}"

--- a/webtrees/rootfs/etc/cont-init.d/99-run.sh
+++ b/webtrees/rootfs/etc/cont-init.d/99-run.sh
@@ -93,7 +93,7 @@ if bashio::config.true 'ssl'; then
     export HTTPS=true
     export SSL=true
     export HTTPS_REDIRECT=true
-    BASE_URL_PORT=":$(bashio::addon.port 443)"
+    BASE_URL_PORT=":$(bashio::app.port 443)"
     if [[ "$BASE_URL_PORT" == ":443" ]]; then BASE_URL_PORT=""; fi
     BASE_URL_PROTO="https"
 
@@ -103,14 +103,14 @@ else
     export HTTPS=false
     export SSL=false
     export HTTPS_REDIRECT=false
-    BASE_URL_PORT=":$(bashio::addon.port 80)"
+    BASE_URL_PORT=":$(bashio::app.port 80)"
     if [[ "$BASE_URL_PORT" == ":80" ]]; then BASE_URL_PORT=""; fi
     BASE_URL_PROTO="http"
 fi
 
 if [[ "$BASE_URL_PORT" == ":" ]]; then
     bashio::log.fatal "Your $BASE_URL_PROTO port is not set in the addon options, please check your configuration and restart"
-    bashio::addon.stop
+    bashio::app.stop
 fi
 BASE_URL="${BASE_URL_PROTO}://${BASE_URL}${BASE_URL_PORT}"
 export BASE_URL

--- a/whoogle/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/whoogle/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -11,7 +11,7 @@ set -e
 #sed -i 's|manifest.json">|manifest.json" crossorigin="use-credentials">|g' /whoogle/app/templates/index.html
 
 #Allow ingress
-sed -i "1a export WHOOGLE_URL_PREFIX=\'$(bashio::addon.ingress_entry)\'" /etc/cont-init.d/99-run.sh
+sed -i "1a export WHOOGLE_URL_PREFIX=\'$(bashio::app.ingress_entry)\'" /etc/cont-init.d/99-run.sh
 
 #################
 # NGINX SETTING #
@@ -22,7 +22,7 @@ declare ingress_interface
 declare ingress_port
 declare keyfile
 
-port=$(bashio::addon.port 80)
+port=$(bashio::app.port 80)
 if bashio::var.has_value "${port}"; then
     bashio::config.require.ssl
 
@@ -39,9 +39,9 @@ if bashio::var.has_value "${port}"; then
     fi
 fi
 
-ingress_port="$(bashio::addon.ingress_port)"
-ingress_interface="$(bashio::addon.ip_address)"
-ingress_entry="$(bashio::addon.ingress_entry)"
+ingress_port="$(bashio::app.ingress_port)"
+ingress_interface="$(bashio::app.ip_address)"
+ingress_entry="$(bashio::app.ingress_entry)"
 ingress_entry_modified="$(echo "$ingress_entry" | sed 's/[@_!#$%^&*()<>?/\|}{~:]//g')"
 
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf


### PR DESCRIPTION
bashio now emits deprecation warnings for bashio::addon.* calls.
This migrates all 227 call-sites across 86 files to use the new
bashio::app.* API.

Cross-compatibility is preserved in two ways:
1. bashio-standalone.sh: adds bashio::app.* functions that forward to
   bashio::addon.* (used when running without HA Supervisor).
   Also adds the missing ingress_url, restart and stop stubs.
2. ha_entrypoint.sh: injects a one-liner compat shim after the shebang
   of every cont-init and service script at container startup. On old
   bashio installations (bashio::app.* absent) the shim defines
   bashio::app.* as thin wrappers around bashio::addon.*; on new bashio
   the guard condition is true so the block is a no-op.

The probe script in ha_entrypoint.sh is also updated to try
bashio::app.version before falling back to bashio::addon.version.

https://claude.ai/code/session_011FWFBhYQ6VS5FauSqv4UMo