### PR TITLE
Immich: migrate immich, immich_cuda, immich_noml and immich_openvino to Immich v3

### DIFF
--- a/immich/CHANGELOG.md
+++ b/immich/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.1 (2026-07-04)
+- Migrate to Immich v3 (now based on the `ghcr.io/imagegenius/immich:3` image line, tracking the v3 major release)
+- Immich v3 requires the VectorChord (`vchord`) Postgres extension; upstream `pgvecto.rs` support has been removed. Use this repository's `Postgres 15`/`Postgres 17` add-ons (or another VectorChord-capable Postgres), and let Immich finish migrating existing data before the old extension is removed
+- Immich v3 requires an x86-64-v2 (or newer) CPU on amd64
+- Migration guide: https://immich.app/blog/v3-migration
+
 ## 2.7.5-2 (21-05-2026)
 - Minor bugs fixed
 

--- a/immich/README.md
+++ b/immich/README.md
@@ -34,6 +34,16 @@ _Thanks to everyone having starred my repo! To star it click on the image below,
 Web based files browser.
 This addon is based on the [docker image](https://github.com/imagegenius/docker-immich) from imagegenius.
 
+## Immich v3
+
+This add-on tracks **Immich v3** (built on the `ghcr.io/imagegenius/immich:3` image line).
+
+- **Database**: Immich v3 requires PostgreSQL (14–17) with the **VectorChord (`vchord`)** extension; upstream `pgvecto.rs` support has been removed. The `Postgres 15` and `Postgres 17` add-ons in this repository already provide a VectorChord-capable database and are the recommended choice (you can also use the official `ghcr.io/immich-app/postgres:*-vectorchord*` image).
+- **Upgrading from Immich v2**: keep your existing VectorChord-capable database so Immich can migrate its data automatically. If your database still holds data in the old `pgvecto.rs` extension, leave that extension in place until Immich has finished migrating to VectorChord.
+- **CPU**: on `amd64`, Immich v3 requires an x86-64-v2 (or newer) CPU.
+
+See the official [v3 migration guide](https://immich.app/blog/v3-migration) for details.
+
 ## Configuration
 
 Webui can be found at `<your-ip>:8080`. PostgreSQL/MySQL can be either internal or external.

--- a/immich/README.md
+++ b/immich/README.md
@@ -46,7 +46,7 @@ See the official [v3 migration guide](https://immich.app/blog/v3-migration) for 
 
 ## Configuration
 
-Webui can be found at `<your-ip>:8080`. PostgreSQL/MySQL can be either internal or external.
+Webui can be found at `<your-ip>:8080`. PostgreSQL can be either internal or external.
 
 ### Options
 

--- a/immich/build.json
+++ b/immich/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/imagegenius/immich:latest",
-    "amd64": "ghcr.io/imagegenius/immich:latest"
+    "aarch64": "ghcr.io/imagegenius/immich:3",
+    "amd64": "ghcr.io/imagegenius/immich:3"
   }
 }

--- a/immich/config.yaml
+++ b/immich/config.yaml
@@ -143,6 +143,6 @@ slug: immich
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "2.7.5-2"
+version: "3.0.1"
 video: true
 webui: http://[HOST]:[PORT:8080]

--- a/immich/config.yaml
+++ b/immich/config.yaml
@@ -137,8 +137,6 @@ schema:
   localdisks: str?
   networkdisks: str?
   skip_permissions_check: bool?
-services:
-  - mysql:want
 slug: immich
 udev: true
 url: https://github.com/alexbelgium/hassio-addons

--- a/immich/rootfs/etc/cont-init.d/99-run.sh
+++ b/immich/rootfs/etc/cont-init.d/99-run.sh
@@ -193,4 +193,18 @@ migrate_database
 export_db_env
 setup_root_user
 setup_database
-# check_vchord_extension || check_vector_extension
+
+# Immich v3 requires the VectorChord ('vchord') extension and no longer supports
+# 'pgvecto.rs'. Warn (non-fatally) when the external database does not expose it, so users
+# get a clear diagnostic instead of an opaque Immich startup failure. Immich creates and
+# validates the extension itself, so we never stop the addon here.
+if ! check_vchord_extension; then
+    bashio::log.warning "------------------------------------------------------------"
+    bashio::log.warning "Immich v3 requires the VectorChord ('vchord') PostgreSQL extension."
+    bashio::log.warning "Support for 'pgvecto.rs' has been removed upstream."
+    bashio::log.warning "Use the 'Postgres 15'/'Postgres 17' add-ons from this repository,"
+    bashio::log.warning "or another VectorChord-capable PostgreSQL image."
+    bashio::log.warning "Immich will attempt to create the extension itself on startup."
+    bashio::log.warning "Migration guide: https://immich.app/blog/v3-migration"
+    bashio::log.warning "------------------------------------------------------------"
+fi

--- a/immich/rootfs/etc/cont-init.d/99-run.sh
+++ b/immich/rootfs/etc/cont-init.d/99-run.sh
@@ -144,28 +144,31 @@ EOF
     bashio::log.info "Database setup completed successfully."
 }
 
