### PR TITLE
Fix wger fresh-install startup

### DIFF
--- a/wger/CHANGELOG.md
+++ b/wger/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.6-dev-3 (2026-06-16)
+- Fix fresh-install startup by making the persistent `/data/static` and `/data/media` directories writable by the `wger` user without recursively changing all of `/data`.
+- Make nginx startup idempotent and fail loudly if its configuration is invalid, instead of masking nginx startup errors that can leave the add-on web port closed.
 
 ## 2.6-dev-2 (2026-06-16)
 - Fix startup script database path rewrite by switching the `settings.py` matching with `*.py` since last update moved the settings.py file into several files within the settings folder

--- a/wger/CHANGELOG.md
+++ b/wger/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.6-dev-3 (2026-06-16)
 - Fix fresh-install startup by making the persistent `/data/static` and `/data/media` directories writable by the `wger` user without recursively changing all of `/data`.
+- Preserve existing persistent data by reusing `/data/database.sqlite` when present, and migrating a legacy `/home/wger/db/database.sqlite` only if no persistent database exists yet.
 - Make nginx startup idempotent and fail loudly if its configuration is invalid, instead of masking nginx startup errors that can leave the add-on web port closed.
 
 ## 2.6-dev-2 (2026-06-16)

--- a/wger/config.yaml
+++ b/wger/config.yaml
@@ -23,5 +23,5 @@ schema:
 slug: wger
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "2.6-dev-2"
+version: "2.6-dev-3"
 webui: "[PROTO:ssl]://[HOST]:[PORT:80]"

--- a/wger/rootfs/etc/cont-init.d/90-run.sh
+++ b/wger/rootfs/etc/cont-init.d/90-run.sh
@@ -106,7 +106,7 @@ mkdir -p /run/nginx /var/log/nginx
 if [ -f /run/nginx.pid ] && kill -0 "$(cat /run/nginx.pid)" 2> /dev/null; then
     bashio::log.info "nginx is already running"
 elif nginx -t; then
-    nginx
+    nginx &
 else
     bashio::log.error "nginx configuration test failed"
     exit 1

--- a/wger/rootfs/etc/cont-init.d/90-run.sh
+++ b/wger/rootfs/etc/cont-init.d/90-run.sh
@@ -32,6 +32,25 @@ move_persistent_dir() {
     ln -sfn "$target" "$source"
 }
 
+migrate_database() {
+    local legacy_db=/home/wger/db/database.sqlite
+    local persistent_db=/data/database.sqlite
+
+    if [ -f "$persistent_db" ]; then
+        bashio::log.info "Using existing persistent database at $persistent_db"
+    elif [ -f "$legacy_db" ]; then
+        bashio::log.info "Migrating legacy database from $legacy_db to $persistent_db"
+        cp -n "$legacy_db" "$persistent_db"
+    else
+        bashio::log.info "No existing database found; wger will create a new persistent database at $persistent_db"
+    fi
+
+    if [ -f "$persistent_db" ]; then
+        chown wger "$persistent_db" || bashio::log.warning "Unable to set $persistent_db ownership to wger"
+        chmod a+rw "$persistent_db" || bashio::log.warning "Unable to make $persistent_db writable"
+    fi
+}
+
 ############################
 # Change database location #
 ############################
@@ -51,6 +70,7 @@ fi
 #####################
 echo "... create directories"
 prepare_data_root
+migrate_database
 move_persistent_dir /home/wger/static /data/static
 move_persistent_dir /home/wger/media /data/media
 
@@ -60,10 +80,7 @@ move_persistent_dir /home/wger/media /data/media
 echo "... align permissions"
 prepare_writable_dir /data/static
 prepare_writable_dir /data/media
