### PR TITLE
Add original Scrutiny addon variants

### DIFF
--- a/scrutiny_fa_original/CHANGELOG.md
+++ b/scrutiny_fa_original/CHANGELOG.md
@@ -1,0 +1,174 @@
+ 
+## v1.63.0 (2026-06-13)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+ 
+## v1.62.4 (2026-06-11)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+## v1.62.3 (2026-06-05)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+## v1.62.2 (2026-06-01)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.62.1 (2026-05-30)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.59.0 (2026-05-22)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.55.0 (2026-05-16)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.52.0 (2026-05-02)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.50.0 (2026-04-23)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.49.2 (2026-04-06)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.47.1 (2026-03-21)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.46.2 (2026-03-14)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.41.0 (2026-03-07)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.39.0 (2026-03-02)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.37.0 (2026-02-28)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.30.1 (2026-02-23)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.28.0 (2026-02-21)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.23.3 (2026-02-14)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+## v1.23.2-3 (08-02-2026)
+- Minor bugs fixed
+## v1.23.2-2 (08-02-2026)
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
+## v1.23.2 (2026-02-08)
+- Switch upstream to https://github.com/Starosdev/scrutiny
+
+## v0.8.1-12 (2025-08-16)
+- Replace s6-based shutdown with standard command to avoid s6-svwait error
+
+## v0.8.1-11 (2025-08-15)
+- Minor bugs fixed
+## v0.8.1-10 (2025-08-13)
+- Disable port by default for security purposes; it can be readded from the addon options. Ingress access is not affected @soosp
+- Document internal domain name for accessing the REST API without exposing the port.
+
+## v0.8.1-9 (2024-11-14)
+- Align behavior with other addons : map /addons_config/xxx-scrutiny to enable env injection or custom scripts
+
+## v0.8.1-8 (2024-11-13)
+- Minor bugs fixed
+## v0.8.1-7 (2024-11-13)
+- New feature : if you select "Custom" as "Updates" variable, you can define specific updates in natural language in the "Updates_custom_time" field. Example : select "Custom" as "Updates", then type a custom intervals like "5m", "2h", "1w", or "2mo" to have an update every 5 minutes, or every 2 hours, or evey week, or every 2 months
+
+## v0.8.1-6 (2024-11-02)
+- Minor bugs fixed
+## v0.8.1-5 (2024-08-22)
+- Minor bugs fixed
+## v0.8.1-4 (2024-07-30)
+- Minor bugs fixed
+## v0.8.1-3 (2024-06-11)
+- Minor bugs fixed
+## v0.8.1-2 (2024-04-13)
+- Minor bugs fixed
+
+## v0.8.1 (2024-04-13)
+- Update to latest version from analogj/scrutiny (changelog : https://github.com/analogj/scrutiny/releases)
+## v0.8.0-3 (2024-03-18)
+-Avoid overriding the smartctl command https://github.com/alexbelgium/hassio-addons/issues/1308
+
+## v0.8.0-2 (2024-03-17)
+- Minor bugs fixed
+
+## v0.8.0 (2024-03-16)
+- Update to latest version from analogj/scrutiny
+
+## v0.7.3 (2024-03-02)
+
+- Update to latest version from analogj/scrutiny
+
+## v0.7.2 (2023-10-20)
+
+- Update to latest version from analogj/scrutiny
+
+## v0.7.1 (2023-04-15)
+
+- Update to latest version from analogj/scrutiny
+
+## v0.7.0 (2023-04-08)
+
+- Update to latest version from analogj/scrutiny
+- Implemented healthcheck
+
+## v0.6.0 (2023-01-14)
+
+- Update to latest version from analogj/scrutiny
+- WARNING : update to supervisor 2022.11 before installing
+- New options SMARTCTL_COMMAND_DEVICE_TYPE & SMARTCTL_MEGARAID_DISK_NUM (@scavara)
+- New option, define COLLECTOR_API_ENDPOINT when in Collector mode
+- New option "Mode" : Collector+WebUI or Collector only
+
+## v0.5.0 (2022-08-26)
+
+- Update to latest version from analogj/scrutiny
+
+- BACKUP BEFORE UPDATE : major version change
+- PUID/PGID, ssl values deprecated
+
+## 2ab714f5-ls35 (2022-05-11)
+
+- Update to latest version from linuxserver/scrutiny
+
+## version-c397a323 (2022-05-10)
+
+- Update to latest version from linuxserver/scrutiny
+
+## 8e34ef8d-ls35 (2022-05-05)
+
+- Update to latest version from linuxserver/scrutiny
+- Add codenotary sign
+- New standardized logic for Dockerfile build and packages installation
+- Added : "/dev/nvme0"
+
+## 0.3.13 (2021-10-26)
+
+- Update to latest version from analogj/scrutiny
+- Allow mounting of devices up to sdg2
+
+## 0.3.12 (2021-09-29)
+
+- Update to latest version from AnalogJ/scrutiny
+- Aligned with AnalogJ namings
+
+## fd4f0429
+
+- New ingress icon, thanks to @ElVit
+- New features, selecting of update rate with addon option
+- Add banner in log
+- Align to upstream
+
+## 27b923b5-ls12
+
+- Removed full access flag
+- Improved code for local devices scanning after first installation
+- Solved an issue that made a blank screen on mobile devices
+- Implementation of Ingress with/without ssl
+
+## 27b923b5-ls11
+
+- Enables PUID/PGID options
+- Daily update of values

--- a/scrutiny_fa_original/Dockerfile
+++ b/scrutiny_fa_original/Dockerfile
@@ -1,0 +1,136 @@
+#============================#
+#  ALEXBELGIUM'S DOCKERFILE  #
+#============================#
+#           _.------.
+#       _.-`    ('>.-`"""-.
+# '.--'`       _'`   _ .--.)
+#    -'         '-.-';`   `
+#    ' -      _.'  ``'--.
+#        '---`    .-'""`
+#               /`
+#=== Home Assistant Addon ===#
+
+#################
+# 1 Build Image #
+#################
+
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+##################
+# 2 Modify Image #
+##################
+
+# Set S6 wait time
+ENV S6_CMD_WAIT_FOR_SERVICES=1 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+##################
+# 3 Install apps #
+##################
+
+# Add rootfs
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+# Uses /bin for compatibility purposes
+# hadolint ignore=DL4005
+RUN if [ ! -f /bin/sh ] && [ -f /usr/bin/sh ]; then ln -s /usr/bin/sh /bin/sh; fi && \
+    if [ ! -f /bin/bash ] && [ -f /usr/bin/bash ]; then ln -s /usr/bin/bash /bin/bash; fi
+
+# Modules
+ARG MODULES="00-banner.sh 01-custom_script.sh"
+
+# Automatic modules download
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+# Manual apps
+ENV PACKAGES="jq \
+    curl \
+    cifs-utils \
+    nginx"
+
+# Automatic apps & bashio
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+################
+# 4 Entrypoint #
+################
+
+# Add entrypoint
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+# Install bashio
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+RUN sed -i "1a if ! bashio::require.unprotected; then bashio::addon.stop; fi" /etc/cont-init.d/90-run.sh
+
+ENTRYPOINT [ "/usr/bin/env" ]
+CMD [ "/ha_entrypoint.sh" ]
+
+############
+# 5 Labels #
+############
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="alexbelgium (https://github.com/alexbelgium)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="alexbelgium (https://github.com/alexbelgium)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/alexbelgium" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version=${BUILD_VERSION}
+
+#################
+# 6 Healthcheck #
+#################
+
+# Avoid spamming logs
+# hadolint ignore=SC2016
+RUN \
+    # Handle Apache configuration
+    if [ -d /etc/apache2/sites-available ]; then \
+        for file in /etc/apache2/sites-*/*.conf; do \
+            sed -i '/<VirtualHost/a \ \n    # Match requests with the custom User-Agent "HealthCheck" \n    SetEnvIf User-Agent "HealthCheck" dontlog \n    # Exclude matching requests from access logs \n    CustomLog ${APACHE_LOG_DIR}/access.log combined env=!dontlog' "$file"; \
+        done; \
+    fi && \
+    \
+    # Handle Nginx configuration
+    if [ -f /etc/nginx/nginx.conf ]; then \
+        awk '/http \{/{print; print "map $http_user_agent $dontlog {\n  default 0;\n  \"~*HealthCheck\" 1;\n}\naccess_log /var/log/nginx/access.log combined if=$dontlog;"; next}1' /etc/nginx/nginx.conf > /etc/nginx/nginx.conf.new && \
+        mv /etc/nginx/nginx.conf.new /etc/nginx/nginx.conf; \
+    fi
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/api/health"
+HEALTHCHECK \
+    --interval=5s \
+    --retries=5 \
+    --start-period=30s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/scrutiny_fa_original/README.md
+++ b/scrutiny_fa_original/README.md
@@ -1,0 +1,167 @@
+# Home assistant add-on: scrutiny_fa_original
+
+
+I maintain this and other Home Assistant add-ons in my free time: keeping up with upstream changes, HA changes, and testing on real hardware takes a lot of time (and some money). I use around 5-10 of my >110 addons so regularly I install test machines (and purchase some test services such as vpn) that I don't use myself to troubleshoot and improve the addons
+
+If this add-on saves you time or makes your setup easier, I would be very grateful for your support!
+
+[![Buy me a coffee][donation-badge]](https://www.buymeacoffee.com/alexbelgium)
+[![Donate via PayPal][paypal-badge]](https://www.paypal.com/donate/?hosted_button_id=DZFULJZTP3UQA)
+
+## Addon informations
+
+![Version](https://img.shields.io/badge/dynamic/yaml?label=Version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fscrutiny%2Fconfig.yaml)
+![Ingress](https://img.shields.io/badge/dynamic/yaml?label=Ingress&query=%24.ingress&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fscrutiny%2Fconfig.yaml)
+![Arch](https://img.shields.io/badge/dynamic/yaml?color=success&label=Arch&query=%24.arch&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fscrutiny%2Fconfig.yaml)
+
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/9c6cf10bdbba45ecb202d7f579b5be0e)](https://www.codacy.com/gh/alexbelgium/hassio-addons/dashboard?utm_source=github.com&utm_medium=referral&utm_content=alexbelgium/hassio-addons&utm_campaign=Badge_Grade)
+[![GitHub Super-Linter](https://img.shields.io/github/actions/workflow/status/alexbelgium/hassio-addons/weekly-supelinter.yaml?label=Lint%20code%20base)](https://github.com/alexbelgium/hassio-addons/actions/workflows/weekly-supelinter.yaml)
+[![Builder](https://img.shields.io/github/actions/workflow/status/alexbelgium/hassio-addons/onpush_builder.yaml?label=Builder)](https://github.com/alexbelgium/hassio-addons/actions/workflows/onpush_builder.yaml)
+
+[donation-badge]: https://img.shields.io/badge/Buy%20me%20a%20coffee-%23d32f2f?logo=buy-me-a-coffee&style=flat&logoColor=white
+[paypal-badge]: https://img.shields.io/badge/Donate%20via%20PayPal-0070BA?logo=paypal&style=flat&logoColor=white
+
+_Thanks to everyone having starred my repo! To star it click on the image below, then it will be on top right. Thanks!_
+
+[![Stargazers repo roster for @alexbelgium/hassio-addons](https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.github/stars2.svg)](https://github.com/alexbelgium/hassio-addons/stargazers)
+
+![downloads evolution](https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/scrutiny_fa_original/stats.png)
+
+## About
+
+---
+
+[Scrutiny](https://github.com/AnalogJ/scrutiny) is a Hard Drive Health Dashboard & Monitoring solution, merging manufacturer provided S.M.A.R.T metrics with real-world failure rates. This addon is based on the [docker image](https://hub.docker.com/r/linuxserver/scrutiny) from [linuxserver.io](https://www.linuxserver.io/).
+
+Features :
+
+- SMART monitoring
+- Automatic addition of local drives
+- Hourly updates
+- Ingress
+- Automatic upstream updates
+
+## Configuration
+
+Webui can be found at <http://homeassistant:8080> or through the sidebar using Ingress.
+Configurations can be done through the app webUI, except for the following options.
+It automatically mounts all local drives.
+
+**Note**: Enable full access only if encountering issues. SMART access should work without full access in all scenarios.
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `Updates` | list | `Hourly` | Update schedule (Quarterly/Hourly/Daily/Weekly/Custom) |
+| `Updates_custom_time` | str | | Custom update interval (e.g., "5m", "2h", "1w", "2mo") |
+| `TZ` | str | | Timezone (e.g., `Europe/London`) |
+| `Mode` | list | | Operating mode (Collector+WebUI or Collector only) |
+| `COLLECTOR_API_ENDPOINT` | str | | Collector API endpoint URL |
+| `COLLECTOR_HOST_ID` | str | | Host identifier for collector |
+| `SMARTCTL_COMMAND_DEVICE_TYPE` | list | | Device type for SMARTCTL commands |
+| `SMARTCTL_MEGARAID_DISK_NUM` | int | | MegaRAID disk number |
+| `expose_collector` | bool | | Expose collector port externally |
+
+### Example Configuration
+
+```yaml
+Updates: "Daily"
+Updates_custom_time: "12h"
+TZ: "Europe/London"
+Mode: "Collector+WebUI"
+COLLECTOR_API_ENDPOINT: "http://localhost:8080"
+COLLECTOR_HOST_ID: "home_assistant"
+SMARTCTL_COMMAND_DEVICE_TYPE: "auto"
+expose_collector: false
+```
+
+### Custom Scripts and Environment Variables
+
+This addon supports custom scripts and environment variables:
+
+- **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
+## Installation
+
+---
+
+The installation of this add-on is pretty straightforward and not different in comparison to installing any other add-on.
+
+1. Add my add-ons repository to your home assistant instance (in supervisor addons store at top right, or click button below if you have configured my HA)
+   [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Falexbelgium%2Fhassio-addons)
+1. Install this add-on.
+1. Click the `Save` button to store your configuration.
+1. Set the add-on options to your preferences
+1. Start the add-on.
+1. Check the logs of the add-on to see if everything went well.
+1. Open the webUI (Ingress based) and adapt the software options
+
+# Integration in home assistant
+
+---
+
+Integration with HA can be done with the [rest platform](https://www.home-assistant.io/integrations/rest) in configuration.yaml.
+
+The API is available on Home Assistant's internal network even when the port is not exposed. Use the add-on's internal
+domain name (`http://db21ed7f-scrutiny-fa-original:8080`) to query it from Home Assistant or other add-ons. If you need to reach the API from your local network, expose the port in the add-on options and replace the domain with your Home Assistant IP address.
+
+Two types of API endpoints are available:
+
+- Summary data: <http://db21ed7f-scrutiny-fa-original:8080/api/summary>
+- Detailed data: <http://db21ed7f-scrutiny-fa-original:8080/api/device/WWN/details>
+
+For the detailed data, wwn can be found for each HDD within the Scrutiny app. For example: <http://db21ed7f-scrutiny-fa-original:8080/api/device/0x50014ee606c14537/details>
+
+Example to get data from the first hdd.
+
+```yaml
+rest:
+  - verify_ssl: false
+    scan_interval: 60
+    resource: http://db21ed7f-scrutiny-fa-original:8080/api/device/0x57c35481f82a7a9c/details
+    sensor:
+      - name: "HDD - WWN"
+        value_template: "{{ value_json.data.smart_results[0].device_wwn }}"
+      - name: "HDD - Last Update"
+        value_template: "{{ value_json.data.smart_results[0].date }}"
+        device_class: timestamp
+      - name: "HDD - Temperature"
+        value_template: "{{ value_json.data.smart_results[0].temp }}"
+        device_class: temperature
+        unit_of_measurement: "°C"
+        state_class: measurement
+      - name: "HDD - Power Cycles"
+        value_template: "{{ value_json.data.smart_results[0].power_cycle_count }}"
+      - name: "HDD - Power Hours"
+        value_template: "{{ value_json.data.smart_results[0].power_on_hours }}"
+      - name: "HDD - Protocol"
+        value_template: "{{ value_json.data.smart_results[0].device_protocol }}"
+      - name: "HDD - Reallocated Sectors Count"
+        value_template: '{{ value_json.data.smart_results[0].attrs["5"].raw_value }}'
+      - name: "HDD - Reallocation Event Count"
+        value_template: '{{ value_json.data.smart_results[0].attrs["196"].raw_value }}'
+      - name: "HDD - Current Pending Sector Count"
+        value_template: '{{ value_json.data.smart_results[0].attrs["197"].raw_value }}'
+      - name: "HDD - (Offline) Uncorrectable Sector Count"
+        value_template: '{{ value_json.data.smart_results[0].attrs["198"].raw_value }}'
+    binary_sensor:
+      - name: "HDD - SMART Status"
+        value_template: "{{ 1 if value_json.data.smart_results[0].Status in [1, 2] else 0 }}"
+        device_class: problem
+```
+
+## Illustration
+
+---
+
+![Illustration](https://github.com/AnalogJ/scrutiny/raw/master/docs/dashboard.png)
+
+## Support
+
+Create an issue on github, or ask on the [home assistant thread](https://community.home-assistant.io/t/home-assistant-addon-scrutiny-smart-dashboard/295747)
+
+<https://github.com/alexbelgium/hassio-addons>
+
+[repository]: https://github.com/alexbelgium/hassio-addons

--- a/scrutiny_fa_original/apparmor.txt
+++ b/scrutiny_fa_original/apparmor.txt
@@ -1,0 +1,79 @@
+#include <tunables/global>
+
+profile db21ed7f_scrutiny flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  capability chown,
+  capability dac_override,
+  capability dac_read_search,
+  capability fowner,
+  capability setgid,
+  capability setuid,
+  capability sys_admin,
+  capability sys_rawio,
+  file,
+  signal,
+  mount,
+  umount,
+  remount,
+  network udp,
+  network tcp,
+  network dgram,
+  network stream,
+  network inet,
+  network inet6,
+  network netlink raw,
+  network unix dgram,
+
+
+# S6-Overlay
+  /init ix,
+  /run/{s6,s6-rc*,service}/** ix,
+  /package/** ix,
+  /command/** ix,
+  /run/{,**} rwk,
+  /dev/tty rw,
+  /bin/** ix,
+  /usr/bin/** ix,
+  /usr/lib/bashio/** ix,
+  /etc/s6/** rix,
+  /run/s6/** rix,
+  /etc/services.d/** rwix,
+  /etc/cont-init.d/** rwix,
+  /etc/cont-finish.d/** rwix,
+  /init rix,
+  /var/run/** mrwkl,
+  /var/run/ mrwkl,
+  /dev/i2c-1 mrwkl,
+  # Files required
+  /dev/fuse mrwkl,
+  /dev/sda1 mrwkl,
+  /dev/sdb1 mrwkl,
+  /dev/nvme0 mrwkl,
+  /dev/nvme1 mrwkl,
+  /dev/mmcblk0p1 mrwkl,
+  /dev/* mrwkl,
+  /tmp/** mrkwl,
+  /dev/sda mrwkl,
+  /dev/sdb mrwkl,
+  /dev/sdc mrwkl,
+  /dev/sdd mrwkl,
+  /dev/sde mrwkl,
+  /dev/sdf mrwkl,
+  /dev/sdg mrwkl,
+  /dev/nvme0 mrwkl,
+  /dev/nvme1 mrwkl,
+  /dev/nvme2 mrwkl,
+  /dev/nvme3 mrwkl,
+  /dev/nvme4 mrwkl,
+
+  # Data access
+  /data/** rw,
+
+  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
+  ptrace (trace,read) peer=docker-default,
+
+  # docker daemon confinement requires explict allow rule for signal
+  signal (receive) set=(kill,term) peer=/usr/bin/docker,
+
+}

--- a/scrutiny_fa_original/build.json
+++ b/scrutiny_fa_original/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "ghcr.io/analogj/scrutiny:latest-omnibus",
+    "amd64": "ghcr.io/analogj/scrutiny:latest-omnibus"
+  }
+}

--- a/scrutiny_fa_original/config.yaml
+++ b/scrutiny_fa_original/config.yaml
@@ -1,0 +1,48 @@
+apparmor: "true"
+arch:
+  - aarch64
+  - amd64
+description: Scrutiny WebUI for smartd S.M.A.R.T monitoring (Full Access)
+environment:
+  COLLECTOR_API_ENDPOINT: http://localhost:8080
+  COLLECTOR_HOST_ID: home_assistant
+full_access: true
+image: ghcr.io/alexbelgium/scrutiny-fa-original-{arch}
+ingress: true
+init: false
+map:
+  - share:rw
+  - addon_config:rw
+name: scrutiny_fa_original
+options:
+  env_vars: []
+  Updates: Hourly
+panel_admin: false
+panel_icon: mdi:glasses
+ports:
+  8080/tcp: null
+  8086/tcp: null
+ports_description:
+  8080/tcp: Web UI port
+  8086/tcp: InfluxDB admin
+privileged:
+  - SYS_ADMIN
+  - SYS_RAWIO
+  - DAC_READ_SEARCH
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  COLLECTOR_API_ENDPOINT: str?
+  COLLECTOR_HOST_ID: str?
+  Mode: list(Collector+WebUI|Collector)?
+  SMARTCTL_COMMAND_DEVICE_TYPE: list(auto|ata|scsi|sat|usbcypress|usbjmicron|usbsunplus|sntasmedia|sntjmicron|sntrealtek|marvell|megaraid)?
+  SMARTCTL_MEGARAID_DISK_NUM: int?
+  TZ: str?
+  Updates: list(Quarterly|Hourly|Daily|Weekly|Custom)
+  Updates_custom_time: str?
+  expose_collector: bool?
+slug: scrutiny_fa_original
+udev: true
+url: https://github.com/analogj/scrutiny
+version: "v1.63.0"

--- a/scrutiny_fa_original/rootfs/etc/cont-init.d/01-configuration.sh
+++ b/scrutiny_fa_original/rootfs/etc/cont-init.d/01-configuration.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+
+#################
+# Create folder #
+#################
+
+DATABASELOCATION="/data"
+echo "Updating folders structure"
+mkdir -p "$DATABASELOCATION"/config
+mkdir -p "$DATABASELOCATION"/influxdb
+if [ -d /opt/scrutiny/config ]; then rm -r /opt/scrutiny/config; fi
+if [ -d /opt/scrutiny/influxdb ]; then rm -r /opt/scrutiny/influxdb; fi
+ln -s "$DATABASELOCATION"/config /opt/scrutiny
+ln -s "$DATABASELOCATION"/influxdb /opt/scrutiny
+
+###############################
+# Migrating previous database #
+###############################
+
+if [ -f /data/scrutiny.db ]; then
+    bashio::log.warning "Previous database detected, migration will start. Backup stored in /share/scrutiny.db.bak"
+    cp /data/scrutiny.db /share/scrutiny.db.bak
+    mv /data/scrutiny.db "$DATABASELOCATION"/config/
+fi
+
+######
+# TZ #
+######
+
+# Align timezone with options
+if bashio::config.has_value "TZ"; then
+    TZ="$(bashio::config 'TZ')"
+    bashio::log.info "Timezone : $TZ"
+    sed -i "1a export TZ=$TZ" /etc/cont-init.d/01-timezone
+fi
+
+################
+# CRON OPTIONS #
+################
+
+# Align update with options
+FREQUENCY="$(bashio::config 'Updates')"
+bashio::log.info "$FREQUENCY updates as defined in the 'Updates' option"
+
+case "$FREQUENCY" in
+    "Quarterly")
+        sed -i "/customize the cron schedule/a export COLLECTOR_CRON_SCHEDULE=\"*/15 * * * *\"" /etc/cont-init.d/50-cron-config
+        ;;
+
+    "Hourly")
+        sed -i "/customize the cron schedule/a export COLLECTOR_CRON_SCHEDULE=\"0 * * * *\"" /etc/cont-init.d/50-cron-config
+        ;;
+
+    "Daily")
+        sed -i "/customize the cron schedule/a export COLLECTOR_CRON_SCHEDULE=\"0 0 * * *\"" /etc/cont-init.d/50-cron-config
+        ;;
+
+    "Weekly")
+        sed -i "/customize the cron schedule/a export COLLECTOR_CRON_SCHEDULE=\"0 0 * * 0\"" /etc/cont-init.d/50-cron-config
+        ;;
+
+    "Custom")
+        interval="$(bashio::config 'Updates_custom_time')"
+        bashio::log.info "... frequency is defined manually as $interval"
+
+        case "$interval" in
+            *m) # Matches intervals in minutes, like "5m" or "30m"
+                minutes="${interval%m}"
+                if [[ "$minutes" -gt 0 && "$minutes" -le 59 ]]; then
+                    cron_schedule="*/$minutes * * * *"
+                else
+                    bashio::log.error "Invalid minute interval: $interval"
+                fi
+                ;;
+
+            *h) # Matches intervals in hours, like "2h"
+                hours="${interval%h}"
+                if [[ "$hours" -gt 0 && "$hours" -le 23 ]]; then
+                    cron_schedule="0 */$hours * * *"
+                else
+                    bashio::log.error "Invalid hour interval: $interval"
+                fi
+                ;;
+
+            *w) # Matches intervals in weeks, like "1w"
+                weeks="${interval%w}"
+                if [[ "$weeks" -gt 0 && "$weeks" -le 4 ]]; then
+                    cron_schedule="0 0 * * 0" # Weekly on Sunday (adjust if needed for multi-week)
+                else
+                    bashio::log.error "Invalid week interval: $interval"
+                fi
+                ;;
+
+            *mo) # Matches intervals in months, like "1mo"
+                months="${interval%mo}"
+                if [[ "$months" -gt 0 && "$months" -le 12 ]]; then
+                    cron_schedule="0 0 1 */$months *" # Monthly on the 1st
+                else
+                    bashio::log.error "Invalid month interval: $interval"
+                fi
+                ;;
+
+            *)
+                bashio::log.error "Empty or unsupported custom interval. It should be in the format of 5m (every 5 minutes), 10d (every 10 days), 3w (every 3 weeks), 3mo (every 3 months)"
+                ;;
+        esac
+
+        if [[ -n "$cron_schedule" ]]; then
+            sed -i "/customize the cron schedule/a export COLLECTOR_CRON_SCHEDULE=\"$cron_schedule\"" /etc/cont-init.d/50-cron-config
+            bashio::log.info "Custom cron schedule set to: $cron_schedule"
+        fi
+        ;;
+esac

