### PR TITLE
Fix nginx_webserver_proxy startup bash permission error

### DIFF
--- a/nginx_webserver_proxy/Dockerfile
+++ b/nginx_webserver_proxy/Dockerfile
@@ -1,18 +1,14 @@
-ARG BUILD_FROM=jc21/nginx-proxy-manager:latest
+ARG BUILD_FROM=jc21/nginx-proxy-manager:2.14.0
 FROM ${BUILD_FROM}
 
-# NPM is Debian-based; install jq for options parsing + stub with-contenv if absent
+# NPM is Debian-based; install jq for options parsing and ensure bash is present.
 # hadolint ignore=DL3008
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends jq \
-    && rm -rf /var/lib/apt/lists/* \
-    && if ! command -v with-contenv >/dev/null 2>&1; then \
-         printf '#!/usr/bin/env bash\nexec "$@"\n' > /usr/bin/with-contenv \
-         && chmod +x /usr/bin/with-contenv; \
-       fi
+    && apt-get install -y --no-install-recommends bash jq \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY run.sh /npm-addon-init.sh
-RUN chmod +x /npm-addon-init.sh
+RUN chmod 0755 /npm-addon-init.sh
 
 ARG BUILD_VERSION
 LABEL \
@@ -20,4 +16,4 @@ LABEL \
   io.hass.type="addon" \
   io.hass.arch="aarch64|amd64"
 
-ENTRYPOINT ["/npm-addon-init.sh"]
+ENTRYPOINT ["/bin/bash", "/npm-addon-init.sh"]

--- a/nginx_webserver_proxy/Dockerfile
+++ b/nginx_webserver_proxy/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=jc21/nginx-proxy-manager:2.14.0
+ARG BUILD_FROM=jc21/nginx-proxy-manager:latest
 FROM ${BUILD_FROM}
 
 # NPM is Debian-based; install jq for options parsing and ensure bash is present.

--- a/nginx_webserver_proxy/Dockerfile
+++ b/nginx_webserver_proxy/Dockerfile
@@ -16,4 +16,4 @@ LABEL \
   io.hass.type="addon" \
   io.hass.arch="aarch64|amd64"
 
-ENTRYPOINT ["/bin/bash", "/npm-addon-init.sh"]
+ENTRYPOINT ["/npm-addon-init.sh"]

--- a/nginx_webserver_proxy/build.yaml
+++ b/nginx_webserver_proxy/build.yaml
@@ -1,4 +1,4 @@
 ---
 build_from:
-  aarch64: jc21/nginx-proxy-manager:latest
-  amd64: jc21/nginx-proxy-manager:latest
+  aarch64: jc21/nginx-proxy-manager:2.14.0
+  amd64: jc21/nginx-proxy-manager:2.14.0

--- a/nginx_webserver_proxy/build.yaml
+++ b/nginx_webserver_proxy/build.yaml
@@ -1,4 +1,4 @@
 ---
 build_from:
-  aarch64: jc21/nginx-proxy-manager:2.14.0
-  amd64: jc21/nginx-proxy-manager:2.14.0
+  aarch64: jc21/nginx-proxy-manager:latest
+  amd64: jc21/nginx-proxy-manager:latest

--- a/nginx_webserver_proxy/config.yaml
+++ b/nginx_webserver_proxy/config.yaml
@@ -1,7 +1,7 @@
 name: "Nginx Proxy Manager + Static Web Server"
 slug: nginx_webserver_proxy
 description: "Nginx Proxy Manager with a built-in configurable static file server. Manage reverse proxies via NPM UI on port 81 while serving files from HA storage on port 80."
-version: "2.14.0"
+version: "2.14.1"
 url: "https://github.com/alexbelgium/hassio-addons/tree/master/nginx_webserver_proxy"
 arch:
   - amd64

--- a/nginx_webserver_proxy/run.sh
+++ b/nginx_webserver_proxy/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv bash
+#!/bin/bash
 # shellcheck shell=bash
 set -Eeuo pipefail
 


### PR DESCRIPTION
## Summary

Fixes #2777.

This keeps the change scoped to the `nginx_webserver_proxy` add-on startup path:

- use `/bin/bash` directly for the add-on init script instead of routing through `with-contenv`
- remove the fallback `with-contenv` stub that used `#!/usr/bin/env bash`
- ensure `bash` and `jq` are installed explicitly
- keep the upstream Nginx Proxy Manager base image on `jc21/nginx-proxy-manager:latest`
- bump the add-on version to `2.14.1` so the existing builder workflow rebuilds the add-on image

## Rationale

The reported failure is:

```text
/usr/bin/env: 'bash': Permission denied
```

The previous image build could create `/usr/bin/with-contenv` as a stub with `#!/usr/bin/env bash`, and the add-on entrypoint itself started via `#!/usr/bin/with-contenv bash`. Using `/bin/bash` directly removes that unnecessary `/usr/bin/env bash` dependency from the earliest startup path while keeping the upstream NPM `latest` base image behavior unchanged.

## Validation

- Current PR diff reviewed after corrections
- Verified `nginx_webserver_proxy/Dockerfile` keeps `ARG BUILD_FROM=jc21/nginx-proxy-manager:latest`
- Verified `nginx_webserver_proxy/build.yaml` keeps both architectures on `jc21/nginx-proxy-manager:latest`
- Verified `nginx_webserver_proxy/run.sh` starts with `#!/bin/bash`

Note: I could not run ShellCheck or Hadolint in the execution environment because those binaries were not installed.