### PR TITLE
fix(gitea,elasticsearch): allow sys_chroot in AppArmor profiles

### DIFF
--- a/elasticsearch/CHANGELOG.md
+++ b/elasticsearch/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.14.3-3 (2026-06-19)
+- Fix startup failing with `chroot: cannot change root directory` by allowing `capability sys_chroot` in the AppArmor profile (#2709)
+- Fix AppArmor profile name (was `inadyn_addon`, colliding with several other add-ons); renamed to `elasticsearch_addon`
+
 ## 8.14.3-2 (2025-11-18)
 - 8.14.3-1 (2025-11-18)
   - Added `env_vars` option to support custom environment variables from the add-on configuration.

--- a/elasticsearch/apparmor.txt
+++ b/elasticsearch/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile inadyn_addon flags=(attach_disconnected,mediate_deleted) {
+profile elasticsearch_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   capability chown,
@@ -8,6 +8,7 @@ profile inadyn_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/elasticsearch/config.yaml
+++ b/elasticsearch/config.yaml
@@ -90,4 +90,4 @@ slug: elasticsearch
 startup: services
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/elasticsearch
-version: 8.14.3-1
+version: 8.14.3-3

--- a/gitea/CHANGELOG.md
+++ b/gitea/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 1.26.2-1 (2026-06-19)
+- Fix SSH authentication failing with `chroot("/var/empty"): Operation not permitted [preauth]` by allowing `capability sys_chroot` in the AppArmor profile, which sshd needs for privilege-separation (#2653)
+
 ## 1.26.2 (2026-05-22)
 - Update to latest version from go-gitea/gitea (changelog : https://github.com/go-gitea/gitea/releases)
 

--- a/gitea/apparmor.txt
+++ b/gitea/apparmor.txt
@@ -8,6 +8,7 @@ profile gitea_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/gitea/config.yaml
+++ b/gitea/config.yaml
@@ -97,5 +97,5 @@ schema:
 slug: gitea
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/gitea
-version: "1.26.2"
+version: "1.26.2-1"
 webui: "[PROTO:ssl]://[HOST]:[PORT:3000]"


### PR DESCRIPTION
Both add-ons failed because their AppArmor profiles did not list
`capability sys_chroot`, which AppArmor then denied even though it is
part of Docker's default capability set:

- gitea: sshd privilege-separation chroot("/var/empty") failed with
  "Operation not permitted [preauth]", breaking git-over-SSH (#2653)
- elasticsearch: upstream startup chroot failed with
  "chroot: cannot change root directory" (#2709)

Also rename the elasticsearch AppArmor profile from the copy-pasted
`inadyn_addon` (shared with several other add-ons) to
`elasticsearch_addon` to avoid profile-name collisions.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V7P3Nbem7n9FqGTXrLMadP