### PR TITLE
Fix AppArmor profiles: add capability sys_chroot and fix profile name collisions

### DIFF
--- a/addons_updater/apparmor.txt
+++ b/addons_updater/apparmor.txt
@@ -2,6 +2,7 @@
 
 profile addon_updater flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
+  capability sys_chroot,
 
   # Capabilities
   file,

--- a/arpspoof/apparmor.txt
+++ b/arpspoof/apparmor.txt
@@ -9,6 +9,7 @@ profile arpspoof_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/aurral/apparmor.txt
+++ b/aurral/apparmor.txt
@@ -2,6 +2,7 @@
 
 profile aurral flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
+  capability sys_chroot,
 
   file,
   signal (send) set=(kill,term,int,hup,cont),

--- a/autobrr/apparmor.txt
+++ b/autobrr/apparmor.txt
@@ -9,6 +9,7 @@ profile autobrr_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/baikal/apparmor.txt
+++ b/baikal/apparmor.txt
@@ -9,6 +9,7 @@ profile baikal_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/battybirdnet-pi/apparmor.txt
+++ b/battybirdnet-pi/apparmor.txt
@@ -9,6 +9,7 @@ profile battybirdnet-pi_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/bazarr/apparmor.txt
+++ b/bazarr/apparmor.txt
@@ -10,6 +10,7 @@ profile bazarr_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/bentopdf/apparmor.txt
+++ b/bentopdf/apparmor.txt
@@ -2,6 +2,7 @@
 
 profile bentopdf flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
+  capability sys_chroot,
 
   # Capabilities
   file,

--- a/binance-trading-bot/apparmor.txt
+++ b/binance-trading-bot/apparmor.txt
@@ -9,6 +9,7 @@ profile db21ed7f_binance-trading-bot flags=(attach_disconnected,mediate_deleted)
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/birdnet-go/apparmor.txt
+++ b/birdnet-go/apparmor.txt
@@ -9,6 +9,7 @@ profile db21ed7f_birdnet-go flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   capability sys_resource,
   file,

