### PR TITLE
Immich: fix build failure by dropping the redundant postgresql-client install

### DIFF
--- a/immich/Dockerfile
+++ b/immich/Dockerfile
@@ -91,16 +91,10 @@ RUN if [ -f /etc/s6-overlay/s6-rc.d/init-test-run/run ]; then \
         sed -i "s|postgresql-16|postgresql-15|g" /etc/s6-overlay/s6-rc.d/init-test-run/run; \
     fi
 
-# Install dependencies (postgresql-client for psql CLI used in 99-run.sh)
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    lsb-release \
-    wget \
-    gnupg && \
-    echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends postgresql-client-15
+# postgresql-client (for the psql CLI used in 99-run.sh) is already installed by the
+# imagegenius base image (postgresql-client-14 through 18), so no separate install is
+# needed here. A previous PGDG-repo install using `apt-key add` was removed: the base
+# image moved to a release where the apt-key binary no longer exists, breaking the build.
 
 #ENTRYPOINT [ "/usr/bin/env" ]
 #CMD [ "/ha_entrypoint.sh" ]

--- a/immich/Dockerfile
+++ b/immich/Dockerfile
@@ -92,9 +92,11 @@ RUN if [ -f /etc/s6-overlay/s6-rc.d/init-test-run/run ]; then \
     fi
 
 # postgresql-client (for the psql CLI used in 99-run.sh) is already installed by the
-# imagegenius base image (postgresql-client-14 through 18), so no separate install is
-# needed here. A previous PGDG-repo install using `apt-key add` was removed: the base
-# image moved to a release where the apt-key binary no longer exists, breaking the build.
+# imagegenius base image, so no separate install is needed here. A previous PGDG-repo
+# install using `apt-key add` was removed: the base image moved to a release where the
+# apt-key binary no longer exists, breaking the build. Fail the build early, rather than
+# surfacing a cryptic runtime failure in 99-run.sh, if a future base image drops it.
+RUN command -v psql || { echo "psql not found in base image; postgresql-client must be provided by the upstream base image" >&2; exit 1; }
 
 #ENTRYPOINT [ "/usr/bin/env" ]
 #CMD [ "/ha_entrypoint.sh" ]

--- a/immich_cuda/Dockerfile
+++ b/immich_cuda/Dockerfile
@@ -91,16 +91,10 @@ RUN if [ -f /etc/s6-overlay/s6-rc.d/init-test-run/run ]; then \
         sed -i "s|postgresql-16|postgresql-15|g" /etc/s6-overlay/s6-rc.d/init-test-run/run; \
     fi
 
-# Install dependencies (postgresql-client for psql CLI used in 99-run.sh)
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    lsb-release \
-    wget \
-    gnupg && \
-    echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends postgresql-client-15
+# postgresql-client (for the psql CLI used in 99-run.sh) is already installed by the
+# imagegenius base image (postgresql-client-14 through 18), so no separate install is
+# needed here. A previous PGDG-repo install using `apt-key add` was removed: the base
+# image moved to a release where the apt-key binary no longer exists, breaking the build.
 
 #ENTRYPOINT [ "/usr/bin/env" ]
 #CMD [ "/ha_entrypoint.sh" ]

--- a/immich_cuda/Dockerfile
+++ b/immich_cuda/Dockerfile
@@ -92,9 +92,11 @@ RUN if [ -f /etc/s6-overlay/s6-rc.d/init-test-run/run ]; then \
     fi
 
 # postgresql-client (for the psql CLI used in 99-run.sh) is already installed by the
-# imagegenius base image (postgresql-client-14 through 18), so no separate install is
-# needed here. A previous PGDG-repo install using `apt-key add` was removed: the base
-# image moved to a release where the apt-key binary no longer exists, breaking the build.
+# imagegenius base image, so no separate install is needed here. A previous PGDG-repo
+# install using `apt-key add` was removed: the base image moved to a release where the
+# apt-key binary no longer exists, breaking the build. Fail the build early, rather than
+# surfacing a cryptic runtime failure in 99-run.sh, if a future base image drops it.
+RUN command -v psql || { echo "psql not found in base image; postgresql-client must be provided by the upstream base image" >&2; exit 1; }
 
 #ENTRYPOINT [ "/usr/bin/env" ]
 #CMD [ "/ha_entrypoint.sh" ]

--- a/immich_noml/Dockerfile
+++ b/immich_noml/Dockerfile
@@ -91,16 +91,10 @@ RUN if [ -f /etc/s6-overlay/s6-rc.d/init-test-run/run ]; then \
         sed -i "s|postgresql-16|postgresql-15|g" /etc/s6-overlay/s6-rc.d/init-test-run/run; \
     fi
 
-# Install dependencies (postgresql-client for psql CLI used in 99-run.sh)
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    lsb-release \
-    wget \
-    gnupg && \
-    echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends postgresql-client-15
+# postgresql-client (for the psql CLI used in 99-run.sh) is already installed by the
+# imagegenius base image (postgresql-client-14 through 18), so no separate install is
+# needed here. A previous PGDG-repo install using `apt-key add` was removed: the base
+# image moved to a release where the apt-key binary no longer exists, breaking the build.
 
 #ENTRYPOINT [ "/usr/bin/env" ]
 #CMD [ "/ha_entrypoint.sh" ]