-if [ -f /data/database.sqlite ]; then
-    chown wger /data/database.sqlite || bashio::log.warning "Unable to set /data/database.sqlite ownership to wger"
-    chmod a+rw /data/database.sqlite || bashio::log.warning "Unable to make /data/database.sqlite writable"
-fi
+migrate_database
 
 echo "... add env variables"
 (

--- a/wger/rootfs/etc/cont-init.d/90-run.sh
+++ b/wger/rootfs/etc/cont-init.d/90-run.sh
@@ -1,5 +1,37 @@
 #!/usr/bin/env bashio
 
+set -u
+
+prepare_data_root() {
+    mkdir -p /data
+    chown wger /data || bashio::log.warning "Unable to set /data ownership to wger"
+    chmod a+rwx /data || bashio::log.warning "Unable to make /data writable"
+}
+
+prepare_writable_dir() {
+    local path="$1"
+
+    mkdir -p "$path"
+    chown -R wger "$path" || bashio::log.warning "Unable to set $path ownership to wger"
+    chmod -R a+rwX "$path" || bashio::log.warning "Unable to make $path writable"
+}
+
+move_persistent_dir() {
+    local source="$1"
+    local target="$2"
+
+    prepare_writable_dir "$target"
+
+    if [ -d "$source" ] && [ ! -L "$source" ]; then
+        if [ -n "$(ls -A "$source" 2> /dev/null)" ]; then
+            cp -rnf "$source"/. "$target"/
+        fi
+        rm -rf "$source"
+    fi
+
+    ln -sfn "$target" "$source"
+}
+
 ############################
 # Change database location #
 ############################
@@ -11,56 +43,56 @@ if [ "${#SETTINGS_FILES[@]}" -gt 0 ]; then
         sed -i "s|/home/wger/db/database.sqlite|/data/database.sqlite|g" "$settings_file"
     done
 else
-    bashio::log.warning "Unable to find settings.py containing database path under /home, skipping rewrite"
+    bashio::log.warning "Unable to find Python settings containing database path under /home, skipping rewrite"
 fi
 
 #####################
 # Adapt directories #
 #####################
 echo "... create directories"
-mkdir -p /data/static
-if [ -d /home/wger/static ] && [ ! -L /home/wger/static ]; then
-    if [ -n "$(ls -A /home/wger/static 2> /dev/null)" ]; then
-        cp -rnf /home/wger/static/* /data/static/
-    fi
-    rm -r /home/wger/static
-fi
-ln -sf /data/static /home/wger
-
-mkdir -p /data/media
-if [ -d /home/wger/media ] && [ ! -L /home/wger/media ]; then
-    if [ -n "$(ls -A /home/wger/media 2> /dev/null)" ]; then
-        cp -rnf /home/wger/media/* /data/media/
-    fi
-    rm -r /home/wger/media
-fi
-ln -sf /data/media /home/wger
+prepare_data_root
+move_persistent_dir /home/wger/static /data/static
+move_persistent_dir /home/wger/media /data/media
 
 #####################
 # Align permissions #
 #####################
 echo "... align permissions"
-chown -R wger /data
-chown -R wger /home/wger
-chmod -R 777 /data
+prepare_writable_dir /data/static
+prepare_writable_dir /data/media
+if [ -f /data/database.sqlite ]; then
+    chown wger /data/database.sqlite || bashio::log.warning "Unable to set /data/database.sqlite ownership to wger"
+    chmod a+rw /data/database.sqlite || bashio::log.warning "Unable to make /data/database.sqlite writable"
+fi
 
 echo "... add env variables"
 (
     set -o posix
     export -p
 ) > /data/env.sh
-while IFS= read -r line; do
-    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
-    var="${line%%=*}"
-    sed -i "/^export[[:space:]]\+$var=/d" /data/env.sh
-    echo "export $line" >> /data/env.sh
-done < /.env
 
-chown wger /data/env.sh
-chmod +x /data/env.sh
+if [ -f /.env ]; then
+    while IFS= read -r line; do
+        [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+        var="${line%%=*}"
+        [[ "$var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+        sed -i "/^export[[:space:]]\+$var=/d" /data/env.sh
+        echo "export $line" >> /data/env.sh
+    done < /.env
+fi
+
+chown wger /data/env.sh || bashio::log.warning "Unable to set /data/env.sh ownership to wger"
+chmod 0644 /data/env.sh || bashio::log.warning "Unable to make /data/env.sh readable"
 
 bashio::log.info "Starting nginx"
-nginx || true &
-true
+mkdir -p /run/nginx /var/log/nginx
+if [ -f /run/nginx.pid ] && kill -0 "$(cat /run/nginx.pid)" 2> /dev/null; then
+    bashio::log.info "nginx is already running"
+elif nginx -t; then
+    nginx
+else
+    bashio::log.error "nginx configuration test failed"
+    exit 1
+fi
 
 bashio::log.info "Starting entrypoint"


### PR DESCRIPTION
Fixes #2529

## Summary
- Make wger's `/data/static` and `/data/media` preparation explicit and limited to persistent wger directories, avoiding a broad recursive chmod/chown over all of `/data`.
- Preserve/migrate existing static/media contents before recreating symlinks.
- Make nginx startup idempotent and fail loudly on invalid config instead of masking startup errors.
- Bump wger to `2.6-dev-3` and update the changelog.

## Validation
- `bash -n` on updated `wger/rootfs/etc/cont-init.d/90-run.sh` passed locally.

Note: ShellCheck/Hadolint were not available in this execution environment.