--- a/scrutiny_fa_original/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/scrutiny_fa_original/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+
+#################
+# NGINX SETTING #
+#################
+declare port
+declare certfile
+declare ingress_interface
+declare ingress_port
+declare keyfile
+
+port=$(bashio::addon.port 80)
+if bashio::var.has_value "${port}"; then
+    bashio::config.require.ssl
+
+    if bashio::config.true 'ssl'; then
+        certfile=$(bashio::config 'certfile')
+        keyfile=$(bashio::config 'keyfile')
+
+        mv /etc/nginx/servers/direct-ssl.disabled /etc/nginx/servers/direct.conf
+        sed -i "s/%%certfile%%/${certfile}/g" /etc/nginx/servers/direct.conf
+        sed -i "s/%%keyfile%%/${keyfile}/g" /etc/nginx/servers/direct.conf
+
+    else
+        mv /etc/nginx/servers/direct.disabled /etc/nginx/servers/direct.conf
+    fi
+fi
+
+ingress_port=$(bashio::addon.ingress_port)
+ingress_interface=$(bashio::addon.ip_address)
+ingress_entry=$(bashio::addon.ingress_entry)
+sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
+sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
+sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf

--- a/scrutiny_fa_original/rootfs/etc/cont-init.d/90-run.sh
+++ b/scrutiny_fa_original/rootfs/etc/cont-init.d/90-run.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+
+#########################
+# EXPOSE COLLECTOR.YAML #
+#########################
+
+if bashio::config.true "expose_collector"; then
+    bashio::log.info "collector.yaml exposed in /share/scrutiny"
+    mkdir -p /share/scrutiny
+    if [ -f /data/config/collector.yaml ]; then
+        cp -rnf /data/config/collector.yaml /share/scrutiny || true
+        rm -R /data/config/collector.yaml
+    fi
+    if [ -f /opt/scrutiny/config/collector.yaml ]; then
+        cp -rnf /opt/scrutiny/config/collector.yaml /share/scrutiny || true
+        rm /opt/scrutiny/config/collector.yaml
+    fi
+    touch /share/scrutiny/collector.yaml
+    ln -sf /share/scrutiny/collector.yaml /data/config || true
+    mkdir -p /opt/scrutiny/config
+    ln -sf /share/scrutiny/collector.yaml /opt/scrutiny/config/collector.yaml || true
+    chmod 755 -R /share/scrutiny
+fi
+
+########
+# MODE #
+########
+
+if [[ "$(bashio::config "Mode")" == Collector ]]; then
+    # Clean services
+    bashio::log.warning "Collector only mode. WebUI and Influxdb will be disabled"
+    rm -r /etc/services.d/influxdb
+    rm -r /etc/services.d/scrutiny
+    rm -r /etc/services.d/nginx
+    sed -i "/wait/d" /etc/services.d/collector-once/run
+    sed -i "/scrutiny api not ready/d" /etc/services.d/collector-once/run
+
+    # Check collector
+    if bashio::config.has_value "COLLECTOR_API_ENDPOINT"; then
+        echo "export COLLECTOR_API_ENDPOINT=$(bashio::config "COLLECTOR_API_ENDPOINT")" >> /env.sh
+        sed -i "1a export COLLECTOR_API_ENDPOINT=$(bashio::config "COLLECTOR_API_ENDPOINT")" /etc/services.d/collector-once/run
+        if [ -d /var/run/s6/container_environment ]; then printf "%s" "$COLLECTOR_API_ENDPOINT" > /var/run/s6/container_environment/COLLECTOR_API_ENDPOINT; fi
+        printf "%s\n" "IN_BACKGROUND=\"$COLLECTOR_API_ENDPOINT\"" >> ~/.bashrc
+        bashio::log.info "Using 'COLLECTOR_API_ENDPOINT' $(bashio::config "COLLECTOR_API_ENDPOINT")"
+    else
+        bashio::exit.nok "Mode is set to 'Collector', but 'COLLECTOR_API_ENDPOINT' is not defined"
+    fi
+fi

