### PR TITLE
allow using seerr without admin

### DIFF
--- a/seerr/config.yaml
+++ b/seerr/config.yaml
@@ -79,6 +79,7 @@ options:
   PGID: "0"
   PUID: "0"
 panel_icon: mdi:movie-search
+panel_admin: false
 ports:
   5055/tcp: 5055
 ports_description:


### PR DESCRIPTION
I have some family on my home assistant instance that I'd like to give access to seerr, but right now it's missing the panel admin flag, so they can't see it without admin.

Notes that radarr and sonarr already have this flag, so it seems reasonable for it to be here too.