--- a/birdnet-pi/apparmor.txt
+++ b/birdnet-pi/apparmor.txt
@@ -9,6 +9,7 @@ profile birdnet-pi_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/birdnet-pipy/apparmor.txt
+++ b/birdnet-pipy/apparmor.txt
@@ -8,6 +8,7 @@ profile birdnet-pipy_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/bitwarden/apparmor.txt
+++ b/bitwarden/apparmor.txt
@@ -8,6 +8,7 @@ profile bitwarden_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/booksonic_air/apparmor.txt
+++ b/booksonic_air/apparmor.txt
@@ -9,6 +9,7 @@ profile booksonic-air_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/browser_brave/apparmor.txt
+++ b/browser_brave/apparmor.txt
@@ -1,1 +1,72 @@
-../browser_chromium/apparmor.txt
+#include <tunables/global>
+
+profile browser_brave_addon flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  capability chown,
+  capability dac_override,
+  capability dac_read_search,
+  capability fowner,
+  capability setgid,
+  capability setuid,
+  capability sys_chroot,
+  capability sys_admin,
+  file,
+  signal,
+  mount,
+  umount,
+  remount,
+  network udp,
+  network tcp,
+  network dgram,
+  network stream,
+  network inet,
+  network inet6,
+  network netlink raw,
+  network unix dgram,
+
+
+# S6-Overlay
+  /init ix,
+  /run/{s6,s6-rc*,service}/** ix,
+  /package/** ix,
+  /command/** ix,
+  /run/{,**} rwk,
+  /dev/tty rw,
+  /bin/** ix,
+  /usr/bin/** ix,
+  /usr/lib/bashio/** ix,
+  /etc/s6/** rix,
+  /run/s6/** rix,
+  /etc/services.d/** rwix,
+  /etc/cont-init.d/** rwix,
+  /etc/cont-finish.d/** rwix,
+  /init rix,
+  /var/run/** mrwkl,
+  /var/run/ mrwkl,
+  /dev/i2c-1 mrwkl,
+  # Files required
+  /dev/fuse mrwkl,
+  /dev/sda1 mrwkl,
+  /dev/sdb1 mrwkl,
+  /dev/nvme0 mrwkl,
+  /dev/nvme0n1 mrwkl,
+  /dev/nvme1 mrwkl,
+  /dev/mmcblk0p1 mrwkl,
+  /dev/* mrwkl,
+  /udev/* mrwkl,
+  /tmp/** mrkwl,
+  /dev/fuse/** mrkwl,
+  /dev/** mrkwl,
+  /sys/firmware/** mrkwl,
+
+  # Data access
+  /data/** rw,
+
+  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
+  ptrace (trace,read) peer=docker-default,
+
+  # docker daemon confinement requires explict allow rule for signal
+  signal (receive) set=(kill,term) peer=/usr/bin/docker,
+
+}

--- a/browser_chromium/apparmor.txt
+++ b/browser_chromium/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile chromium_addon flags=(attach_disconnected,mediate_deleted) {
+profile browser_chromium_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   capability chown,
@@ -9,6 +9,7 @@ profile chromium_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/browserless_chrome/apparmor.txt
+++ b/browserless_chrome/apparmor.txt
@@ -9,6 +9,7 @@ profile browserlesschrome_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/calibre/apparmor.txt
+++ b/calibre/apparmor.txt
@@ -10,6 +10,7 @@ profile calibre_addon flags=(attach_disconnected,mediate_deleted) {
   capability net_admin,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/calibre_web/apparmor.txt
+++ b/calibre_web/apparmor.txt
@@ -10,6 +10,7 @@ profile calibre-web_addon flags=(attach_disconnected,mediate_deleted) {
   capability net_admin,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/changedetection.io/apparmor.txt
+++ b/changedetection.io/apparmor.txt
@@ -8,6 +8,7 @@ profile addon_db21ed7f_changedetection.io_nas flags=(attach_disconnected,mediate
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/cleanuparr/apparmor.txt
+++ b/cleanuparr/apparmor.txt
@@ -8,6 +8,7 @@ profile cleanuparr_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/cloudcommander/apparmor.txt
+++ b/cloudcommander/apparmor.txt
@@ -9,6 +9,7 @@ profile cloudcommander_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/codex/apparmor.txt
+++ b/codex/apparmor.txt
@@ -9,6 +9,7 @@ profile db21ed7f_codex flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/collabora/apparmor.txt
+++ b/collabora/apparmor.txt
@@ -8,6 +8,7 @@ profile collabora_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/comixed/apparmor.txt
+++ b/comixed/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile db21ed7f_qbittorrent flags=(attach_disconnected,mediate_deleted) {
+profile comixed_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   capability chown,
@@ -9,6 +9,7 @@ profile db21ed7f_qbittorrent flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/emby/apparmor.txt
+++ b/emby/apparmor.txt
@@ -9,6 +9,7 @@ profile addon_db21ed7f_emby_nas flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/emby_beta/apparmor.txt
+++ b/emby_beta/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile addon_db21ed7f_emby_nas flags=(attach_disconnected,mediate_deleted) {
+profile emby_beta_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   capability chown,
@@ -9,6 +9,7 @@ profile addon_db21ed7f_emby_nas flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/enedisgateway2mqtt/apparmor.txt
+++ b/enedisgateway2mqtt/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile inadyn_addon flags=(attach_disconnected,mediate_deleted) {
+profile enedisgateway2mqtt_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   capability chown,
@@ -8,6 +8,7 @@ profile inadyn_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/enedisgateway2mqtt_dev/apparmor.txt
+++ b/enedisgateway2mqtt_dev/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile inadyn_addon flags=(attach_disconnected,mediate_deleted) {
+profile enedisgateway2mqtt_dev_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   capability chown,
@@ -8,6 +8,7 @@ profile inadyn_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/ente/apparmor.txt
+++ b/ente/apparmor.txt
@@ -9,6 +9,7 @@ profile ente_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/epicgamesfree/apparmor.txt
+++ b/epicgamesfree/apparmor.txt
@@ -8,6 +8,7 @@ profile epicgamesfree_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/filebrowser/apparmor.txt
+++ b/filebrowser/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile db21ed7f_qbittorrent flags=(attach_disconnected,mediate_deleted) {
+profile filebrowser_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   capability chown,
@@ -9,6 +9,7 @@ profile db21ed7f_qbittorrent flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/filebrowser_quantum/apparmor.txt
+++ b/filebrowser_quantum/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile db21ed7f_qbittorrent flags=(attach_disconnected,mediate_deleted) {
+profile filebrowser_quantum_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   capability chown,
@@ -9,6 +9,7 @@ profile db21ed7f_qbittorrent flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/fireflyiii/apparmor.txt
+++ b/fireflyiii/apparmor.txt
@@ -8,6 +8,7 @@ profile fireflyiii_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/fireflyiii_data_importer/apparmor.txt
+++ b/fireflyiii_data_importer/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile fireflyiii_addon flags=(attach_disconnected,mediate_deleted) {
+profile fireflyiii_data_importer_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   capability chown,
@@ -8,6 +8,7 @@ profile fireflyiii_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/fireflyiii_fints_importer/apparmor.txt
+++ b/fireflyiii_fints_importer/apparmor.txt
@@ -8,6 +8,7 @@ profile fireflyiii_fints_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/flaresolverr/apparmor.txt
+++ b/flaresolverr/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile joplin flags=(attach_disconnected,mediate_deleted) {
+profile flaresolverr_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   capability chown,
@@ -8,6 +8,7 @@ profile joplin flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/flexget/apparmor.txt
+++ b/flexget/apparmor.txt
@@ -8,6 +8,7 @@ profile flexget_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/free_games_claimer/apparmor.txt
+++ b/free_games_claimer/apparmor.txt
@@ -8,6 +8,7 @@ profile free_games_claimer_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/gazpar2mqtt/apparmor.txt
+++ b/gazpar2mqtt/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile inadyn_addon flags=(attach_disconnected,mediate_deleted) {
+profile gazpar2mqtt_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   capability chown,
@@ -8,6 +8,7 @@ profile inadyn_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/grampsweb/apparmor.txt
+++ b/grampsweb/apparmor.txt
@@ -8,6 +8,7 @@ profile grampsweb_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/grav/apparmor.txt
+++ b/grav/apparmor.txt
@@ -8,6 +8,7 @@ profile grav_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/guacamole/apparmor.txt
+++ b/guacamole/apparmor.txt
@@ -8,6 +8,7 @@ profile guacamole_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/immich/apparmor.txt
+++ b/immich/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile db21ed7f_qbittorrent flags=(attach_disconnected,mediate_deleted) {
+profile immich_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   capability chown,
@@ -9,6 +9,7 @@ profile db21ed7f_qbittorrent flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/immich_frame/apparmor.txt
+++ b/immich_frame/apparmor.txt
@@ -8,6 +8,7 @@ profile db21ed7f_immich_frame flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/immich_power_tools/apparmor.txt
+++ b/immich_power_tools/apparmor.txt
@@ -8,6 +8,7 @@ profile db21ed7f_immich_power_tools flags=(attach_disconnected,mediate_deleted) 
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/inadyn/apparmor.txt
+++ b/inadyn/apparmor.txt
@@ -8,6 +8,7 @@ profile inadyn_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/jackett/apparmor.txt
+++ b/jackett/apparmor.txt
@@ -9,6 +9,7 @@ profile jackett_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/jellyfin/apparmor.txt
+++ b/jellyfin/apparmor.txt
@@ -10,6 +10,7 @@ profile addon_db21ed7f_jellyfin_nas flags=(attach_disconnected,mediate_deleted) 
   capability net_admin,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/joal/apparmor.txt
+++ b/joal/apparmor.txt
@@ -8,6 +8,7 @@ profile joal_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/joplin/apparmor.txt
+++ b/joplin/apparmor.txt
@@ -8,6 +8,7 @@ profile joplin flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_time,
   file,
   signal,

--- a/kometa/apparmor.txt
+++ b/kometa/apparmor.txt
@@ -9,6 +9,7 @@ profile kometa_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/librespeed/apparmor.txt
+++ b/librespeed/apparmor.txt
@@ -8,6 +8,7 @@ profile librespeed_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/lidarr/apparmor.txt
+++ b/lidarr/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile radarr_addon flags=(attach_disconnected,mediate_deleted) {
+profile lidarr_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   capability chown,
@@ -9,6 +9,7 @@ profile radarr_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/linkwarden/apparmor.txt
+++ b/linkwarden/apparmor.txt
@@ -8,6 +8,7 @@ profile linkwarden_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/maintainerr/apparmor.txt
+++ b/maintainerr/apparmor.txt
@@ -8,6 +8,7 @@ profile maintainerr_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/manyfold/apparmor.txt
+++ b/manyfold/apparmor.txt
@@ -15,6 +15,7 @@ profile hassio-addons/manyfold flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
 
   deny /proc/kcore rwklx,
   deny /proc/sysrq-trigger rwklx,

--- a/mealie/apparmor.txt
+++ b/mealie/apparmor.txt
@@ -8,6 +8,7 @@ profile mealie_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/monica/apparmor.txt
+++ b/monica/apparmor.txt
@@ -8,6 +8,7 @@ profile monica_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/mylar3/apparmor.txt
+++ b/mylar3/apparmor.txt
@@ -9,6 +9,7 @@ profile mylar3_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/navidrome/apparmor.txt
+++ b/navidrome/apparmor.txt
@@ -9,6 +9,7 @@ profile navidrome_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/netalertx/apparmor.txt
+++ b/netalertx/apparmor.txt
@@ -10,6 +10,7 @@ profile netalertx_addon flags=(attach_disconnected,mediate_deleted) {
   capability net_raw,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/nextcloud/apparmor.txt
+++ b/nextcloud/apparmor.txt
@@ -9,6 +9,7 @@ profile nextcloud_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/nzbget/apparmor.txt
+++ b/nzbget/apparmor.txt
@@ -9,6 +9,7 @@ profile nzbget_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/omni-tools/apparmor.txt
+++ b/omni-tools/apparmor.txt
@@ -9,6 +9,7 @@ profile omni-tools flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal (send) set=(kill,term,int,hup,cont),
 

--- a/openproject/apparmor.txt
+++ b/openproject/apparmor.txt
@@ -8,6 +8,7 @@ profile openproject_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/organizr/apparmor.txt
+++ b/organizr/apparmor.txt
@@ -8,6 +8,7 @@ profile organizr_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/photoprism/apparmor.txt
+++ b/photoprism/apparmor.txt
@@ -9,6 +9,7 @@ profile photoprism flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   capability sys_rawio,
   file,

--- a/piwigo/apparmor.txt
+++ b/piwigo/apparmor.txt
@@ -9,6 +9,7 @@ profile piwigo_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/plex/apparmor.txt
+++ b/plex/apparmor.txt
@@ -9,6 +9,7 @@ profile addon_db21ed7f_plex_nas flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/portainer/apparmor.txt
+++ b/portainer/apparmor.txt
@@ -8,6 +8,7 @@ profile portainer_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/portainer_agent/apparmor.txt
+++ b/portainer_agent/apparmor.txt
@@ -19,6 +19,7 @@ profile portainer_agent_addon flags=(attach_disconnected,mediate_deleted) {
   network unix dgram,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
 
 
 # S6-Overlay

--- a/postgres_15/apparmor.txt
+++ b/postgres_15/apparmor.txt
@@ -8,6 +8,7 @@ profile postgres_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/prowlarr/apparmor.txt
+++ b/prowlarr/apparmor.txt
@@ -9,6 +9,7 @@ profile prowlarr_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/qbittorrent/apparmor.txt
+++ b/qbittorrent/apparmor.txt
@@ -10,6 +10,7 @@ profile db21ed7f_qbittorrent flags=(attach_disconnected,mediate_deleted) {
   capability net_admin,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/radarr/apparmor.txt
+++ b/radarr/apparmor.txt
@@ -9,6 +9,7 @@ profile radarr_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/readarr/apparmor.txt
+++ b/readarr/apparmor.txt
@@ -9,6 +9,7 @@ profile readarr_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/requestrr/apparmor.txt
+++ b/requestrr/apparmor.txt
@@ -9,6 +9,7 @@ profile requestrr_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/resiliosync/apparmor.txt
+++ b/resiliosync/apparmor.txt
@@ -10,6 +10,7 @@ profile resiliosync_addon flags=(attach_disconnected,mediate_deleted) {
   capability net_admin,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/sabnzbd/apparmor.txt
+++ b/sabnzbd/apparmor.txt
@@ -9,6 +9,7 @@ profile sabnzbd_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/scrutiny/apparmor.txt
+++ b/scrutiny/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile db21ed7f_scrutiny flags=(attach_disconnected,mediate_deleted) {
+profile scrutiny_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   capability chown,
@@ -9,6 +9,7 @@ profile db21ed7f_scrutiny flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   capability sys_rawio,
   file,

--- a/scrutiny_fa_original/apparmor.txt
+++ b/scrutiny_fa_original/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile db21ed7f_scrutiny flags=(attach_disconnected,mediate_deleted) {
+profile scrutiny_fa_original_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   capability chown,
@@ -9,6 +9,7 @@ profile db21ed7f_scrutiny flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   capability sys_rawio,
   file,

--- a/scrutiny_original/apparmor.txt
+++ b/scrutiny_original/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile db21ed7f_scrutiny flags=(attach_disconnected,mediate_deleted) {
+profile scrutiny_original_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   capability chown,
@@ -9,6 +9,7 @@ profile db21ed7f_scrutiny flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   capability sys_rawio,
   file,

--- a/seafile/apparmor.txt
+++ b/seafile/apparmor.txt
@@ -10,6 +10,7 @@ profile seafile_addon flags=(attach_disconnected,mediate_deleted) {
   capability net_admin,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/seerr/apparmor.txt
+++ b/seerr/apparmor.txt
@@ -8,6 +8,7 @@ profile seerr_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/social_to_mealie/apparmor.txt
+++ b/social_to_mealie/apparmor.txt
@@ -8,6 +8,7 @@ profile social_to_mealie_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/sonarr/apparmor.txt
+++ b/sonarr/apparmor.txt
@@ -9,6 +9,7 @@ profile sonarr_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/sponsorblockcast/apparmor.txt
+++ b/sponsorblockcast/apparmor.txt
@@ -1,7 +1,8 @@
 #include <tunables/global>
 
-profile addon_updater flags=(attach_disconnected,mediate_deleted) {
+profile sponsorblockcast_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
+  capability sys_chroot,
 
   # Capabilities
   file,

--- a/spotweb/apparmor.txt
+++ b/spotweb/apparmor.txt
@@ -8,6 +8,7 @@ profile spotweb_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/tandoor_recipes/apparmor.txt
+++ b/tandoor_recipes/apparmor.txt
@@ -8,6 +8,7 @@ profile tandoor_recipes_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/tdarr/apparmor.txt
+++ b/tdarr/apparmor.txt
@@ -9,6 +9,7 @@ profile db21ed7f_tdarr flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/teamspeak/apparmor.txt
+++ b/teamspeak/apparmor.txt
@@ -8,6 +8,7 @@ profile teamspeak_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/transmission/apparmor.txt
+++ b/transmission/apparmor.txt
@@ -9,6 +9,7 @@ profile db21ed7f_transmission flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/transmission_openvpn/apparmor.txt
+++ b/transmission_openvpn/apparmor.txt
@@ -10,6 +10,7 @@ profile db21ed7f_transmission_openvpn flags=(attach_disconnected,mediate_deleted
   capability net_admin,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/ubooquity/apparmor.txt
+++ b/ubooquity/apparmor.txt
@@ -9,6 +9,7 @@ profile ubooquity_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/unpackerr/apparmor.txt
+++ b/unpackerr/apparmor.txt
@@ -9,6 +9,7 @@ profile unpackerr_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/webtop/apparmor.txt
+++ b/webtop/apparmor.txt
@@ -1,1 +1,72 @@
-../webtop_kde/apparmor.txt
+#include <tunables/global>
+
+profile webtop_addon flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  capability chown,
+  capability dac_override,
+  capability dac_read_search,
+  capability fowner,
+  capability setgid,
+  capability setuid,
+  capability sys_chroot,
+  capability sys_admin,
+  file,
+  signal,
+  mount,
+  umount,
+  remount,
+  network udp,
+  network tcp,
+  network dgram,
+  network stream,
+  network inet,
+  network inet6,
+  network netlink raw,
+  network unix dgram,
+
+
+# S6-Overlay
+  /init ix,
+  /run/{s6,s6-rc*,service}/** ix,
+  /package/** ix,
+  /command/** ix,
+  /run/{,**} rwk,
+  /dev/tty rw,
+  /bin/** ix,
+  /usr/bin/** ix,
+  /usr/lib/bashio/** ix,
+  /etc/s6/** rix,
+  /run/s6/** rix,
+  /etc/services.d/** rwix,
+  /etc/cont-init.d/** rwix,
+  /etc/cont-finish.d/** rwix,
+  /init rix,
+  /var/run/** mrwkl,
+  /var/run/ mrwkl,
+  /dev/i2c-1 mrwkl,
+  # Files required
+  /dev/fuse mrwkl,
+  /dev/sda1 mrwkl,
+  /dev/sdb1 mrwkl,
+  /dev/nvme0 mrwkl,
+  /dev/nvme0n1 mrwkl,
+  /dev/nvme1 mrwkl,
+  /dev/mmcblk0p1 mrwkl,
+  /dev/* mrwkl,
+  /udev/* mrwkl,
+  /tmp/** mrkwl,
+  /dev/fuse/** mrkwl,
+  /dev/** mrkwl,
+  /sys/firmware/** mrkwl,
+
+  # Data access
+  /data/** rw,
+
+  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
+  ptrace (trace,read) peer=docker-default,
+
+  # docker daemon confinement requires explict allow rule for signal
+  signal (receive) set=(kill,term) peer=/usr/bin/docker,
+
+}

--- a/webtop_kde/apparmor.txt
+++ b/webtop_kde/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile webtop_addon flags=(attach_disconnected,mediate_deleted) {
+profile webtop_kde_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   capability chown,
@@ -9,6 +9,7 @@ profile webtop_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/webtrees/apparmor.txt
+++ b/webtrees/apparmor.txt
@@ -9,6 +9,7 @@ profile webtrees_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   capability sys_admin,
   file,
   signal,

--- a/wger/apparmor.txt
+++ b/wger/apparmor.txt
@@ -8,6 +8,7 @@ profile wger_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/whatsapper/apparmor.txt
+++ b/whatsapper/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile gitea_addon flags=(attach_disconnected,mediate_deleted) {
+profile whatsapper_addon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   capability chown,
@@ -8,6 +8,7 @@ profile gitea_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/whoogle/apparmor.txt
+++ b/whoogle/apparmor.txt
@@ -8,6 +8,7 @@ profile whoogle-search_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/xteve/apparmor.txt
+++ b/xteve/apparmor.txt
@@ -8,6 +8,7 @@ profile xteve_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,

--- a/zoneminder/apparmor.txt
+++ b/zoneminder/apparmor.txt
@@ -8,6 +8,7 @@ profile zoneminder_addon flags=(attach_disconnected,mediate_deleted) {
   capability fowner,
   capability setgid,
   capability setuid,
+  capability sys_chroot,
   file,
   signal,
   mount,


### PR DESCRIPTION
## Summary

Fixes two classes of AppArmor profile issues across the add-on repository.

### 1. Missing `capability sys_chroot`

Several add-ons fail at startup because their AppArmor profile does not allow `sys_chroot`, which is in Docker's default capability set but must be explicitly listed in the profile. Affected services include:

- **Gitea** — sshd privilege separation fails with `chroot("/var/empty"): Operation not permitted [preauth]` (#2653)
- **Elasticsearch** — JVM startup fails with `chroot: cannot change root directory` (#2709)

This PR adds `capability sys_chroot` to all add-on AppArmor profiles as a prophylactic fix (any service using privilege-separation chroot needs it).

### 2. Profile name collisions

Many profiles had a copy-pasted, wrong `profile <name>` line (e.g. `inadyn_addon`, `db21ed7f_qbittorrent`, `radarr_addon`, `db21ed7f_scrutiny`, `chromium_addon`, `fireflyiii_addon`, `webtop_addon`, `joplin`, `gitea_addon`, `addon_updater`, `addon_db21ed7f_emby_nas`). Duplicate profile names cause AppArmor to silently apply the wrong profile. Each profile is now uniquely named after its add-on.

## Notes

- The broad sweep carries **no version bumps** — the corrected profiles apply automatically on each add-on's next update.
- Gitea and Elasticsearch include version bumps + CHANGELOG entries since their fixes resolve specific reported issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7P3Nbem7n9FqGTXrLMadP)_