--- a/scrutiny_fa_original/rootfs/etc/nginx/includes/mime.types
+++ b/scrutiny_fa_original/rootfs/etc/nginx/includes/mime.types
@@ -1,0 +1,96 @@
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    application/javascript                           js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                         wmlc;
+    application/x-7z-compressed                      7z;
+    application/x-cocoa                              cco;
+    application/x-java-archive-diff                  jardiff;
+    application/x-java-jnlp-file                     jnlp;
+    application/x-makeself                           run;
+    application/x-perl                               pl pm;
+    application/x-pilot                              prc pdb;
+    application/x-rar-compressed                     rar;
+    application/x-redhat-package-manager             rpm;
+    application/x-sea                                sea;
+    application/x-shockwave-flash                    swf;
+    application/x-stuffit                            sit;
+    application/x-tcl                                tcl tk;
+    application/x-x509-ca-cert                       der pem crt;
+    application/x-xpinstall                          xpi;
+    application/xhtml+xml                            xhtml;
+    application/xspf+xml                             xspf;
+    application/zip                                  zip;
+
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+
+    audio/midi                                       mid midi kar;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        ogg;
+    audio/x-m4a                                      m4a;
+    audio/x-realaudio                                ra;
+
+    video/3gpp                                       3gpp 3gp;
+    video/mp2t                                       ts;
+    video/mp4                                        mp4;
+    video/mpeg                                       mpeg mpg;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-m4v                                      m4v;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asx asf;
+    video/x-ms-wmv                                   wmv;
+    video/x-msvideo                                  avi;
+}

