### PR TITLE
Add CodeRabbit configuration for issue triage and PR review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,16 +7,8 @@
 # Docs: https://docs.coderabbit.ai/getting-started/configure-coderabbit
 language: "en-US"
 
-# Steer CodeRabbit toward the Home Assistant add-on context. This drives both
-# PR review comments and the help it offers when mentioned on issues.
-tone_instructions: >-
-  You are assisting a Home Assistant add-on repository that packages 120+
-  Docker-based add-ons for the Home Assistant Supervisor. Be concise, friendly
-  and practical. Most contributors are hobbyists, not professional developers,
-  so explain reasoning briefly and link to the add-on's README or the repo wiki
-  when relevant. Each add-on lives in its own top-level directory with a
-  config.yaml, Dockerfile, updater.json and CHANGELOG.md. Respect the existing
-  conventions described in CLAUDE.md rather than imposing generic best practices.
+# Max 250 chars. Detailed context lives in path_instructions below.
+tone_instructions: "HA add-on repo with 120+ Docker add-ons for Home Assistant Supervisor. Be concise, practical and friendly; most contributors are hobbyists. Link to add-on READMEs and the repo wiki. Follow existing conventions over generic best practices."
 
 early_access: false
 enable_free_tier: true


### PR DESCRIPTION
## Summary

- Add `.coderabbit.yaml` at repo root to enable CodeRabbit issue triage and PR review
- `tone_instructions` tuned to HA add-on context (hobbyist contributors, repo wiki, existing conventions)
- `path_instructions` encode per-file conventions from `CLAUDE.md`: `config.yaml`, `Dockerfile`, S6 `cont-init.d`/`services.d`, `updater.json`, `CHANGELOG.md`, workflows
- `chat.auto_reply` + `knowledge_base` (issues/PRs/learnings) for first-line issue help without explicit `@coderabbitai` mention
- Tools enabled to match CI: shellcheck, hadolint, markdownlint, yamllint, actionlint, gitleaks, checkov
- `tone_instructions` capped at 238 chars to stay within the v2 schema 250-char limit

## Test plan

- [ ] Merge and verify CodeRabbit activates on the next opened issue (auto-reply)
- [ ] Open a test PR touching an add-on and confirm path-specific review comments appear
- [ ] Confirm labels (`bug` / `enhancement`) are suggested correctly by CodeRabbit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195h5b5zBHAA6urgJtp4aJP

---
_Generated by [Claude Code](https://claude.ai/code/session_0195h5b5zBHAA6urgJtp4aJP)_