### PR TITLE
Update Filebrowser addon

### DIFF
--- a/filebrowser/CHANGELOG.md
+++ b/filebrowser/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## 2.63.18 (2026-07-04)
+- Update to latest version from filebrowser/filebrowser (changelog : https://github.com/filebrowser/filebrowser/releases)
+
 ## 2.63.17 (2026-06-29)
 - Update to latest version from filebrowser/filebrowser (changelog : https://github.com/filebrowser/filebrowser/releases)
 

--- a/filebrowser/config.yaml
+++ b/filebrowser/config.yaml
@@ -124,4 +124,4 @@ schema:
 slug: filebrowser
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "2.63.17"
+version: "2.63.18"

--- a/filebrowser/updater.json
+++ b/filebrowser/updater.json
@@ -1,10 +1,10 @@
 {
   "github_beta": "true",
-  "last_update": "2026-06-29",
+  "last_update": "2026-07-04",
   "paused": false,
   "repository": "alexbelgium/hassio-addons",
   "slug": "filebrowser",
   "source": "github",
   "upstream_repo": "filebrowser/filebrowser",
-  "upstream_version": "2.63.17"
+  "upstream_version": "2.63.18"
 }


### PR DESCRIPTION
## Summary
- Update Filebrowser from `2.63.17` to `2.63.18`.
- Refresh `updater.json` metadata and add a changelog entry.

## Why
Filebrowser published a new upstream release after the previous add-on update was merged.

## Validation
- Ran `git diff --check`.
- Parsed `filebrowser/updater.json` successfully.
- Verified the latest upstream Filebrowser release: https://github.com/filebrowser/filebrowser/releases/tag/v2.63.18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Filebrowser to version 2.63.18.
  * Refreshed release metadata and changelog to match the latest upstream release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->