### PR TITLE
aurral: set github_beta=false to track stable releases only

### DIFF
--- a/aurral/updater.json
+++ b/aurral/updater.json
@@ -4,5 +4,6 @@
   "slug": "aurral",
   "source": "github",
   "upstream_repo": "lklynet/aurral",
-  "upstream_version": "1.76.51"
+  "upstream_version": "1.76.51",
+  "github_beta": false
 }


### PR DESCRIPTION
## Problem

The updater bot is picking up pre-release tags (e.g. `1.76.51-dev.35`, `1.76.51-test.19`) from lklynet/aurral and bumping `config.yaml` with them. Since `build.json` uses `:latest` which only updates on stable releases, this creates a version mismatch — HA reports a newer version than what's actually in the container.

## Fix

Add `"github_beta": false` to `updater.json` so the bot filters to stable releases only (`.draft == false and .prerelease == false`), consistent with how lklynet defines stable: pushes to `main` only.