### PR TITLE
Fix SignalK mdns native rebuild dependencies

### DIFF
--- a/signalk/CHANGELOG.md
+++ b/signalk/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.28.0-2 (2026-06-28)
+- Add Bonjour/mDNS development headers so native npm modules such as mdns can rebuild after add-on updates.
+
  
 ## 2.28.0 (2026-06-20)
 - Update to latest version from SignalK/signalk-server (changelog : https://github.com/SignalK/signalk-server/releases)

--- a/signalk/Dockerfile
+++ b/signalk/Dockerfile
@@ -57,7 +57,7 @@ COPY ha_automodules.sh /ha_automodules.sh
 RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
 
 # Manual apps
-ENV PACKAGES=""
+ENV PACKAGES="libavahi-compat-libdnssd-dev"
 
 # Automatic apps & bashio
 COPY ha_autoapps.sh /ha_autoapps.sh

--- a/signalk/config.yaml
+++ b/signalk/config.yaml
@@ -57,5 +57,5 @@ uart: true
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "2.28.0"
+version: "2.28.0-2"
 webui: http://[HOST]:[PORT:3000]


### PR DESCRIPTION
### Motivation
- Native npm modules such as `mdns` require the Bonjour/mDNS development headers (`dns_sd.h`) to rebuild during `npm rebuild`, and the SignalK add-on image was missing those headers causing rebuild failures (issue #2796). 
- Bump the add-on revision so the fix can be distributed as a minor build update.

### Description
- Add `libavahi-compat-libdnssd-dev` to `ENV PACKAGES` in `signalk/Dockerfile` so the Debian Bonjour/mDNS development headers are installed during image preparation. 
- Update `signalk/config.yaml` `version` to `2.28.0-2`. 
- Prepend a changelog entry in `signalk/CHANGELOG.md` documenting the Bonjour/mDNS native rebuild dependency fix.

### Testing
- `python3` check that modified text files end with a newline succeeded. 
- `bash -n signalk/rootfs/etc/cont-init.d/99-run.sh` syntax check succeeded. 
- `apt-cache show libavahi-compat-libdnssd-dev` returned the package as available on the environment and the check succeeded. 
- Attempted automated `yaml` parse failed because `PyYAML` is not installed in the environment, and `docker build` could not be executed because Docker is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41294e5c988325b6870f103b0a3ff4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the add-on image to include Bonjour/mDNS development headers, which helps native modules rebuild successfully after updates.
  * Bumped the add-on version to **2.28.0-2**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->