### PR TITLE
fix(birdnet-pipy): nginx fails to start on 0.8.2 — build ingress.conf from the server block only

### DIFF
--- a/birdnet-pipy/CHANGELOG.md
+++ b/birdnet-pipy/CHANGELOG.md
@@ -1,4 +1,8 @@
  
+## 0.8.2-1 (2026-07-04)
+- Fix nginx failing to start with `limit_req_zone "api_rl" already bound` (502 on every page, Suncuss/BirdNET-PiPy#59). Upstream 0.8.2 added http-level rate-limit zones, and the ingress config was generated as a full copy of nginx.conf — duplicating those declarations in the shared http context. `ingress.conf` is now built from the `server` block only, so http-level directives stay declared once.
+- Comment out the new upstream Content-Security-Policy header in ingress mode, matching the existing X-* security-header handling (ingress runs inside Home Assistant's authenticated frame; direct access keeps the full CSP).
+
 ## 0.8.2 (2026-07-04)
 - Update to latest version from Suncuss/BirdNET-PiPy (changelog : https://github.com/Suncuss/BirdNET-PiPy/releases)
  

--- a/birdnet-pipy/config.yaml
+++ b/birdnet-pipy/config.yaml
@@ -96,4 +96,4 @@ schema:
   ssl: bool?
 slug: birdnet-pipy
 url: https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-pipy
-version: "0.8.2"
+version: "0.8.2-1"

--- a/birdnet-pipy/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/birdnet-pipy/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -24,11 +24,18 @@ if ! [[ "${ingress_port}" =~ ^[0-9]+$ ]] || [[ "${ingress_port}" -le 0 ]]; then
     exit 0
 fi
 
-cp /etc/nginx/servers/nginx.conf /etc/nginx/servers/ingress.conf
+# Build the ingress server from the server block ONLY. Both files in
+# servers/ are included into one http context, so http-level directives
+# (map, limit_req_zone, ...) must stay declared once, in nginx.conf — a
+# duplicated limit_req_zone is a fatal "already bound" error and nginx
+# never starts (502 on every page). Upstream keeps all http-level
+# directives above its single column-0 "server {".
+sed -n '/^server {/,$p' /etc/nginx/servers/nginx.conf > /etc/nginx/servers/ingress.conf
 sed -i \
     -e "s|listen 80;|listen ${ingress_interface}:${ingress_port} default_server;|g" \
     -e "/index index.html;/a\\    include /etc/nginx/includes/ingress_params.conf;" \
     -e 's|^[[:space:]]*add_header X|#&|g' \
+    -e 's|^[[:space:]]*add_header Content-Security-Policy|#&|g' \
     /etc/nginx/servers/ingress.conf
 
 sed -i "s#%%ingress_entry%%#${ingress_entry}#g" /etc/nginx/includes/ingress_params.conf


### PR DESCRIPTION
## Summary

BirdNET-PiPy 0.8.2 (built into the add-on by the updater-bot bump earlier today) fails to start whenever ingress is active: nginx dies with

```
[emerg] limit_req_zone "api_rl" is already bound to key "$binary_remote_addr" in /etc/nginx/servers/nginx.conf:29
```

and every page returns **502**. Reported upstream as [Suncuss/BirdNET-PiPy#59](https://github.com/Suncuss/BirdNET-PiPy/issues/59).

## Root cause

Upstream 0.8.2 added http-level `limit_req_zone` directives (per-IP rate limiting) to its `nginx.conf`. `32-nginx_ingress.sh` generates the ingress server with `cp nginx.conf ingress.conf`, and both files are included into the same `http` context via `servers/*.conf` — so every http-level directive is declared twice. The duplicated `map` blocks were silently tolerated for months, but nginx refuses to declare a named shared-memory zone twice, so 0.8.2 is the first upstream release that turns the wholesale copy into a fatal startup error.

## Fix

Generate `ingress.conf` from the `server { … }` block only (`sed -n '/^server {/,$p'`). Http-level directives stay declared once in `nginx.conf`; nginx resolves zone and map-variable references across included files after the full parse, so include order doesn't matter. This also future-proofs the add-on against any http-level directive upstream adds later.

Also comments out upstream's new `Content-Security-Policy` header in the ingress copy, matching the existing `add_header X*` handling (ingress runs inside Home Assistant's authenticated frame; direct access keeps the full CSP).

## Testing

- `nginx -t` in Docker against the add-on's base config + includes and upstream 0.8.2 source: the old copy reproduces the exact `already bound` emerg; the extraction passes.
- Verified on a Home Assistant device via our test add-on repo (same commit): direct `IP:port` and ingress (sidebar) modes — dashboard, navigation, auth flows, and Live Feed audio all work.
- Packaging-only change → version `0.8.2` → `0.8.2-1` to trigger the CI image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016acGazhHvyCNUFt71xzFxm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the app could fail to start in ingress mode, which could lead to 502 errors.
  * Improved ingress configuration handling so security headers are applied consistently and the page serves correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->