### PR TITLE
Update Filebrowser and Prowlarr addons

### DIFF
--- a/filebrowser/CHANGELOG.md
+++ b/filebrowser/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## 2.63.17 (2026-06-29)
+- Update to latest version from filebrowser/filebrowser (changelog : https://github.com/filebrowser/filebrowser/releases)
+
 ## 2.63.16 (2026-06-23)
 - Update to latest version from filebrowser/filebrowser (changelog : https://github.com/filebrowser/filebrowser/releases)
  

--- a/filebrowser/config.yaml
+++ b/filebrowser/config.yaml
@@ -124,4 +124,4 @@ schema:
 slug: filebrowser
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "2.63.16"
+version: "2.63.17"

--- a/filebrowser/updater.json
+++ b/filebrowser/updater.json
@@ -1,10 +1,10 @@
 {
   "github_beta": "true",
-  "last_update": "2026-06-23",
+  "last_update": "2026-06-29",
   "paused": false,
   "repository": "alexbelgium/hassio-addons",
   "slug": "filebrowser",
   "source": "github",
   "upstream_repo": "filebrowser/filebrowser",
-  "upstream_version": "2.63.16"
+  "upstream_version": "2.63.17"
 }

--- a/prowlarr/CHANGELOG.md
+++ b/prowlarr/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## nightly-2.5.0.5443-ls4 (2026-06-29)
+- Update to latest version from linuxserver/docker-prowlarr (changelog : https://github.com/linuxserver/docker-prowlarr/releases)
+
 ## nightly-2.5.0.5422-ls3 (2026-06-27)
 - Update to latest version from linuxserver/docker-prowlarr (changelog : https://github.com/linuxserver/docker-prowlarr/releases)
  

--- a/prowlarr/config.yaml
+++ b/prowlarr/config.yaml
@@ -110,5 +110,5 @@ schema:
 slug: prowlarr
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "nightly-2.5.0.5422-ls3"
+version: "nightly-2.5.0.5443-ls4"
 webui: "[PROTO:ssl]://[HOST]:[PORT:9696]"

--- a/prowlarr/updater.json
+++ b/prowlarr/updater.json
@@ -1,10 +1,10 @@
 {
   "github_beta": "true",
   "github_fulltag": "true",
-  "last_update": "2026-06-27",
+  "last_update": "2026-06-29",
   "repository": "alexbelgium/hassio-addons",
   "slug": "prowlarr",
   "source": "github",
   "upstream_repo": "linuxserver/docker-prowlarr",
-  "upstream_version": "nightly-2.5.0.5422-ls3"
+  "upstream_version": "nightly-2.5.0.5443-ls4"
 }


### PR DESCRIPTION
## Summary
- Update Filebrowser from `2.63.16` to `2.63.17`.
- Update Prowlarr from `nightly-2.5.0.5422-ls3` to `nightly-2.5.0.5443-ls4`.
- Refresh `updater.json` metadata and add changelog entries for both add-ons.

## Why
These add-ons from the requested list were behind their tracked upstream releases.

## Validation
- Ran `git diff --check`.
- Parsed the updated `updater.json` files successfully.
- Verified the latest upstream GitHub releases for Filebrowser and linuxserver/docker-prowlarr.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated File Browser to version 2.63.17 and refreshed its changelog and update metadata.
  * Updated Prowlarr to nightly-2.5.0.5443-ls4 and refreshed its changelog and update metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->