-# Function to check if vectors extension is enabled
+# Function to check if the vectors (pgvecto.rs) extension is available on the server
 check_vector_extension() {
-    echo "Checking if 'vectors' extension is enabled..."
-    RESULT=$(psql "postgres://$DB_USERNAME:$DB_PASSWORD@$DB_HOSTNAME:$DB_PORT" -tAc "SELECT extname FROM pg_extension WHERE extname = 'vectors';")
-    if [[ "$RESULT" == "vectors" ]]; then
-        echo "✅ 'vectors' extension is enabled."
+    echo "Checking if 'vectors' extension is available for database '${DB_DATABASE_NAME}'..."
+    RESULT=$(psql "postgres://$DB_USERNAME:$DB_PASSWORD@$DB_HOSTNAME:$DB_PORT/${DB_DATABASE_NAME}" -tAc "SELECT 1 FROM pg_available_extensions WHERE name = 'vectors';")
+    if [[ "$RESULT" == "1" ]]; then
+        echo "✅ 'vectors' extension is available."
         return 0
     else
-        bashio::log.warning "❌ 'vectors' extension is NOT enabled."
+        bashio::log.warning "❌ 'vectors' extension is NOT available."
         return 1
     fi
 }
 
-# Function to check if vchord extension is enabled
+# Function to check if the VectorChord (vchord) extension is available on the server.
+# Uses pg_available_extensions (whether the extension CAN be created) rather than
+# pg_extension (whether it has already been created), since Immich creates the extension
+# itself on first startup; checking pg_extension would false-warn on every fresh install.
 check_vchord_extension() {
-    echo "Checking if 'vchord' extension is enabled..."
-    RESULT=$(psql "postgres://$DB_USERNAME:$DB_PASSWORD@$DB_HOSTNAME:$DB_PORT" -tAc "SELECT extname FROM pg_extension WHERE extname = 'vchord';")
-    if [[ "$RESULT" == "vchord" ]]; then
-        echo "✅ 'vchord' extension is enabled."
+    echo "Checking if 'vchord' extension is available for database '${DB_DATABASE_NAME}'..."
+    RESULT=$(psql "postgres://$DB_USERNAME:$DB_PASSWORD@$DB_HOSTNAME:$DB_PORT/${DB_DATABASE_NAME}" -tAc "SELECT 1 FROM pg_available_extensions WHERE name = 'vchord';")
+    if [[ "$RESULT" == "1" ]]; then
+        echo "✅ 'vchord' extension is available."
         return 0
     else
-        bashio::log.warning "❌ 'vchord' extension is NOT enabled."
+        bashio::log.warning "❌ 'vchord' extension is NOT available."
         return 1
     fi
 }

--- a/immich/updater.json
+++ b/immich/updater.json
@@ -1,10 +1,10 @@
 {
   "github_beta": "false",
-  "github_exclude": "2026",
+  "github_exclude": "",
   "last_update": "2026-07-04",
   "repository": "alexbelgium/hassio-addons",
   "slug": "immich",
   "source": "github",
-  "upstream_repo": "imagegenius/docker-immich",
+  "upstream_repo": "immich-app/immich",
   "upstream_version": "3.0.1"
 }

--- a/immich/updater.json
+++ b/immich/updater.json
@@ -1,10 +1,10 @@
 {
   "github_beta": "false",
   "github_exclude": "2026",
-  "last_update": "2026-05-19",
+  "last_update": "2026-07-04",
   "repository": "alexbelgium/hassio-addons",
   "slug": "immich",
   "source": "github",
   "upstream_repo": "imagegenius/docker-immich",
-  "upstream_version": "2.7.5"
+  "upstream_version": "3.0.1"
 }