--- a/scrutiny_fa_original/rootfs/etc/nginx/includes/proxy_params.conf
+++ b/scrutiny_fa_original/rootfs/etc/nginx/includes/proxy_params.conf
@@ -1,0 +1,15 @@
+proxy_http_version          1.1;
+proxy_ignore_client_abort   off;
+proxy_read_timeout          86400s;
+proxy_redirect              off;
+proxy_send_timeout          86400s;
+proxy_max_temp_file_size    0;
+
+proxy_set_header Accept-Encoding "";
+proxy_set_header Connection $connection_upgrade;
+proxy_set_header Host $http_host;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-NginX-Proxy true;
+proxy_set_header X-Real-IP $remote_addr;

--- a/scrutiny_fa_original/rootfs/etc/nginx/includes/resolver.conf
+++ b/scrutiny_fa_original/rootfs/etc/nginx/includes/resolver.conf
@@ -1,0 +1,1 @@
+resolver 127.0.0.11 ipv6=off;

--- a/scrutiny_fa_original/rootfs/etc/nginx/includes/server_params.conf
+++ b/scrutiny_fa_original/rootfs/etc/nginx/includes/server_params.conf
@@ -1,0 +1,5 @@
+server_name     $hostname;
+
+add_header X-Content-Type-Options nosniff;
+add_header X-XSS-Protection "1; mode=block";
+add_header X-Robots-Tag none;

--- a/scrutiny_fa_original/rootfs/etc/nginx/includes/ssl_params.conf
+++ b/scrutiny_fa_original/rootfs/etc/nginx/includes/ssl_params.conf
@@ -1,0 +1,9 @@
+ssl_protocols TLSv1.2;
+ssl_prefer_server_ciphers on;
+ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA;
+ssl_ecdh_curve secp384r1;
+ssl_session_timeout  10m;
+ssl_session_cache shared:SSL:10m;
+ssl_session_tickets off;
+ssl_stapling on;
+ssl_stapling_verify on;

--- a/scrutiny_fa_original/rootfs/etc/nginx/includes/upstream.conf
+++ b/scrutiny_fa_original/rootfs/etc/nginx/includes/upstream.conf
@@ -1,0 +1,3 @@
+upstream backend {
+    server 127.0.0.1:8080;
+}

