### PR TITLE
fix(birdnet-pipy): re-tag 0.8.2-1 as 0.8.2.1 so HA offers it as an update

### DIFF
--- a/birdnet-pipy/CHANGELOG.md
+++ b/birdnet-pipy/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## 0.8.2.1 (2026-07-05)
+- Re-tag of 0.8.2-1 with no content change. Home Assistant compares add-on versions with semver semantics, where a `-N` suffix counts as a *pre-release* and sorts **below** the base version — so users already on 0.8.2 saw the 0.8.2-1 nginx fix as "Up-to-date" with the Update button disabled. Four-segment `0.8.2.1` sorts above both `0.8.2` and `0.8.2-1` (and below the next upstream `0.8.3`), so the update becomes installable everywhere.
+
 ## 0.8.2-1 (2026-07-04)
 - Fix nginx failing to start with `limit_req_zone "api_rl" already bound` (502 on every page, Suncuss/BirdNET-PiPy#59). Upstream 0.8.2 added http-level rate-limit zones, and the ingress config was generated as a full copy of nginx.conf — duplicating those declarations in the shared http context. `ingress.conf` is now built from the `server` block only, so http-level directives stay declared once.
 - Comment out the new upstream Content-Security-Policy header in ingress mode, matching the existing X-* security-header handling (ingress runs inside Home Assistant's authenticated frame; direct access keeps the full CSP).

--- a/birdnet-pipy/config.yaml
+++ b/birdnet-pipy/config.yaml
@@ -96,4 +96,4 @@ schema:
   ssl: bool?
 slug: birdnet-pipy
 url: https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-pipy
-version: "0.8.2-1"
+version: "0.8.2.1"


### PR DESCRIPTION
Follow-up to #2804, version string only — no content change.

HA compares add-on versions with `awesomeversion`, which treats `-1` as a semver pre-release: `0.8.2-1` sorts *below* `0.8.2`, so users on the broken 0.8.2 see "Up-to-date" with the Update button disabled ([screenshots](https://github.com/Suncuss/BirdNET-PiPy/issues/59)). `0.8.2.1` sorts above both, and below the next upstream `0.8.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016acGazhHvyCNUFt71xzFxm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the add-on version so it installs correctly for users who were previously shown as “Up-to-date.”
  * Adjusted the release numbering to avoid being treated as a pre-release in sorting, ensuring the update is offered properly.

* **Documentation**
  * Added a changelog note explaining the version re-tag and that there are no content changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->