### PR TITLE
Claude/triage hassio addons issues ssmjik

### DIFF
--- a/netalertx/CHANGELOG.md
+++ b/netalertx/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 26.6.3-1 (2026-06-19)
+- Suppress the misleading upstream "capabilities audit" ALERT (NET_RAW/NET_ADMIN reported as missing). Under the Home Assistant Supervisor these capabilities are granted but the upstream audit cannot read them, which alarmed users (#2454).
+
 ## 26.6.3 (2026-06-05)
 - Update to latest version from jokob-sk/NetAlertX (changelog : https://github.com/jokob-sk/NetAlertX/releases)
 

--- a/netalertx/Dockerfile
+++ b/netalertx/Dockerfile
@@ -58,6 +58,18 @@ USER 0
 COPY rootfs/ /
 RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
 
+# Neutralise the upstream capabilities-audit step.
+# Under the Home Assistant Supervisor the required NET_RAW/NET_ADMIN capabilities
+# are granted, but the upstream audit cannot read them and prints a misleading
+# "🚨 ALERT: capabilities are missing" banner that users mistake for the cause of
+# unrelated issues (see issue #2454). The script is informational only, so we
+# replace its body with a no-op while keeping the file in place for the runner.
+RUN set -eux; \
+    for f in $(find / -type f -name '*capabilities*audit*.sh' 2>/dev/null); do \
+      printf '#!/usr/bin/env bash\n# Neutralised by the Home Assistant add-on: the required capabilities are\n# provided by the Supervisor but the upstream audit misreports them, which\n# alarmed users (issue #2454). This audit is informational only.\n:\n' > "$f"; \
+      chmod +x "$f"; \
+    done
+
 # Bring in jq + gosu (and their libs). NO apk in final stage.
 COPY --from=ha_tools /out/ /
 

--- a/netalertx/config.yaml
+++ b/netalertx/config.yaml
@@ -42,4 +42,4 @@ slug: netalertx
 tmpfs: true
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "26.6.3"
+version: "26.6.3-1"

--- a/netalertx_fa/CHANGELOG.md
+++ b/netalertx_fa/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 26.6.3-1 (2026-06-19)
+- Suppress the misleading upstream "capabilities audit" ALERT (NET_RAW/NET_ADMIN reported as missing). Under the Home Assistant Supervisor these capabilities are granted but the upstream audit cannot read them, which alarmed users (#2454).
+
 ## 26.6.3 (2026-06-05)
 - Update to latest version from jokob-sk/NetAlertX (changelog : https://github.com/jokob-sk/NetAlertX/releases)
 

--- a/netalertx_fa/apparmor.txt
+++ b/netalertx_fa/apparmor.txt
@@ -1,0 +1,1 @@
+../netalertx/apparmor.txt

--- a/netalertx_fa/config.yaml
+++ b/netalertx_fa/config.yaml
@@ -43,4 +43,4 @@ slug: netalertx_fa
 tmpfs: true
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "26.6.3"
+version: "26.6.3-1"

--- a/netbird-server/apparmor.txt
+++ b/netbird-server/apparmor.txt
@@ -1,0 +1,49 @@
+#include <tunables/global>
+
+profile netbird-server_addon flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  capability chown,
+  capability dac_override,
+  capability fowner,
+  capability net_bind_service,
+  capability setgid,
+  capability setuid,
+  capability sys_chroot,
+  file,
+  signal,
+  mount,
+  umount,
+  remount,
+  network udp,
+  network tcp,
+  network dgram,
+  network stream,
+  network inet,
+  network inet6,
+  network netlink raw,
+  network unix dgram,
+
+  /init ix,
+  /run/{s6,s6-rc*,service}/** ix,
+  /package/** ix,
+  /command/** ix,
+  /bin/** ix,
+  /usr/bin/** ix,
+  /usr/lib/bashio/** ix,
+  /etc/s6/** rix,
+  /run/s6/** rix,
+  /etc/services.d/** rwix,
+  /etc/cont-init.d/** rwix,
+  /etc/cont-finish.d/** rwix,
+
+  # Data access
+  /data/** rw,
+
+  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
+  ptrace (trace,read) peer=docker-default,
+
+  # docker daemon confinement requires explict allow rule for signal
+  signal (receive) set=(kill,term) peer=/usr/bin/docker,
+
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed a misleading “capabilities audit” ALERT in the Home Assistant Supervisor environment that incorrectly reported missing `NET_RAW`/`NET_ADMIN`.

* **Chores**
  * Bumped add-on versions to **26.6.3-1** for both relevant add-ons.
  * Updated container build behavior to avoid emitting the false capability alert.
  * Updated AppArmor policy files, including adding a policy for the netbird-server add-on and linking the Flutter architecture policy to the shared configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->