### PR TITLE
gitea: expose app.ini in addon_config folder for direct editing

### DIFF
--- a/gitea/rootfs/etc/cont-init.d/99-run.sh
+++ b/gitea/rootfs/etc/cont-init.d/99-run.sh
@@ -9,12 +9,13 @@ set -e
 # Ensure the gitea conf directory exists
 mkdir -p /data/gitea/conf
 
-# If a real file (not a symlink) exists, migrate it to /config so users can edit it
+# If a real file (not a symlink) exists, move it to /config.
+# This covers both the initial migration from older installs and the post-wizard
+# case where Gitea's atomic SaveTo replaces the symlink with the completed config.
+# Always overwrite /config/app.ini so the installed settings are never discarded.
 if [ -f "/data/gitea/conf/app.ini" ] && [ ! -L "/data/gitea/conf/app.ini" ]; then
-    if [ ! -f "/config/app.ini" ]; then
-        bashio::log.info "Migrating app.ini to addon_config folder for direct access"
-        cp /data/gitea/conf/app.ini /config/app.ini
-    fi
+    bashio::log.info "Moving app.ini to addon_config folder for direct access"
+    cp /data/gitea/conf/app.ini /config/app.ini
     rm /data/gitea/conf/app.ini
 fi
 


### PR DESCRIPTION
## Summary

- Symlinks `/data/gitea/conf/app.ini` → `/config/app.ini` so the full Gitea configuration file is accessible in the add-on's config folder (`/addon_configs/gitea/app.ini` on the host)
- On first restart after the setup wizard, Gitea's `SaveTo` replaces the symlink with a real file; the script now **always** copies that real file to `/config/app.ini` (overwriting any pre-wizard template) so installed DB/security settings are never lost
- On subsequent restarts the symlink is intact, no copy happens
- Existing add-on options (SSL, DOMAIN, ROOT_URL, APP_NAME) are still applied on top of the file each restart
- Updated README with documentation for the new feature
- Bumped version to `1.26.2-2`

Closes #1907

## Fix detail

Gitea's install wizard uses an atomic `SaveTo` that replaces the symlink at `/data/gitea/conf/app.ini` with a real file. The previous guard (`if [ ! -f /config/app.ini ]`) skipped the copy when the pre-wizard template already existed at `/config/app.ini`, then `rm` deleted the real installed config — wiping all DB/security/install settings. The fix removes the inner guard so the real file always overwrites `/config/app.ini`.

## Test plan

- [ ] Fresh install: complete setup wizard, restart — `/addon_configs/gitea/app.ini` contains the completed install config (not the template), all settings preserved
- [ ] Existing install: restart add-on — existing `app.ini` is migrated to `/addon_configs/gitea/app.ini`, symlink created
- [ ] Edit `app.ini` directly, restart — changes are preserved; HA options (SSL, DOMAIN etc.) still override their respective keys
- [ ] SSL on/off still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D46Ef3nZZdbVuwUpPhCd4T

---
_Generated by [Claude Code](https://claude.ai/code/session_01D46Ef3nZZdbVuwUpPhCd4T)_