--- a/scrutiny_fa_original/rootfs/etc/nginx/nginx.conf
+++ b/scrutiny_fa_original/rootfs/etc/nginx/nginx.conf
@@ -1,0 +1,56 @@
+# Run nginx in foreground.
+daemon off;
+
+# This is run inside Docker.
+user root;
+
+# Pid storage location.
+pid /var/run/nginx.pid;
+
+# Set number of worker processes.
+worker_processes 1;
+
+# Enables the use of JIT for regular expressions to speed-up their processing.
+pcre_jit on;
+
+# Write error log to Hass.io add-on log.
+error_log /proc/1/fd/1 error;
+
+# Load allowed environment vars
+env HASSIO_TOKEN;
+
+# Load dynamic modules.
+include /etc/nginx/modules/*.conf;
+
+# Max num of simultaneous connections by a worker process.
+events {
+    worker_connections 512;
+}
+
+http {
+    include /etc/nginx/includes/mime.types;
+
+    log_format hassio '[$time_local] $status '
+                        '$http_x_forwarded_for($remote_addr) '
+                        '$request ($http_user_agent)';
+
+    access_log              /proc/1/fd/1 hassio;
+    client_max_body_size    4G;
+    default_type            application/octet-stream;
+    gzip                    on;
+    keepalive_timeout       65;
+    sendfile                on;
+    server_tokens           off;
+    tcp_nodelay             on;
+    tcp_nopush              on;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
+    include /etc/nginx/includes/resolver.conf;
+    include /etc/nginx/includes/upstream.conf;
+
+    include /etc/nginx/servers/*.conf;
+}

--- a/scrutiny_fa_original/rootfs/etc/nginx/servers/ingress.conf
+++ b/scrutiny_fa_original/rootfs/etc/nginx/servers/ingress.conf
@@ -1,0 +1,28 @@
+server {
+    listen %%interface%%:%%port%% default_server;
+
+    include /etc/nginx/includes/server_params.conf;
+    include /etc/nginx/includes/proxy_params.conf;
+    
+    client_max_body_size 0;
+
+    root /opt/scrutiny/web;
+
+   location = / {
+      absolute_redirect off;              # Do not add port to redirect
+      return 301 %%ingress_entry%%/web/dashboard;
+   }
+
+  location /api { 
+       add_header Access-Control-Allow-Origin *;   
+       proxy_read_timeout 30;
+       proxy_pass         http://backend/api;
+  }
+
+  location /web/ { 
+       add_header Access-Control-Allow-Origin *;   
+       proxy_read_timeout 30;
+       proxy_pass         http://backend/web/;
+  }
+
+}

--- a/scrutiny_fa_original/rootfs/etc/services.d/nginx/finish
+++ b/scrutiny_fa_original/rootfs/etc/services.d/nginx/finish
@@ -1,0 +1,9 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+# ==============================================================================
+# Stop the container when Nginx fails
+# ==============================================================================
+if [[ "$1" -ne 0 && "$1" -ne 256 ]]; then
+    bashio::log.error "Nginx exited with code $1"
+    kill -15 1
+fi

--- a/scrutiny_fa_original/rootfs/etc/services.d/nginx/run
+++ b/scrutiny_fa_original/rootfs/etc/services.d/nginx/run
@@ -1,0 +1,11 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+# ==============================================================================
+
+# Wait for transmission to become available
+bashio::net.wait_for 8080 localhost 900
+
+bashio::log.info "Starting NGinx..."
+
+exec nginx

--- a/scrutiny_fa_original/updater.json
+++ b/scrutiny_fa_original/updater.json
@@ -1,0 +1,10 @@
+{
+  "github_fulltag": "true",
+  "last_update": "2026-06-13",
+  "paused": false,
+  "repository": "alexbelgium/hassio-addons",
+  "slug": "scrutiny_fa_original",
+  "source": "github",
+  "upstream_repo": "analogj/scrutiny",
+  "upstream_version": "v1.63.0"
+}

--- a/scrutiny_original/CHANGELOG.md
+++ b/scrutiny_original/CHANGELOG.md
@@ -1,0 +1,169 @@
+ 
+## v1.63.0 (2026-06-13)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+ 
+## v1.62.4 (2026-06-11)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+## v1.62.3 (2026-06-05)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+## v1.62.2 (2026-06-01)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.62.1 (2026-05-30)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.59.0 (2026-05-22)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.55.0 (2026-05-16)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.52.0 (2026-05-02)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.50.0 (2026-04-23)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.49.2 (2026-04-06)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.47.1 (2026-03-21)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.46.2 (2026-03-14)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.41.0 (2026-03-07)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.37.0 (2026-02-28)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.30.1 (2026-02-23)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.28.0 (2026-02-21)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+
+## v1.23.3 (2026-02-14)
+- Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
+## v1.23.2-2 (08-02-2026)
+- Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
+## v1.23.2 (2026-02-08)
+- Switch upstream to https://github.com/Starosdev/scrutiny
+
+## v0.8.1-12 (2025-08-16)
+- Replace s6-based shutdown with standard command to avoid s6-svwait error
+
+## v0.8.1-11 (2025-08-15)
+- Minor bugs fixed
+## v0.8.1-10 (2025-08-13)
+- Disable port by default for security purposes; it can be readded from the addon options. Ingress access is not affected @soosp
+- Document internal domain name for accessing the REST API without exposing the port.
+
+## v0.8.1-9 (2024-11-14)
+- Align behavior with other addons : map /addons_config/xxx-scrutiny to enable env injection or custom scripts
+
+## v0.8.1-8 (2024-11-13)
+- Minor bugs fixed
+## v0.8.1-7 (2024-11-13)
+- New feature : if you select "Custom" as "Updates" variable, you can define specific updates in natural language in the "Updates_custom_time" field. Example : select "Custom" as "Updates", then type a custom intervals like "5m", "2h", "1w", or "2mo" to have an update every 5 minutes, or every 2 hours, or evey week, or every 2 months
+
+## v0.8.1-6 (2024-11-02)
+- Minor bugs fixed
+## v0.8.1-5 (2024-08-22)
+- Minor bugs fixed
+## v0.8.1-4 (2024-07-30)
+- Minor bugs fixed
+## v0.8.1-3 (2024-06-11)
+- Minor bugs fixed
+## v0.8.1-2 (2024-04-13)
+- Minor bugs fixed
+
+## v0.8.1 (2024-04-13)
+- Update to latest version from analogj/scrutiny (changelog : https://github.com/analogj/scrutiny/releases)
+## v0.8.0-3 (2024-03-18)
+-Avoid overriding the smartctl command https://github.com/alexbelgium/hassio-addons/issues/1308
+
+## v0.8.0-2 (2024-03-17)
+- Minor bugs fixed
+
+## v0.8.0 (2024-03-16)
+- Update to latest version from analogj/scrutiny
+
+## v0.7.3 (2024-03-02)
+
+- Update to latest version from analogj/scrutiny
+
+## v0.7.2 (2023-10-20)
+
+- Update to latest version from analogj/scrutiny
+
+## v0.7.1 (2023-04-15)
+
+- Update to latest version from analogj/scrutiny
+
+## v0.7.0 (2023-04-08)
+
+- Update to latest version from analogj/scrutiny
+- Implemented healthcheck
+
+## v0.6.0 (2023-01-14)
+
+- Update to latest version from analogj/scrutiny
+- WARNING : update to supervisor 2022.11 before installing
+- New options SMARTCTL_COMMAND_DEVICE_TYPE & SMARTCTL_MEGARAID_DISK_NUM (@scavara)
+- New option, define COLLECTOR_API_ENDPOINT when in Collector mode
+- New option "Mode" : Collector+WebUI or Collector only
+
+## v0.5.0 (2022-08-26)
+
+- Update to latest version from analogj/scrutiny
+
+- BACKUP BEFORE UPDATE : major version change
+- PUID/PGID, ssl values deprecated
+
+## 2ab714f5-ls35 (2022-05-11)
+
+- Update to latest version from linuxserver/scrutiny
+
+## version-c397a323 (2022-05-10)
+
+- Update to latest version from linuxserver/scrutiny
+
+## 8e34ef8d-ls35 (2022-05-05)
+
+- Update to latest version from linuxserver/scrutiny
+- Add codenotary sign
+- New standardized logic for Dockerfile build and packages installation
+- Added : "/dev/nvme0"
+
+## 0.3.13 (2021-10-26)
+
+- Update to latest version from analogj/scrutiny
+- Allow mounting of devices up to sdg2
+
+## 0.3.12 (2021-09-29)
+
+- Update to latest version from AnalogJ/scrutiny
+- Aligned with AnalogJ namings
+
+## fd4f0429
+
+- New ingress icon, thanks to @ElVit
+- New features, selecting of update rate with addon option
+- Add banner in log
+- Align to upstream
+
+## 27b923b5-ls12
+
+- Removed full access flag
+- Improved code for local devices scanning after first installation
+- Solved an issue that made a blank screen on mobile devices
+- Implementation of Ingress with/without ssl
+
+## 27b923b5-ls11
+
+- Enables PUID/PGID options
+- Daily update of values

--- a/scrutiny_original/Dockerfile
+++ b/scrutiny_original/Dockerfile
@@ -1,0 +1,134 @@
+#============================#
+#  ALEXBELGIUM'S DOCKERFILE  #
+#============================#
+#           _.------.
+#       _.-`    ('>.-`"""-.
+# '.--'`       _'`   _ .--.)
+#    -'         '-.-';`   `
+#    ' -      _.'  ``'--.
+#        '---`    .-'""`
+#               /`
+#=== Home Assistant Addon ===#
+
+#################
+# 1 Build Image #
+#################
+
+ARG BUILD_FROM
+ARG BUILD_VERSION
+FROM ${BUILD_FROM}
+
+##################
+# 2 Modify Image #
+##################
+
+# Set S6 wait time
+ENV S6_CMD_WAIT_FOR_SERVICES=1 \
+    S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
+    S6_SERVICES_GRACETIME=0
+
+##################
+# 3 Install apps #
+##################
+
+# Add rootfs
+COPY rootfs/ /
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+
+# Uses /bin for compatibility purposes
+# hadolint ignore=DL4005
+RUN if [ ! -f /bin/sh ] && [ -f /usr/bin/sh ]; then ln -s /usr/bin/sh /bin/sh; fi && \
+    if [ ! -f /bin/bash ] && [ -f /usr/bin/bash ]; then ln -s /usr/bin/bash /bin/bash; fi
+
+# Modules
+ARG MODULES="00-banner.sh 01-custom_script.sh"
+
+# Automatic modules download
+COPY ha_automodules.sh /ha_automodules.sh
+RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
+
+# Manual apps
+ENV PACKAGES="jq \
+    curl \
+    cifs-utils \
+    nginx"
+
+# Automatic apps & bashio
+COPY ha_autoapps.sh /ha_autoapps.sh
+RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.sh
+
+################
+# 4 Entrypoint #
+################
+
+# Add entrypoint
+ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 777 /ha_entrypoint.sh
+
+# Install bashio
+COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
+RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
+
+ENTRYPOINT [ "/usr/bin/env" ]
+CMD [ "/ha_entrypoint.sh" ]
+
+############
+# 5 Labels #
+############
+
+ARG BUILD_ARCH
+ARG BUILD_DATE
+ARG BUILD_DESCRIPTION
+ARG BUILD_NAME
+ARG BUILD_REF
+ARG BUILD_REPOSITORY
+ARG BUILD_VERSION
+ENV BUILD_VERSION="${BUILD_VERSION}"
+LABEL \
+    io.hass.name="${BUILD_NAME}" \
+    io.hass.description="${BUILD_DESCRIPTION}" \
+    io.hass.arch="${BUILD_ARCH}" \
+    io.hass.type="addon" \
+    io.hass.version=${BUILD_VERSION} \
+    maintainer="alexbelgium (https://github.com/alexbelgium)" \
+    org.opencontainers.image.title="${BUILD_NAME}" \
+    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+    org.opencontainers.image.vendor="Home Assistant Add-ons" \
+    org.opencontainers.image.authors="alexbelgium (https://github.com/alexbelgium)" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.url="https://github.com/alexbelgium" \
+    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+    org.opencontainers.image.created=${BUILD_DATE} \
+    org.opencontainers.image.revision=${BUILD_REF} \
+    org.opencontainers.image.version=${BUILD_VERSION}
+
+#################
+# 6 Healthcheck #
+#################
+
+# Avoid spamming logs
+# hadolint ignore=SC2016
+RUN \
+    # Handle Apache configuration
+    if [ -d /etc/apache2/sites-available ]; then \
+        for file in /etc/apache2/sites-*/*.conf; do \
+            sed -i '/<VirtualHost/a \ \n    # Match requests with the custom User-Agent "HealthCheck" \n    SetEnvIf User-Agent "HealthCheck" dontlog \n    # Exclude matching requests from access logs \n    CustomLog ${APACHE_LOG_DIR}/access.log combined env=!dontlog' "$file"; \
+        done; \
+    fi && \
+    \
+    # Handle Nginx configuration
+    if [ -f /etc/nginx/nginx.conf ]; then \
+        awk '/http \{/{print; print "map $http_user_agent $dontlog {\n  default 0;\n  \"~*HealthCheck\" 1;\n}\naccess_log /var/log/nginx/access.log combined if=$dontlog;"; next}1' /etc/nginx/nginx.conf > /etc/nginx/nginx.conf.new && \
+        mv /etc/nginx/nginx.conf.new /etc/nginx/nginx.conf; \
+    fi
+
+ENV HEALTH_PORT="8080" \
+    HEALTH_URL="/api/health"
+HEALTHCHECK \
+    --interval=5s \
+    --retries=5 \
+    --start-period=30s \
+    --timeout=25s \
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/scrutiny_original/README.md
+++ b/scrutiny_original/README.md
@@ -1,0 +1,169 @@
+# Home assistant add-on: scrutiny_original
+
+
+I maintain this and other Home Assistant add-ons in my free time: keeping up with upstream changes, HA changes, and testing on real hardware takes a lot of time (and some money). I use around 5-10 of my >110 addons so regularly I install test machines (and purchase some test services such as vpn) that I don't use myself to troubleshoot and improve the addons
+
+If this add-on saves you time or makes your setup easier, I would be very grateful for your support!
+
+[![Buy me a coffee][donation-badge]](https://www.buymeacoffee.com/alexbelgium)
+[![Donate via PayPal][paypal-badge]](https://www.paypal.com/donate/?hosted_button_id=DZFULJZTP3UQA)
+
+## Addon informations
+
+![Version](https://img.shields.io/badge/dynamic/yaml?label=Version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fscrutiny%2Fconfig.yaml)
+![Ingress](https://img.shields.io/badge/dynamic/yaml?label=Ingress&query=%24.ingress&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fscrutiny%2Fconfig.yaml)
+![Arch](https://img.shields.io/badge/dynamic/yaml?color=success&label=Arch&query=%24.arch&url=https%3A%2F%2Fraw.githubusercontent.com%2Falexbelgium%2Fhassio-addons%2Fmaster%2Fscrutiny%2Fconfig.yaml)
+
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/9c6cf10bdbba45ecb202d7f579b5be0e)](https://www.codacy.com/gh/alexbelgium/hassio-addons/dashboard?utm_source=github.com&utm_medium=referral&utm_content=alexbelgium/hassio-addons&utm_campaign=Badge_Grade)
+[![GitHub Super-Linter](https://img.shields.io/github/actions/workflow/status/alexbelgium/hassio-addons/weekly-supelinter.yaml?label=Lint%20code%20base)](https://github.com/alexbelgium/hassio-addons/actions/workflows/weekly-supelinter.yaml)
+[![Builder](https://img.shields.io/github/actions/workflow/status/alexbelgium/hassio-addons/onpush_builder.yaml?label=Builder)](https://github.com/alexbelgium/hassio-addons/actions/workflows/onpush_builder.yaml)
+
+[donation-badge]: https://img.shields.io/badge/Buy%20me%20a%20coffee-%23d32f2f?logo=buy-me-a-coffee&style=flat&logoColor=white
+[paypal-badge]: https://img.shields.io/badge/Donate%20via%20PayPal-0070BA?logo=paypal&style=flat&logoColor=white
+
+_Thanks to everyone having starred my repo! To star it click on the image below, then it will be on top right. Thanks!_
+
+[![Stargazers repo roster for @alexbelgium/hassio-addons](https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/.github/stars2.svg)](https://github.com/alexbelgium/hassio-addons/stargazers)
+
+![downloads evolution](https://raw.githubusercontent.com/alexbelgium/hassio-addons/master/scrutiny_original/stats.png)
+
+## About
+
+---
+
+[Scrutiny](https://github.com/AnalogJ/scrutiny) is a Hard Drive Health Dashboard & Monitoring solution, merging manufacturer provided S.M.A.R.T metrics with real-world failure rates. This addon is based on the [docker image](https://hub.docker.com/r/linuxserver/scrutiny) from [linuxserver.io](https://www.linuxserver.io/).
+
+Features :
+
+- SMART monitoring
+- Automatic addition of local drives
+- Hourly updates
+- Ingress
+- Automatic upstream updates
+
+## Configuration
+
+Webui can be found at <http://homeassistant:8080> or through the sidebar using Ingress.
+Configurations can be done through the app webUI, except for the following options.
+It automatically mounts all local drives.
+
+**Note**: Enable full access only if encountering issues. SMART access should work without full access in all scenarios.
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `Updates` | list | `Hourly` | Update schedule (Quarterly/Hourly/Daily/Weekly/Custom) |
+| `Updates_custom_time` | str | | Custom update interval (e.g., "5m", "2h", "1w", "2mo") |
+| `TZ` | str | | Timezone (e.g., `Europe/London`) |
+| `Mode` | list | | Operating mode (Collector+WebUI or Collector only) |
+| `COLLECTOR_API_ENDPOINT` | str | | Collector API endpoint URL |
+| `COLLECTOR_HOST_ID` | str | | Host identifier for collector |
+| `SMARTCTL_COMMAND_DEVICE_TYPE` | list | | Device type for SMARTCTL commands |
+| `SMARTCTL_MEGARAID_DISK_NUM` | int | | MegaRAID disk number |
+| `expose_collector` | bool | | Expose collector port externally |
+
+### Example Configuration
+
+```yaml
+Updates: "Daily"
+Updates_custom_time: "12h"
+TZ: "Europe/London"
+Mode: "Collector+WebUI"
+COLLECTOR_API_ENDPOINT: "http://localhost:8080"
+COLLECTOR_HOST_ID: "home_assistant"
+SMARTCTL_COMMAND_DEVICE_TYPE: "auto"
+expose_collector: false
+```
+
+### Custom Scripts and Environment Variables
+
+This addon supports custom scripts and environment variables:
+
+- **Custom scripts**: See [Running Custom Scripts in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Running-custom-scripts-in-Addons)
+- **env_vars option**: Use the add-on `env_vars` option to pass extra environment variables (uppercase or lowercase names). See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
+
+## Installation
+
+---
+
+The installation of this add-on is pretty straightforward and not different in comparison to installing any other add-on.
+
+1. Add my add-ons repository to your home assistant instance (in supervisor addons store at top right, or click button below if you have configured my HA)
+   [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Falexbelgium%2Fhassio-addons)
+1. Install this add-on.
+1. Click the `Save` button to store your configuration.
+1. Set the add-on options to your preferences
+1. Start the add-on.
+1. Check the logs of the add-on to see if everything went well.
+1. Open the webUI (Ingress based) and adapt the software options
+
+# Integration in home assistant
+
+---
+
+Integration with HA can be done with the [rest platform](https://www.home-assistant.io/integrations/rest) in configuration.yaml.
+
+The API is available on Home Assistant's internal network even when the port is not exposed. Use the add-on's internal
+domain name (`http://db21ed7f-scrutiny-original:8080`) to query it from Home Assistant or other add-ons. If you need to reach the API from your local network, expose the port in the add-on options and replace the domain with your Home Assistant IP address.
+
+Two types of API endpoints are available:
+
+- Summary data: <http://db21ed7f-scrutiny-original:8080/api/summary>
+- Detailed data: <http://db21ed7f-scrutiny-original:8080/api/device/WWN/details>
+
+For the detailed data, wwn can be found for each HDD within the Scrutiny app. For example: <http://db21ed7f-scrutiny-original:8080/api/device/0x50014ee606c14537/details>
+
+Example to get data from the first hdd.
+
+```yaml
+rest:
+  - verify_ssl: false
+    scan_interval: 60
+    resource: http://db21ed7f-scrutiny-original:8080/api/device/0x57c35481f82a7a9c/details
+    sensor:
+      - name: "HDD - WWN"
+        value_template: "{{ value_json.data.smart_results[0].device_wwn }}"
+      - name: "HDD - Last Update"
+        value_template: "{{ value_json.data.smart_results[0].date }}"
+        device_class: timestamp
+      - name: "HDD - Temperature"
+        value_template: "{{ value_json.data.smart_results[0].temp }}"
+        device_class: temperature
+        unit_of_measurement: "°C"
+        state_class: measurement
+      - name: "HDD - Power Cycles"
+        value_template: "{{ value_json.data.smart_results[0].power_cycle_count }}"
+      - name: "HDD - Power Hours"
+        value_template: "{{ value_json.data.smart_results[0].power_on_hours }}"
+      - name: "HDD - Protocol"
+        value_template: "{{ value_json.data.smart_results[0].device_protocol }}"
+      - name: "HDD - Reallocated Sectors Count"
+        value_template: '{{ value_json.data.smart_results[0].attrs["5"].raw_value }}'
+      - name: "HDD - Reallocation Event Count"
+        value_template: '{{ value_json.data.smart_results[0].attrs["196"].raw_value }}'
+      - name: "HDD - Current Pending Sector Count"
+        value_template: '{{ value_json.data.smart_results[0].attrs["197"].raw_value }}'
+      - name: "HDD - (Offline) Uncorrectable Sector Count"
+        value_template: '{{ value_json.data.smart_results[0].attrs["198"].raw_value }}'
+    binary_sensor:
+      - name: "HDD - SMART Status"
+        value_template: "{{ 1 if value_json.data.smart_results[0].Status in [1, 2] else 0 }}"
+        device_class: problem
+```
+
+## Illustration
+
+---
+
+![Illustration](https://github.com/AnalogJ/scrutiny/raw/master/docs/dashboard.png)
+
+## Support
+
+Create an issue on github, or ask on the [home assistant thread](https://community.home-assistant.io/t/home-assistant-addon-scrutiny-smart-dashboard/295747)
+
+<https://github.com/alexbelgium/hassio-addons>
+
+[repository]: https://github.com/alexbelgium/hassio-addons
+
+

--- a/scrutiny_original/apparmor.txt
+++ b/scrutiny_original/apparmor.txt
@@ -1,0 +1,79 @@
+#include <tunables/global>
+
+profile db21ed7f_scrutiny flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  capability chown,
+  capability dac_override,
+  capability dac_read_search,
+  capability fowner,
+  capability setgid,
+  capability setuid,
+  capability sys_admin,
+  capability sys_rawio,
+  file,
+  signal,
+  mount,
+  umount,
+  remount,
+  network udp,
+  network tcp,
+  network dgram,
+  network stream,
+  network inet,
+  network inet6,
+  network netlink raw,
+  network unix dgram,
+
+
+# S6-Overlay
+  /init ix,
+  /run/{s6,s6-rc*,service}/** ix,
+  /package/** ix,
+  /command/** ix,
+  /run/{,**} rwk,
+  /dev/tty rw,
+  /bin/** ix,
+  /usr/bin/** ix,
+  /usr/lib/bashio/** ix,
+  /etc/s6/** rix,
+  /run/s6/** rix,
+  /etc/services.d/** rwix,
+  /etc/cont-init.d/** rwix,
+  /etc/cont-finish.d/** rwix,
+  /init rix,
+  /var/run/** mrwkl,
+  /var/run/ mrwkl,
+  /dev/i2c-1 mrwkl,
+  # Files required
+  /dev/fuse mrwkl,
+  /dev/sda1 mrwkl,
+  /dev/sdb1 mrwkl,
+  /dev/nvme0 mrwkl,
+  /dev/nvme1 mrwkl,
+  /dev/mmcblk0p1 mrwkl,
+  /dev/* mrwkl,
+  /tmp/** mrkwl,
+  /dev/sda mrwkl,
+  /dev/sdb mrwkl,
+  /dev/sdc mrwkl,
+  /dev/sdd mrwkl,
+  /dev/sde mrwkl,
+  /dev/sdf mrwkl,
+  /dev/sdg mrwkl,
+  /dev/nvme0 mrwkl,
+  /dev/nvme1 mrwkl,
+  /dev/nvme2 mrwkl,
+  /dev/nvme3 mrwkl,
+  /dev/nvme4 mrwkl,
+
+  # Data access
+  /data/** rw,
+
+  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
+  ptrace (trace,read) peer=docker-default,
+
+  # docker daemon confinement requires explict allow rule for signal
+  signal (receive) set=(kill,term) peer=/usr/bin/docker,
+
+}

--- a/scrutiny_original/build.json
+++ b/scrutiny_original/build.json
@@ -1,0 +1,6 @@
+{
+  "build_from": {
+    "aarch64": "ghcr.io/analogj/scrutiny:latest-omnibus",
+    "amd64": "ghcr.io/analogj/scrutiny:latest-omnibus"
+  }
+}

--- a/scrutiny_original/config.yaml
+++ b/scrutiny_original/config.yaml
@@ -1,0 +1,116 @@
+apparmor: "true"
+arch:
+  - aarch64
+  - amd64
+description: Scrutiny webUI for smartd S.M.A.R.T monitoring
+devices:
+  - /dev/dri
+  - /dev/dri/card0
+  - /dev/dri/card1
+  - /dev/dri/renderD128
+  - /dev/vchiq
+  - /dev/video10
+  - /dev/video11
+  - /dev/video12
+  - /dev/video13
+  - /dev/video14
+  - /dev/video15
+  - /dev/video16
+  - /dev/ttyUSB0
+  - /dev/sda
+  - /dev/sdb
+  - /dev/sdc
+  - /dev/sdd
+  - /dev/sde
+  - /dev/sdf
+  - /dev/sdg
+  - /dev/nvme
+  - /dev/nvme0
+  - /dev/nvme0n1
+  - /dev/nvme0n1p1
+  - /dev/nvme0n1p2
+  - /dev/nvme0n1p3
+  - /dev/nvme1n1
+  - /dev/nvme1n1p1
+  - /dev/nvme1n1p2
+  - /dev/nvme1n1p3
+  - /dev/nvme2n1
+  - /dev/nvme2n1p1
+  - /dev/nvme2n1p2
+  - /dev/nvme2n3p3
+  - /dev/mmcblk
+  - /dev/fuse
+  - /dev/sda1
+  - /dev/sdb1
+  - /dev/sdc1
+  - /dev/sdd1
+  - /dev/sde1
+  - /dev/sdf1
+  - /dev/sdg1
+  - /dev/sda2
+  - /dev/sdb2
+  - /dev/sdc2
+  - /dev/sdd2
+  - /dev/sde2
+  - /dev/sdf2
+  - /dev/sdg2
+  - /dev/sda3
+  - /dev/sdb3
+  - /dev/sda4
+  - /dev/sdb4
+  - /dev/sda5
+  - /dev/sda6
+  - /dev/sda7
+  - /dev/sda8
+  - /dev/nvme0
+  - /dev/nvme1
+  - /dev/nvme2
+  - /dev/nvme0
+  - /dev/nvme1
+  - /dev/nvme2
+  - /dev/md0
+  - /dev/md1
+  - /dev/md2
+  - /dev/md3
+environment:
+  COLLECTOR_API_ENDPOINT: http://localhost:8080
+  COLLECTOR_HOST_ID: home_assistant
+image: ghcr.io/alexbelgium/scrutiny-original-{arch}
+ingress: true
+init: false
+map:
+  - share:rw
+  - addon_config:rw
+name: scrutiny_original
+options:
+  env_vars: []
+  Updates: Hourly
+panel_admin: false
+panel_icon: mdi:glasses
+ports:
+  8080/tcp: null
+  8086/tcp: null
+ports_description:
+  8080/tcp: Web UI port
+  8086/tcp: InfluxDB admin
+privileged:
+  - SYS_ADMIN
+  - SYS_RAWIO
+  - DAC_READ_SEARCH
+schema:
+  env_vars:
+    - name: match(^[A-Za-z0-9_]+$)
+      value: str?
+  COLLECTOR_API_ENDPOINT: str?
+  COLLECTOR_HOST_ID: str?
+  Mode: list(Collector+WebUI|Collector)?
+  SMARTCTL_COMMAND_DEVICE_TYPE: list(auto|ata|scsi|sat|usbcypress|usbjmicron|usbsunplus|sntasmedia|sntjmicron|sntrealtek|marvell|megaraid)?
+  SMARTCTL_MEGARAID_DISK_NUM: int?
+  TZ: str?
+  Updates: list(Quarterly|Hourly|Daily|Weekly|Custom)
+  Updates_custom_time: str?
+  expose_collector: bool?
+slug: scrutiny_original
+udev: true
+url: https://github.com/analogj/scrutiny
+version: "v1.63.0"

--- a/scrutiny_original/rootfs/etc/cont-init.d/01-configuration.sh
+++ b/scrutiny_original/rootfs/etc/cont-init.d/01-configuration.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+
+#################
+# Create folder #
+#################
+
+DATABASELOCATION="/data"
+echo "Updating folders structure"
+mkdir -p "$DATABASELOCATION"/config
+mkdir -p "$DATABASELOCATION"/influxdb
+if [ -d /opt/scrutiny/config ]; then rm -r /opt/scrutiny/config; fi
+if [ -d /opt/scrutiny/influxdb ]; then rm -r /opt/scrutiny/influxdb; fi
+ln -s "$DATABASELOCATION"/config /opt/scrutiny
+ln -s "$DATABASELOCATION"/influxdb /opt/scrutiny
+
+###############################
+# Migrating previous database #
+###############################
+
+if [ -f /data/scrutiny.db ]; then
+    bashio::log.warning "Previous database detected, migration will start. Backup stored in /share/scrutiny.db.bak"
+    cp /data/scrutiny.db /share/scrutiny.db.bak
+    mv /data/scrutiny.db "$DATABASELOCATION"/config/
+fi
+
+######
+# TZ #
+######
+
+# Align timezone with options
+if bashio::config.has_value "TZ"; then
+    TZ="$(bashio::config 'TZ')"
+    bashio::log.info "Timezone : $TZ"
+    sed -i "1a export TZ=$TZ" /etc/cont-init.d/01-timezone
+fi
+
+################
+# CRON OPTIONS #
+################
+
+# Align update with options
+FREQUENCY="$(bashio::config 'Updates')"
+bashio::log.info "$FREQUENCY updates as defined in the 'Updates' option"
+
+case "$FREQUENCY" in
+    "Quarterly")
+        sed -i "/customize the cron schedule/a export COLLECTOR_CRON_SCHEDULE=\"*/15 * * * *\"" /etc/cont-init.d/50-cron-config
+        ;;
+
+    "Hourly")
+        sed -i "/customize the cron schedule/a export COLLECTOR_CRON_SCHEDULE=\"0 * * * *\"" /etc/cont-init.d/50-cron-config
+        ;;
+
+    "Daily")
+        sed -i "/customize the cron schedule/a export COLLECTOR_CRON_SCHEDULE=\"0 0 * * *\"" /etc/cont-init.d/50-cron-config
+        ;;
+
+    "Weekly")
+        sed -i "/customize the cron schedule/a export COLLECTOR_CRON_SCHEDULE=\"0 0 * * 0\"" /etc/cont-init.d/50-cron-config
+        ;;
+
+    "Custom")
+        interval="$(bashio::config 'Updates_custom_time')"
+        bashio::log.info "... frequency is defined manually as $interval"
+
+        case "$interval" in
+            *m) # Matches intervals in minutes, like "5m" or "30m"
+                minutes="${interval%m}"
+                if [[ "$minutes" -gt 0 && "$minutes" -le 59 ]]; then
+                    cron_schedule="*/$minutes * * * *"
+                else
+                    bashio::log.error "Invalid minute interval: $interval"
+                fi
+                ;;
+
+            *h) # Matches intervals in hours, like "2h"
+                hours="${interval%h}"
+                if [[ "$hours" -gt 0 && "$hours" -le 23 ]]; then
+                    cron_schedule="0 */$hours * * *"
+                else
+                    bashio::log.error "Invalid hour interval: $interval"
+                fi
+                ;;
+
+            *w) # Matches intervals in weeks, like "1w"
+                weeks="${interval%w}"
+                if [[ "$weeks" -gt 0 && "$weeks" -le 4 ]]; then
+                    cron_schedule="0 0 * * 0" # Weekly on Sunday (adjust if needed for multi-week)
+                else
+                    bashio::log.error "Invalid week interval: $interval"
+                fi
+                ;;
+
+            *mo) # Matches intervals in months, like "1mo"
+                months="${interval%mo}"
+                if [[ "$months" -gt 0 && "$months" -le 12 ]]; then
+                    cron_schedule="0 0 1 */$months *" # Monthly on the 1st
+                else
+                    bashio::log.error "Invalid month interval: $interval"
+                fi
+                ;;
+
+            *)
+                bashio::log.error "Empty or unsupported custom interval. It should be in the format of 5m (every 5 minutes), 10d (every 10 days), 3w (every 3 weeks), 3mo (every 3 months)"
+                ;;
+        esac
+
+        if [[ -n "$cron_schedule" ]]; then
+            sed -i "/customize the cron schedule/a export COLLECTOR_CRON_SCHEDULE=\"$cron_schedule\"" /etc/cont-init.d/50-cron-config
+            bashio::log.info "Custom cron schedule set to: $cron_schedule"
+        fi
+        ;;
+esac

--- a/scrutiny_original/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/scrutiny_original/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+
+#################
+# NGINX SETTING #
+#################
+declare port
+declare certfile
+declare ingress_interface
+declare ingress_port
+declare keyfile
+
+port=$(bashio::addon.port 80)
+if bashio::var.has_value "${port}"; then
+    bashio::config.require.ssl
+
+    if bashio::config.true 'ssl'; then
+        certfile=$(bashio::config 'certfile')
+        keyfile=$(bashio::config 'keyfile')
+
+        mv /etc/nginx/servers/direct-ssl.disabled /etc/nginx/servers/direct.conf
+        sed -i "s/%%certfile%%/${certfile}/g" /etc/nginx/servers/direct.conf
+        sed -i "s/%%keyfile%%/${keyfile}/g" /etc/nginx/servers/direct.conf
+
+    else
+        mv /etc/nginx/servers/direct.disabled /etc/nginx/servers/direct.conf
+    fi
+fi
+
+ingress_port=$(bashio::addon.ingress_port)
+ingress_interface=$(bashio::addon.ip_address)
+ingress_entry=$(bashio::addon.ingress_entry)
+sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
+sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
+sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf

--- a/scrutiny_original/rootfs/etc/cont-init.d/90-run.sh
+++ b/scrutiny_original/rootfs/etc/cont-init.d/90-run.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+
+#########################
+# EXPOSE COLLECTOR.YAML #
+#########################
+
+if bashio::config.true "expose_collector"; then
+    bashio::log.info "collector.yaml exposed in /share/scrutiny"
+    mkdir -p /share/scrutiny
+    if [ -f /data/config/collector.yaml ]; then
+        cp -rnf /data/config/collector.yaml /share/scrutiny || true
+        rm -R /data/config/collector.yaml
+    fi
+    if [ -f /opt/scrutiny/config/collector.yaml ]; then
+        cp -rnf /opt/scrutiny/config/collector.yaml /share/scrutiny || true
+        rm /opt/scrutiny/config/collector.yaml
+    fi
+    touch /share/scrutiny/collector.yaml
+    ln -sf /share/scrutiny/collector.yaml /data/config || true
+    mkdir -p /opt/scrutiny/config
+    ln -sf /share/scrutiny/collector.yaml /opt/scrutiny/config/collector.yaml || true
+    chmod 755 -R /share/scrutiny
+fi
+
+########
+# MODE #
+########
+
+if [[ "$(bashio::config "Mode")" == Collector ]]; then
+    # Clean services
+    bashio::log.warning "Collector only mode. WebUI and Influxdb will be disabled"
+    rm -r /etc/services.d/influxdb
+    rm -r /etc/services.d/scrutiny
+    rm -r /etc/services.d/nginx
+    sed -i "/wait/d" /etc/services.d/collector-once/run
+    sed -i "/scrutiny api not ready/d" /etc/services.d/collector-once/run
+
+    # Check collector
+    if bashio::config.has_value "COLLECTOR_API_ENDPOINT"; then
+        echo "export COLLECTOR_API_ENDPOINT=$(bashio::config "COLLECTOR_API_ENDPOINT")" >> /env.sh
+        sed -i "1a export COLLECTOR_API_ENDPOINT=$(bashio::config "COLLECTOR_API_ENDPOINT")" /etc/services.d/collector-once/run
+        if [ -d /var/run/s6/container_environment ]; then printf "%s" "$COLLECTOR_API_ENDPOINT" > /var/run/s6/container_environment/COLLECTOR_API_ENDPOINT; fi
+        printf "%s\n" "IN_BACKGROUND=\"$COLLECTOR_API_ENDPOINT\"" >> ~/.bashrc
+        bashio::log.info "Using 'COLLECTOR_API_ENDPOINT' $(bashio::config "COLLECTOR_API_ENDPOINT")"
+    else
+        bashio::exit.nok "Mode is set to 'Collector', but 'COLLECTOR_API_ENDPOINT' is not defined"
+    fi
+fi

--- a/scrutiny_original/rootfs/etc/nginx/includes/mime.types
+++ b/scrutiny_original/rootfs/etc/nginx/includes/mime.types
@@ -1,0 +1,96 @@
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    application/javascript                           js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                         wmlc;
+    application/x-7z-compressed                      7z;
+    application/x-cocoa                              cco;
+    application/x-java-archive-diff                  jardiff;
+    application/x-java-jnlp-file                     jnlp;
+    application/x-makeself                           run;
+    application/x-perl                               pl pm;
+    application/x-pilot                              prc pdb;
+    application/x-rar-compressed                     rar;
+    application/x-redhat-package-manager             rpm;
+    application/x-sea                                sea;
+    application/x-shockwave-flash                    swf;
+    application/x-stuffit                            sit;
+    application/x-tcl                                tcl tk;
+    application/x-x509-ca-cert                       der pem crt;
+    application/x-xpinstall                          xpi;
+    application/xhtml+xml                            xhtml;
+    application/xspf+xml                             xspf;
+    application/zip                                  zip;
+
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+
+    audio/midi                                       mid midi kar;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        ogg;
+    audio/x-m4a                                      m4a;
+    audio/x-realaudio                                ra;
+
+    video/3gpp                                       3gpp 3gp;
+    video/mp2t                                       ts;
+    video/mp4                                        mp4;
+    video/mpeg                                       mpeg mpg;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-m4v                                      m4v;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asx asf;
+    video/x-ms-wmv                                   wmv;
+    video/x-msvideo                                  avi;
+}

--- a/scrutiny_original/rootfs/etc/nginx/includes/proxy_params.conf
+++ b/scrutiny_original/rootfs/etc/nginx/includes/proxy_params.conf
@@ -1,0 +1,15 @@
+proxy_http_version          1.1;
+proxy_ignore_client_abort   off;
+proxy_read_timeout          86400s;
+proxy_redirect              off;
+proxy_send_timeout          86400s;
+proxy_max_temp_file_size    0;
+
+proxy_set_header Accept-Encoding "";
+proxy_set_header Connection $connection_upgrade;
+proxy_set_header Host $http_host;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-NginX-Proxy true;
+proxy_set_header X-Real-IP $remote_addr;

--- a/scrutiny_original/rootfs/etc/nginx/includes/resolver.conf
+++ b/scrutiny_original/rootfs/etc/nginx/includes/resolver.conf
@@ -1,0 +1,1 @@
+resolver 127.0.0.11 ipv6=off;

--- a/scrutiny_original/rootfs/etc/nginx/includes/server_params.conf
+++ b/scrutiny_original/rootfs/etc/nginx/includes/server_params.conf
@@ -1,0 +1,5 @@
+server_name     $hostname;
+
+add_header X-Content-Type-Options nosniff;
+add_header X-XSS-Protection "1; mode=block";
+add_header X-Robots-Tag none;

--- a/scrutiny_original/rootfs/etc/nginx/includes/ssl_params.conf
+++ b/scrutiny_original/rootfs/etc/nginx/includes/ssl_params.conf
@@ -1,0 +1,9 @@
+ssl_protocols TLSv1.2;
+ssl_prefer_server_ciphers on;
+ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA;
+ssl_ecdh_curve secp384r1;
+ssl_session_timeout  10m;
+ssl_session_cache shared:SSL:10m;
+ssl_session_tickets off;
+ssl_stapling on;
+ssl_stapling_verify on;

--- a/scrutiny_original/rootfs/etc/nginx/includes/upstream.conf
+++ b/scrutiny_original/rootfs/etc/nginx/includes/upstream.conf
@@ -1,0 +1,3 @@
+upstream backend {
+    server 127.0.0.1:8080;
+}

--- a/scrutiny_original/rootfs/etc/nginx/nginx.conf
+++ b/scrutiny_original/rootfs/etc/nginx/nginx.conf
@@ -1,0 +1,56 @@
+# Run nginx in foreground.
+daemon off;
+
+# This is run inside Docker.
+user root;
+
+# Pid storage location.
+pid /var/run/nginx.pid;
+
+# Set number of worker processes.
+worker_processes 1;
+
+# Enables the use of JIT for regular expressions to speed-up their processing.
+pcre_jit on;
+
+# Write error log to Hass.io add-on log.
+error_log /proc/1/fd/1 error;
+
+# Load allowed environment vars
+env HASSIO_TOKEN;
+
+# Load dynamic modules.
+include /etc/nginx/modules/*.conf;
+
+# Max num of simultaneous connections by a worker process.
+events {
+    worker_connections 512;
+}
+
+http {
+    include /etc/nginx/includes/mime.types;
+
+    log_format hassio '[$time_local] $status '
+                        '$http_x_forwarded_for($remote_addr) '
+                        '$request ($http_user_agent)';
+
+    access_log              /proc/1/fd/1 hassio;
+    client_max_body_size    4G;
+    default_type            application/octet-stream;
+    gzip                    on;
+    keepalive_timeout       65;
+    sendfile                on;
+    server_tokens           off;
+    tcp_nodelay             on;
+    tcp_nopush              on;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
+    include /etc/nginx/includes/resolver.conf;
+    include /etc/nginx/includes/upstream.conf;
+
+    include /etc/nginx/servers/*.conf;
+}

--- a/scrutiny_original/rootfs/etc/nginx/servers/ingress.conf
+++ b/scrutiny_original/rootfs/etc/nginx/servers/ingress.conf
@@ -1,0 +1,28 @@
+server {
+    listen %%interface%%:%%port%% default_server;
+
+    include /etc/nginx/includes/server_params.conf;
+    include /etc/nginx/includes/proxy_params.conf;
+    
+    client_max_body_size 0;
+
+    root /opt/scrutiny/web;
+
+   location = / {
+      absolute_redirect off;              # Do not add port to redirect
+      return 301 %%ingress_entry%%/web/dashboard;
+   }
+
+  location /api { 
+       add_header Access-Control-Allow-Origin *;   
+       proxy_read_timeout 30;
+       proxy_pass         http://backend/api;
+  }
+
+  location /web/ { 
+       add_header Access-Control-Allow-Origin *;   
+       proxy_read_timeout 30;
+       proxy_pass         http://backend/web/;
+  }
+
+}

--- a/scrutiny_original/rootfs/etc/services.d/nginx/finish
+++ b/scrutiny_original/rootfs/etc/services.d/nginx/finish
@@ -1,0 +1,9 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+# ==============================================================================
+# Stop the container when Nginx fails
+# ==============================================================================
+if [[ "$1" -ne 0 && "$1" -ne 256 ]]; then
+    bashio::log.error "Nginx exited with code $1"
+    kill -15 1
+fi

--- a/scrutiny_original/rootfs/etc/services.d/nginx/run
+++ b/scrutiny_original/rootfs/etc/services.d/nginx/run
@@ -1,0 +1,11 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+# ==============================================================================
+
+# Wait for transmission to become available
+bashio::net.wait_for 8080 localhost 900
+
+bashio::log.info "Starting NGinx..."
+
+exec nginx

--- a/scrutiny_original/updater.json
+++ b/scrutiny_original/updater.json
@@ -1,0 +1,10 @@
+{
+  "github_fulltag": "true",
+  "last_update": "2026-06-13",
+  "paused": false,
+  "repository": "alexbelgium/hassio-addons",
+  "slug": "scrutiny_original",
+  "source": "github",
+  "upstream_repo": "analogj/scrutiny",
+  "upstream_version": "v1.63.0"
+}


### PR DESCRIPTION
### Motivation
- Provide duplicate "original" variants of the Scrutiny addons that build from and follow the AnalogJ upstream image and repo so maintainers/users can choose the AnalogJ upstream binary as a build base.
- Preserve behavior of both the normal and full-access addons while keeping the original author image/source metadata separate.

### Description
- Adds `scrutiny_original` and `scrutiny_fa_original` directories as duplicates of the existing `scrutiny` and `scrutiny_fa` addons with `slug` and `name` adjusted to include `_original` and image names changed to include `-original` where appropriate.
- Updates both addons' `build.json` to use `ghcr.io/analogj/scrutiny:latest-omnibus` for `aarch64` and `amd64`.
- Updates both addons' `updater.json` to set `upstream_repo` to `analogj/scrutiny` and `slug` to the new `_original` slugs.
- Only text files were added or modified; binary/image assets were not changed or added to avoid preventing the PR from being created.

### Testing
- Validated JSON formatting with `python3 -m json.tool` on the new `build.json` and `updater.json` files and they succeeded.
- Validated YAML parsing with Ruby using `ruby -e "require 'yaml'; %w[scrutiny_original/config.yaml scrutiny_fa_original/config.yaml].each { |f| YAML.load_file(f); puts \"ok #{f}\" }"` and it succeeded.
- Scanned new files for NUL bytes with a Python check to ensure no binary-like files were added and it reported no NUL bytes found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2db23d81bc8325af7593dfb2079f0d)