--- a/immich_noml/Dockerfile
+++ b/immich_noml/Dockerfile
@@ -92,9 +92,11 @@ RUN if [ -f /etc/s6-overlay/s6-rc.d/init-test-run/run ]; then \
     fi
 
 # postgresql-client (for the psql CLI used in 99-run.sh) is already installed by the
-# imagegenius base image (postgresql-client-14 through 18), so no separate install is
-# needed here. A previous PGDG-repo install using `apt-key add` was removed: the base
-# image moved to a release where the apt-key binary no longer exists, breaking the build.
+# imagegenius base image, so no separate install is needed here. A previous PGDG-repo
+# install using `apt-key add` was removed: the base image moved to a release where the
+# apt-key binary no longer exists, breaking the build. Fail the build early, rather than
+# surfacing a cryptic runtime failure in 99-run.sh, if a future base image drops it.
+RUN command -v psql || { echo "psql not found in base image; postgresql-client must be provided by the upstream base image" >&2; exit 1; }
 
 #ENTRYPOINT [ "/usr/bin/env" ]
 #CMD [ "/ha_entrypoint.sh" ]

--- a/immich_openvino/Dockerfile
+++ b/immich_openvino/Dockerfile
@@ -91,16 +91,10 @@ RUN if [ -f /etc/s6-overlay/s6-rc.d/init-test-run/run ]; then \
         sed -i "s|postgresql-16|postgresql-15|g" /etc/s6-overlay/s6-rc.d/init-test-run/run; \
     fi
 
-# Install dependencies (postgresql-client for psql CLI used in 99-run.sh)
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    lsb-release \
-    wget \
-    gnupg && \
-    echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends postgresql-client-15
+# postgresql-client (for the psql CLI used in 99-run.sh) is already installed by the
+# imagegenius base image (postgresql-client-14 through 18), so no separate install is
+# needed here. A previous PGDG-repo install using `apt-key add` was removed: the base
+# image moved to a release where the apt-key binary no longer exists, breaking the build.
 
 #ENTRYPOINT [ "/usr/bin/env" ]
 #CMD [ "/ha_entrypoint.sh" ]

--- a/immich_openvino/Dockerfile
+++ b/immich_openvino/Dockerfile
@@ -92,9 +92,11 @@ RUN if [ -f /etc/s6-overlay/s6-rc.d/init-test-run/run ]; then \
     fi
 
 # postgresql-client (for the psql CLI used in 99-run.sh) is already installed by the
-# imagegenius base image (postgresql-client-14 through 18), so no separate install is
-# needed here. A previous PGDG-repo install using `apt-key add` was removed: the base
-# image moved to a release where the apt-key binary no longer exists, breaking the build.
+# imagegenius base image, so no separate install is needed here. A previous PGDG-repo
+# install using `apt-key add` was removed: the base image moved to a release where the
+# apt-key binary no longer exists, breaking the build. Fail the build early, rather than
+# surfacing a cryptic runtime failure in 99-run.sh, if a future base image drops it.
+RUN command -v psql || { echo "psql not found in base image; postgresql-client must be provided by the upstream base image" >&2; exit 1; }
 
 #ENTRYPOINT [ "/usr/bin/env" ]
 #CMD [ "/ha_entrypoint.sh" ]


### PR DESCRIPTION
Follow-up to #2805 (already merged) — the Immich v3 migration built fine locally but broke in CI because the imagegenius v3 base image moved to a newer Ubuntu release where the `apt-key` binary no longer exists.

## Summary
- The Dockerfiles for `immich`, `immich_cuda`, `immich_noml`, `immich_openvino` had a manual step installing `postgresql-client-15` from the PGDG apt repo via `wget ... | apt-key add -`, which fails on the new base (`apt-key: command not found`).
- That step was already redundant: imagegenius's own upstream Dockerfile installs `postgresql-client-14` through `18` itself (via the modern `signed-by` keyring method), so the `psql` CLI used by `99-run.sh` is already present in the base image.
- Removed the downstream install entirely (and the `SHELL` override it needed for `pipefail`) rather than patching it to use a keyring, since it duplicated work the base image already does.

## Test plan
- [ ] CI Docker build succeeds for all four add-ons across their declared architectures
- [ ] Manual smoke test: install one variant and confirm the Immich web UI comes up and `psql`/`99-run.sh` DB setup still works


---
_Generated by [Claude Code](https://claude.ai/code/session_01PcbbgB7A5LLbPuPRjLUouk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified container builds by removing redundant PostgreSQL client installation steps.
  * Reduced reliance on external package repository setup during image creation.
  * Added a fail-fast build check to ensure the `psql` CLI is present, preventing later runtime failures.
  * Kept existing compatibility handling for older runtime setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->