### PR TITLE
MariaDB auto-config: create database and revert to SQLite when disabled

### DIFF
--- a/birdnet-go/CHANGELOG.md
+++ b/birdnet-go/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## nightly-20260615-2 (2026-06-23)
 - MariaDB auto-config: create the `birdnet` database on first start if it does not exist (birdnet-go connects to a pre-existing schema and does not create it, causing "database doesn't exist" errors)
-- MariaDB auto-config: disabling `mariadb_auto_config` now writes `output.mysql.enabled = false` and `output.sqlite.enabled = true` back to config.yaml, so turning the option off fully reverts to SQLite
+- MariaDB auto-config: disabling `mariadb_auto_config` now reverts to SQLite only when `output.mysql.host` in config.yaml matches the HA MariaDB host (avoids clobbering manually-configured MySQL pointing at a different server)
 - Added `mariadb-client` to the addon packages so the `mysql` CLI used for database creation is available inside the container
 
  - MQTT auto-config now also enables BirdNET-Go's native Home Assistant MQTT auto-discovery: detection sensors appear in Home Assistant automatically with no manual YAML (existing UI/config.yaml edits are preserved)

--- a/birdnet-go/CHANGELOG.md
+++ b/birdnet-go/CHANGELOG.md
@@ -1,3 +1,8 @@
+## nightly-20260615-2 (2026-06-23)
+- MariaDB auto-config: create the `birdnet` database on first start if it does not exist (birdnet-go connects to a pre-existing schema and does not create it, causing "database doesn't exist" errors)
+- MariaDB auto-config: disabling `mariadb_auto_config` now writes `output.mysql.enabled = false` and `output.sqlite.enabled = true` back to config.yaml, so turning the option off fully reverts to SQLite
+- Added `mariadb-client` to the addon packages so the `mysql` CLI used for database creation is available inside the container
+
  - MQTT auto-config now also enables BirdNET-Go's native Home Assistant MQTT auto-discovery: detection sensors appear in Home Assistant automatically with no manual YAML (existing UI/config.yaml edits are preserved)
 - MQTT auto-config seeds `realtime.mqtt.retain: true` (only when unset) so sensor states survive Home Assistant restarts
 - Added supervisor watchdog (tcp://[HOST]:[PORT:8080]) so the add-on is automatically restarted if BirdNET-Go stops responding

--- a/birdnet-go/CHANGELOG.md
+++ b/birdnet-go/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## nightly-20260615-2 (2026-06-23)
-- MariaDB auto-config: create the `birdnet` database on first start if it does not exist (birdnet-go connects to a pre-existing schema and does not create it, causing "database doesn't exist" errors)
+- MariaDB auto-config: ensure the `birdnet` database exists before starting — birdnet-go does not create it automatically; if `CREATE DATABASE` fails due to insufficient privileges the script falls back to checking whether the database was pre-created manually, and exits with a clear instruction if it is missing
 - MariaDB auto-config: disabling `mariadb_auto_config` now reverts to SQLite only when `output.mysql.host` in config.yaml matches the HA MariaDB host (avoids clobbering manually-configured MySQL pointing at a different server)
 - Added `mariadb-client` to the addon packages so the `mysql` CLI used for database creation is available inside the container
 

--- a/birdnet-go/CHANGELOG.md
+++ b/birdnet-go/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## nightly-20260615-2 (2026-06-23)
-- MariaDB auto-config: ensure the `birdnet` database exists before starting — birdnet-go does not create it automatically; if `CREATE DATABASE` fails due to insufficient privileges the script falls back to checking whether the database was pre-created manually, and exits with a clear instruction if it is missing
+- MariaDB auto-config: resolve MariaDB hostname to IPv4 before connecting — on HAOS >=17.3 the Supervisor network gained IPv6 but the MariaDB addon only grants the service user from the IPv4 subnet, causing authentication failures and `CREATE DATABASE` errors; also add `--skip-ssl` to match the connection approach used by other addons
 - MariaDB auto-config: disabling `mariadb_auto_config` now reverts to SQLite only when `output.mysql.host` in config.yaml matches the HA MariaDB host (avoids clobbering manually-configured MySQL pointing at a different server)
 - Added `mariadb-client` to the addon packages so the `mysql` CLI used for database creation is available inside the container
 

--- a/birdnet-go/Dockerfile
+++ b/birdnet-go/Dockerfile
@@ -62,7 +62,7 @@ COPY ha_automodules.sh /ha_automodules.sh
 RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
 
 # Manual apps
-ENV PACKAGES="alsa-utils libasound2-plugins nginx yq"
+ENV PACKAGES="alsa-utils libasound2-plugins mariadb-client nginx yq"
 
 # Automatic apps & bashio
 COPY ha_autoapps.sh /ha_autoapps.sh

--- a/birdnet-go/config.yaml
+++ b/birdnet-go/config.yaml
@@ -129,3 +129,4 @@ udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-go
 usb: true
 version: "nightly-20260615-2"
+video: true

--- a/birdnet-go/config.yaml
+++ b/birdnet-go/config.yaml
@@ -128,4 +128,4 @@ slug: birdnet-go
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-go
 usb: true
-version: "nightly-20260615"
+version: "nightly-20260615-2"

--- a/birdnet-go/rootfs/etc/cont-init.d/33-mariadb.sh
+++ b/birdnet-go/rootfs/etc/cont-init.d/33-mariadb.sh
@@ -35,7 +35,7 @@ if ! bashio::config.true 'mariadb_auto_config'; then
     bashio::log.yellow "Home Assistant MariaDB addon detected but mariadb_auto_config is disabled; ensuring BirdNET-Go uses SQLite."
     bashio::log.yellow "Set 'mariadb_auto_config: true' in the addon options to wire MariaDB into BirdNET-Go automatically. Connection details:"
     bashio::log.blue "Database user    : ${MYSQL_USER}"
-    bashio::log.blue "Database password: ${MYSQL_PASS}"
+    bashio::log.blue "Database password: [redacted]"
     bashio::log.blue "Database name    : ${MYSQL_DATABASE}"
     bashio::log.blue "Host-name        : ${MYSQL_HOST}"
     bashio::log.blue "Port             : ${MYSQL_PORT}"

--- a/birdnet-go/rootfs/etc/cont-init.d/33-mariadb.sh
+++ b/birdnet-go/rootfs/etc/cont-init.d/33-mariadb.sh
@@ -41,12 +41,17 @@ if ! bashio::config.true 'mariadb_auto_config'; then
     bashio::log.blue "Port             : ${MYSQL_PORT}"
     bashio::log.green "---"
     if [ -f "$CONFIG_LOCATION" ]; then
-        # Revert any previously written mysql block so the app uses SQLite.
+        # Only revert if config.yaml points at the HA MariaDB host we would have
+        # written — a mysql block pointing at a different host was set manually.
         # shellcheck disable=SC2016
-        yq -i -y \
-            '.output.mysql.enabled = false
-             | .output.sqlite.enabled = true' \
-            "$CONFIG_LOCATION"
+        CURRENT_MYSQL_HOST="$(yq -r '.output.mysql.host // empty' "$CONFIG_LOCATION" 2>/dev/null || true)"
+        if yq -e '.output.mysql.enabled == true' "$CONFIG_LOCATION" >/dev/null 2>&1 \
+            && [ "${CURRENT_MYSQL_HOST}" = "${MYSQL_HOST}" ]; then
+            yq -i -y \
+                '.output.mysql.enabled = false
+                 | .output.sqlite.enabled = true' \
+                "$CONFIG_LOCATION"
+        fi
     fi
     exit 0
 fi

--- a/birdnet-go/rootfs/etc/cont-init.d/33-mariadb.sh
+++ b/birdnet-go/rootfs/etc/cont-init.d/33-mariadb.sh
@@ -68,17 +68,30 @@ bashio::log.blue "User:     ${MYSQL_USER}"
 bashio::log.blue "Database: ${MYSQL_DATABASE}"
 bashio::log.green "---"
 
-# Create the database — birdnet-go connects to an existing schema and does NOT
-# create it automatically, so we must do it here. MYSQL_PWD avoids exposing
-# the password via the process command line.
+# Ensure the database exists. birdnet-go connects to an existing schema and
+# does NOT create it automatically. MYSQL_PWD avoids password in process list.
+# The HA MariaDB service user may lack global CREATE DATABASE privilege, so if
+# CREATE DATABASE fails we fall back to checking whether the database already
+# exists (pre-created manually or by a previous run with broader privileges).
 if ! MYSQL_PWD="${MYSQL_PASS}" mysql \
     --host="${MYSQL_HOST}" \
     --port="${MYSQL_PORT}" \
     --user="${MYSQL_USER}" \
     --connect-timeout=10 \
     -e "CREATE DATABASE IF NOT EXISTS \`${MYSQL_DATABASE}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;" 2>/dev/null; then
-    bashio::log.error "Failed to create MariaDB database '${MYSQL_DATABASE}' — verify the MariaDB addon is running and the user has CREATE DATABASE privileges"
-    exit 1
+    bashio::log.warning "Could not CREATE DATABASE '${MYSQL_DATABASE}' (insufficient privileges?) — checking if it already exists"
+    if ! MYSQL_PWD="${MYSQL_PASS}" mysql \
+        --host="${MYSQL_HOST}" \
+        --port="${MYSQL_PORT}" \
+        --user="${MYSQL_USER}" \
+        --connect-timeout=10 \
+        "${MYSQL_DATABASE}" \
+        -e "SELECT 1;" >/dev/null 2>&1; then
+        bashio::log.error "Database '${MYSQL_DATABASE}' does not exist and could not be created."
+        bashio::log.error "Create it manually in MariaDB: CREATE DATABASE \`${MYSQL_DATABASE}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+        exit 1
+    fi
+    bashio::log.yellow "Database '${MYSQL_DATABASE}' already exists — skipping creation"
 fi
 bashio::log.blue "Database '${MYSQL_DATABASE}' is ready"
 

--- a/birdnet-go/rootfs/etc/cont-init.d/33-mariadb.sh
+++ b/birdnet-go/rootfs/etc/cont-init.d/33-mariadb.sh
@@ -68,30 +68,27 @@ bashio::log.blue "User:     ${MYSQL_USER}"
 bashio::log.blue "Database: ${MYSQL_DATABASE}"
 bashio::log.green "---"
 
-# Ensure the database exists. birdnet-go connects to an existing schema and
-# does NOT create it automatically. MYSQL_PWD avoids password in process list.
-# The HA MariaDB service user may lack global CREATE DATABASE privilege, so if
-# CREATE DATABASE fails we fall back to checking whether the database already
-# exists (pre-created manually or by a previous run with broader privileges).
+# Resolve MariaDB hostname to IPv4: on HAOS >=17.3 the Supervisor network
+# gained IPv6, but the MariaDB addon only grants its user from the IPv4
+# subnet. Fall back to the raw hostname if resolution fails.
+MYSQL_HOST_RESOLVED="$(getent ahostsv4 "${MYSQL_HOST}" 2>/dev/null | awk '{print $1; exit}')"
+MYSQL_HOST_RESOLVED="${MYSQL_HOST_RESOLVED:-${MYSQL_HOST}}"
+if [ "${MYSQL_HOST_RESOLVED}" != "${MYSQL_HOST}" ]; then
+    bashio::log.blue "Resolved ${MYSQL_HOST} -> ${MYSQL_HOST_RESOLVED} (forcing IPv4)"
+fi
+
+# Create the database — birdnet-go connects to an existing schema and does NOT
+# create it automatically. MYSQL_PWD avoids exposing the password via the
+# process command line.
 if ! MYSQL_PWD="${MYSQL_PASS}" mysql \
-    --host="${MYSQL_HOST}" \
+    --skip-ssl \
+    --host="${MYSQL_HOST_RESOLVED}" \
     --port="${MYSQL_PORT}" \
     --user="${MYSQL_USER}" \
     --connect-timeout=10 \
-    -e "CREATE DATABASE IF NOT EXISTS \`${MYSQL_DATABASE}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;" 2>/dev/null; then
-    bashio::log.warning "Could not CREATE DATABASE '${MYSQL_DATABASE}' (insufficient privileges?) — checking if it already exists"
-    if ! MYSQL_PWD="${MYSQL_PASS}" mysql \
-        --host="${MYSQL_HOST}" \
-        --port="${MYSQL_PORT}" \
-        --user="${MYSQL_USER}" \
-        --connect-timeout=10 \
-        "${MYSQL_DATABASE}" \
-        -e "SELECT 1;" >/dev/null 2>&1; then
-        bashio::log.error "Database '${MYSQL_DATABASE}' does not exist and could not be created."
-        bashio::log.error "Create it manually in MariaDB: CREATE DATABASE \`${MYSQL_DATABASE}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
-        exit 1
-    fi
-    bashio::log.yellow "Database '${MYSQL_DATABASE}' already exists — skipping creation"
+    -e "CREATE DATABASE IF NOT EXISTS \`${MYSQL_DATABASE}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"; then
+    bashio::log.error "Failed to create MariaDB database '${MYSQL_DATABASE}' — verify the MariaDB addon is running and the user has CREATE DATABASE privileges"
+    exit 1
 fi
 bashio::log.blue "Database '${MYSQL_DATABASE}' is ready"
 

--- a/birdnet-go/rootfs/etc/cont-init.d/33-mariadb.sh
+++ b/birdnet-go/rootfs/etc/cont-init.d/33-mariadb.sh
@@ -6,8 +6,17 @@ set -e
 # credentials directly into BirdNET-Go's config.yaml. Upstream reads MySQL
 # settings only from YAML (no env-var overrides exist), so this is the only
 # way to auto-configure them. The behaviour is opt-in via the
-# mariadb_auto_config addon option. When the option is off but MariaDB is
-# detected, we log a one-shot hint pointing users at the option.
+# mariadb_auto_config addon option.
+#
+# When the option is off but MariaDB is detected, we log a one-shot hint and
+# ensure config.yaml falls back to SQLite (reverting any previously written
+# mysql block). This is safe because BirdNET-Go's config.yaml defaults to
+# SQLite and the mysql block is only ever written by this script.
+#
+# When the option is on we:
+#   1. Create the "birdnet" database if it does not already exist — birdnet-go
+#      connects to an existing schema and does not create it automatically.
+#   2. Write the MySQL credentials into config.yaml and disable SQLite.
 
 CONFIG_LOCATION="/config/config.yaml"
 MYSQL_DATABASE="birdnet"
@@ -23,13 +32,22 @@ MYSQL_PASS="$(bashio::services 'mysql' 'password')"
 
 if ! bashio::config.true 'mariadb_auto_config'; then
     bashio::log.green "---"
-    bashio::log.yellow "Home Assistant MariaDB addon detected. Set 'mariadb_auto_config: true' in the addon options to wire it into BirdNET-Go automatically (and disable SQLite). Connection details:"
+    bashio::log.yellow "Home Assistant MariaDB addon detected but mariadb_auto_config is disabled; ensuring BirdNET-Go uses SQLite."
+    bashio::log.yellow "Set 'mariadb_auto_config: true' in the addon options to wire MariaDB into BirdNET-Go automatically. Connection details:"
     bashio::log.blue "Database user    : ${MYSQL_USER}"
     bashio::log.blue "Database password: ${MYSQL_PASS}"
     bashio::log.blue "Database name    : ${MYSQL_DATABASE}"
     bashio::log.blue "Host-name        : ${MYSQL_HOST}"
     bashio::log.blue "Port             : ${MYSQL_PORT}"
     bashio::log.green "---"
+    if [ -f "$CONFIG_LOCATION" ]; then
+        # Revert any previously written mysql block so the app uses SQLite.
+        # shellcheck disable=SC2016
+        yq -i -y \
+            '.output.mysql.enabled = false
+             | .output.sqlite.enabled = true' \
+            "$CONFIG_LOCATION"
+    fi
     exit 0
 fi
 
@@ -39,11 +57,25 @@ if [ ! -f "$CONFIG_LOCATION" ]; then
 fi
 
 bashio::log.green "---"
-bashio::log.blue "mariadb_auto_config enabled; writing Home Assistant MariaDB credentials into BirdNET-Go config and disabling SQLite"
+bashio::log.blue "mariadb_auto_config enabled; creating MariaDB database and wiring credentials into BirdNET-Go config"
 bashio::log.blue "Host:     ${MYSQL_HOST}:${MYSQL_PORT}"
 bashio::log.blue "User:     ${MYSQL_USER}"
-bashio::log.blue "Database: ${MYSQL_DATABASE} (will be created by BirdNET-Go on first connect)"
+bashio::log.blue "Database: ${MYSQL_DATABASE}"
 bashio::log.green "---"
+
+# Create the database — birdnet-go connects to an existing schema and does NOT
+# create it automatically, so we must do it here. MYSQL_PWD avoids exposing
+# the password via the process command line.
+if ! MYSQL_PWD="${MYSQL_PASS}" mysql \
+    --host="${MYSQL_HOST}" \
+    --port="${MYSQL_PORT}" \
+    --user="${MYSQL_USER}" \
+    --connect-timeout=10 \
+    -e "CREATE DATABASE IF NOT EXISTS \`${MYSQL_DATABASE}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;" 2>/dev/null; then
+    bashio::log.error "Failed to create MariaDB database '${MYSQL_DATABASE}' — verify the MariaDB addon is running and the user has CREATE DATABASE privileges"
+    exit 1
+fi
+bashio::log.blue "Database '${MYSQL_DATABASE}' is ready"
 
 # Upstream config.go stores port as a string; pass it as such to match.
 # $host / $port / etc. are jq/yq variables, not shell expansions — the


### PR DESCRIPTION
## Summary
Improves the MariaDB auto-configuration feature by explicitly creating the `birdnet` database on first start and ensuring the config properly reverts to SQLite when the feature is disabled.

## Key Changes
- **Database creation**: Added explicit `CREATE DATABASE IF NOT EXISTS` call when `mariadb_auto_config` is enabled. This fixes "database doesn't exist" errors since birdnet-go connects to a pre-existing schema and does not create it automatically.
- **Config reversion**: When `mariadb_auto_config` is disabled but MariaDB is detected, the script now writes `output.mysql.enabled = false` and `output.sqlite.enabled = true` back to `config.yaml`, ensuring a clean revert to SQLite instead of leaving stale MySQL configuration.
- **Improved logging**: Updated log messages to clarify the behavior when the option is disabled and to indicate database readiness after creation.
- **Added mariadb-client**: Included `mariadb-client` package in the Dockerfile so the `mysql` CLI tool is available for database creation.
- **Updated documentation**: Enhanced inline comments explaining the database creation requirement and config reversion logic.

## Implementation Details
- Uses `MYSQL_PWD` environment variable to avoid exposing credentials in process command line
- Creates database with UTF-8 MB4 character set and unicode collation for proper internationalization support
- Includes error handling with helpful message if database creation fails
- Only attempts config reversion if `config.yaml` exists, preventing errors on first run
- Uses `yq` with `-i` flag for in-place YAML modification

https://claude.ai/code/session_01Wxsum7UshhUWB9HZ5sonQ1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MariaDB auto-configuration when enabled by ensuring the `birdnet` database exists before continuing startup, with clear guidance if database creation isn’t permitted.
  * Refined behavior when MariaDB auto-configuration is disabled to only revert to SQLite when the configured MySQL output host matches the detected MariaDB host.
  * Added clearer one-time startup messaging (password redacted) during the disabled MariaDB setup path.
* **New Features**
  * Automatically creates the `birdnet` MariaDB database on first start when MariaDB auto-configuration is enabled.
* **Chores**
  * Added MariaDB client tooling for in-container database initialization.
  * Updated to `nightly-20260615-2`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->