--- a/immich_cuda/CHANGELOG.md
+++ b/immich_cuda/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## 3.0.1 (2026-07-04)
+- Migrate to Immich v3 (now based on the `ghcr.io/imagegenius/immich:3-cuda` image line, tracking the v3 major release)
+- Immich v3 requires the VectorChord (`vchord`) Postgres extension; upstream `pgvecto.rs` support has been removed. Use this repository's `Postgres 15`/`Postgres 17` add-ons (or another VectorChord-capable Postgres), and let Immich finish migrating existing data before the old extension is removed
+- Immich v3 requires an x86-64-v2 (or newer) CPU on amd64
+- Migration guide: https://immich.app/blog/v3-migration
+
 ## 2.7.5 (2026-05-19)
 - Update to latest version from imagegenius/docker-immich (changelog : https://github.com/imagegenius/docker-immich/releases)
 

--- a/immich_cuda/README.md
+++ b/immich_cuda/README.md
@@ -35,6 +35,16 @@ Self-hosted photo and video backup solution directly from your mobile phone with
 
 This addon is based on the [docker image](https://github.com/imagegenius/docker-immich) from imagegenius with CUDA support enabled for enhanced performance.
 
+## Immich v3
+
+This add-on tracks **Immich v3** (built on the `ghcr.io/imagegenius/immich:3-cuda` image line).
+
+- **Database**: Immich v3 requires PostgreSQL (14–17) with the **VectorChord (`vchord`)** extension; upstream `pgvecto.rs` support has been removed. The `Postgres 15` and `Postgres 17` add-ons in this repository already provide a VectorChord-capable database and are the recommended choice (you can also use the official `ghcr.io/immich-app/postgres:*-vectorchord*` image).
+- **Upgrading from Immich v2**: keep your existing VectorChord-capable database so Immich can migrate its data automatically. If your database still holds data in the old `pgvecto.rs` extension, leave that extension in place until Immich has finished migrating to VectorChord.
+- **CPU**: on `amd64`, Immich v3 requires an x86-64-v2 (or newer) CPU.
+
+See the official [v3 migration guide](https://immich.app/blog/v3-migration) for details.
+
 ## Hardware Requirements
 
 - **NVIDIA GPU**: Compatible NVIDIA graphics card with CUDA support

--- a/immich_cuda/build.json
+++ b/immich_cuda/build.json
@@ -1,5 +1,5 @@
 {
   "build_from": {
-    "amd64": "ghcr.io/imagegenius/immich:cuda"
+    "amd64": "ghcr.io/imagegenius/immich:3-cuda"
   }
 }

--- a/immich_cuda/config.yaml
+++ b/immich_cuda/config.yaml
@@ -141,6 +141,6 @@ slug: immich_cuda
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "2.7.5"
+version: "3.0.1"
 video: true
 webui: http://[HOST]:[PORT:8080]

--- a/immich_cuda/config.yaml
+++ b/immich_cuda/config.yaml
@@ -135,8 +135,6 @@ schema:
   localdisks: str?
   networkdisks: str?
   skip_permissions_check: bool?
-services:
-  - mysql:want
 slug: immich_cuda
 udev: true
 url: https://github.com/alexbelgium/hassio-addons

--- a/immich_cuda/updater.json
+++ b/immich_cuda/updater.json
@@ -1,10 +1,10 @@
 {
   "github_beta": "false",
-  "github_exclude": "2026",
+  "github_exclude": "",
   "last_update": "2026-07-04",
   "repository": "alexbelgium/hassio-addons",
   "slug": "immich",
   "source": "github",
-  "upstream_repo": "imagegenius/docker-immich",
+  "upstream_repo": "immich-app/immich",
   "upstream_version": "3.0.1"
 }

--- a/immich_cuda/updater.json
+++ b/immich_cuda/updater.json
@@ -1,10 +1,10 @@
 {
   "github_beta": "false",
   "github_exclude": "2026",
-  "last_update": "2026-05-19",
+  "last_update": "2026-07-04",
   "repository": "alexbelgium/hassio-addons",
   "slug": "immich",
   "source": "github",
   "upstream_repo": "imagegenius/docker-immich",
-  "upstream_version": "2.7.5"
+  "upstream_version": "3.0.1"
 }

--- a/immich_noml/CHANGELOG.md
+++ b/immich_noml/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## 3.0.1 (2026-07-04)
+- Migrate to Immich v3 (now based on the `ghcr.io/imagegenius/immich:3-noml` image line, tracking the v3 major release)
+- This add-on ships without machine learning; the VectorChord (`vchord`) Postgres extension is still required by Immich v3, while upstream `pgvecto.rs` support has been removed. Use this repository's `Postgres 15`/`Postgres 17` add-ons (or another VectorChord-capable Postgres), and let Immich finish migrating existing data before the old extension is removed
+- Immich v3 requires an x86-64-v2 (or newer) CPU on amd64
+- Migration guide: https://immich.app/blog/v3-migration
+
 ## 2.7.5 (2026-05-22)
 - Update to latest version from imagegenius/docker-immich (changelog : https://github.com/imagegenius/docker-immich/releases)
 

--- a/immich_noml/README.md
+++ b/immich_noml/README.md
@@ -35,6 +35,16 @@ Self-hosted photo and video backup solution directly from your mobile phone. Thi
 
 This addon is based on the [docker image](https://github.com/imagegenius/docker-immich) from imagegenius with machine learning components excluded to reduce resource consumption and improve compatibility with resource-constrained systems.
 
+## Immich v3
+
+This add-on tracks **Immich v3** (built on the `ghcr.io/imagegenius/immich:3-noml` image line). Machine learning is excluded, but the database requirement below still applies.
+
+- **Database**: Immich v3 requires PostgreSQL (14–17) with the **VectorChord (`vchord`)** extension; upstream `pgvecto.rs` support has been removed. The `Postgres 15` and `Postgres 17` add-ons in this repository already provide a VectorChord-capable database and are the recommended choice (you can also use the official `ghcr.io/immich-app/postgres:*-vectorchord*` image).
+- **Upgrading from Immich v2**: keep your existing VectorChord-capable database so Immich can migrate its data automatically. If your database still holds data in the old `pgvecto.rs` extension, leave that extension in place until Immich has finished migrating to VectorChord.
+- **CPU**: on `amd64`, Immich v3 requires an x86-64-v2 (or newer) CPU.
+
+See the official [v3 migration guide](https://immich.app/blog/v3-migration) for details.
+
 ## Use Cases
 
 The NoML variant is ideal for:

--- a/immich_noml/build.json
+++ b/immich_noml/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/imagegenius/immich:noml",
-    "amd64": "ghcr.io/imagegenius/immich:noml"
+    "aarch64": "ghcr.io/imagegenius/immich:3-noml",
+    "amd64": "ghcr.io/imagegenius/immich:3-noml"
   }
 }

--- a/immich_noml/config.yaml
+++ b/immich_noml/config.yaml
@@ -136,8 +136,6 @@ schema:
   localdisks: str?
   networkdisks: str?
   skip_permissions_check: bool?
-services:
-  - mysql:want
 slug: immich_noml
 udev: true
 url: https://github.com/alexbelgium/hassio-addons

--- a/immich_noml/config.yaml
+++ b/immich_noml/config.yaml
@@ -142,6 +142,6 @@ slug: immich_noml
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "2.7.5"
+version: "3.0.1"
 video: true
 webui: http://[HOST]:[PORT:8080]

--- a/immich_noml/updater.json
+++ b/immich_noml/updater.json
@@ -1,10 +1,10 @@
 {
   "github_beta": "false",
   "github_exclude": "2026",
-  "last_update": "2026-05-22",
+  "last_update": "2026-07-04",
   "repository": "alexbelgium/hassio-addons",
   "slug": "immich",
   "source": "github",
   "upstream_repo": "imagegenius/docker-immich",
-  "upstream_version": "2.7.5"
+  "upstream_version": "3.0.1"
 }

--- a/immich_noml/updater.json
+++ b/immich_noml/updater.json
@@ -1,10 +1,10 @@
 {
   "github_beta": "false",
-  "github_exclude": "2026",
+  "github_exclude": "",
   "last_update": "2026-07-04",
   "repository": "alexbelgium/hassio-addons",
   "slug": "immich",
   "source": "github",
-  "upstream_repo": "imagegenius/docker-immich",
+  "upstream_repo": "immich-app/immich",
   "upstream_version": "3.0.1"
 }

--- a/immich_openvino/CHANGELOG.md
+++ b/immich_openvino/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.1 (2026-07-04)
+- Migrate to Immich v3 (now based on the `ghcr.io/imagegenius/immich:3-openvino` image line, tracking the v3 major release)
+- Immich v3 requires the VectorChord (`vchord`) Postgres extension; upstream `pgvecto.rs` support has been removed. Use this repository's `Postgres 15`/`Postgres 17` add-ons (or another VectorChord-capable Postgres), and let Immich finish migrating existing data before the old extension is removed
+- Immich v3 requires an x86-64-v2 (or newer) CPU on amd64
+- Migration guide: https://immich.app/blog/v3-migration
+
 ## 2.7.5-2 (21-05-2026)
 - Minor bugs fixed
 

--- a/immich_openvino/README.md
+++ b/immich_openvino/README.md
@@ -35,6 +35,16 @@ Self-hosted photo and video backup solution directly from your mobile phone with
 
 This addon is based on the [docker image](https://github.com/imagegenius/docker-immich) from imagegenius with OpenVINO support enabled for enhanced performance on Intel hardware.
 
+## Immich v3
+
+This add-on tracks **Immich v3** (built on the `ghcr.io/imagegenius/immich:3-openvino` image line).
+
+- **Database**: Immich v3 requires PostgreSQL (14–17) with the **VectorChord (`vchord`)** extension; upstream `pgvecto.rs` support has been removed. The `Postgres 15` and `Postgres 17` add-ons in this repository already provide a VectorChord-capable database and are the recommended choice (you can also use the official `ghcr.io/immich-app/postgres:*-vectorchord*` image).
+- **Upgrading from Immich v2**: keep your existing VectorChord-capable database so Immich can migrate its data automatically. If your database still holds data in the old `pgvecto.rs` extension, leave that extension in place until Immich has finished migrating to VectorChord.
+- **CPU**: on `amd64`, Immich v3 requires an x86-64-v2 (or newer) CPU.
+
+See the official [v3 migration guide](https://immich.app/blog/v3-migration) for details.
+
 ## Hardware Requirements
 
 - **Intel Hardware**: Compatible Intel CPU or Intel integrated/discrete GPU

--- a/immich_openvino/build.json
+++ b/immich_openvino/build.json
@@ -1,5 +1,5 @@
 {
   "build_from": {
-    "amd64": "ghcr.io/imagegenius/immich:openvino"
+    "amd64": "ghcr.io/imagegenius/immich:3-openvino"
   }
 }

--- a/immich_openvino/config.yaml
+++ b/immich_openvino/config.yaml
@@ -142,6 +142,6 @@ slug: immich_openvino
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "2.7.5-2"
+version: "3.0.1"
 video: true
 webui: http://[HOST]:[PORT:8080]

--- a/immich_openvino/config.yaml
+++ b/immich_openvino/config.yaml
@@ -136,8 +136,6 @@ schema:
   localdisks: str?
   networkdisks: str?
   skip_permissions_check: bool?
-services:
-  - mysql:want
 slug: immich_openvino
 udev: true
 url: https://github.com/alexbelgium/hassio-addons

--- a/immich_openvino/updater.json
+++ b/immich_openvino/updater.json
@@ -1,10 +1,10 @@
 {
   "github_beta": "false",
-  "github_exclude": "2026",
+  "github_exclude": "",
   "last_update": "2026-07-04",
   "repository": "alexbelgium/hassio-addons",
   "slug": "immich",
   "source": "github",
-  "upstream_repo": "imagegenius/docker-immich",
+  "upstream_repo": "immich-app/immich",
   "upstream_version": "3.0.1"
 }

--- a/immich_openvino/updater.json
+++ b/immich_openvino/updater.json
@@ -1,10 +1,10 @@
 {
   "github_beta": "false",
   "github_exclude": "2026",
-  "last_update": "2026-04-18",
+  "last_update": "2026-07-04",
   "repository": "alexbelgium/hassio-addons",
   "slug": "immich",
   "source": "github",
   "upstream_repo": "imagegenius/docker-immich",
-  "upstream_version": "2.7.5"
+  "upstream_version": "3.0.1"
 }


### PR DESCRIPTION
- Pin build.json to the imagegenius v3 image line (:3, :3-cuda, :3-noml, :3-openvino)
- Bump config.yaml version to 3.0.1 and record upstream_version 3.0.1 in updater.json
- Add a non-fatal VectorChord (vchord) startup check in the shared 99-run.sh so users
  on a non-VectorChord database get a clear diagnostic (v3 drops pgvecto.rs)
- Document the Immich v3 database (VectorChord) and CPU requirements in each README and
  point users at the Postgres 15 / Postgres 17 add-ons
- CHANGELOG entries for all four add-ons

The Postgres 15 / Postgres 17 add-ons already ship the official immich VectorChord image
(vectorchord0.4.3, matching Immich v3's pinned database) and are intentionally left
unchanged to preserve the pgvecto.rs to VectorChord migration path.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PcbbgB7A5LLbPuPRjLUouk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Immich add-ons now track version **3.0.1** across standard, CUDA, NoML, and OpenVINO variants.
  * Added **Immich v3** upgrade guidance, including the official migration link and updated system requirements.

* **Bug Fixes**
  * Updated PostgreSQL compatibility guidance to require **VectorChord (`vchord`)** (with **`pgvecto.rs`** support removed upstream).
  * Improved startup handling: logs a clear warning if the **`vchord`** extension isn’t available, while continuing startup.

* **Chores**
  * Pinned build images to the new **v3** tags and refreshed release metadata; removed outdated MySQL manifest references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->