### PR TITLE
fix(birdnet-go): harden sqlite path rewrite (traversal + parent dir)

### DIFF
--- a/birdnet-go-dev/CHANGELOG.md
+++ b/birdnet-go-dev/CHANGELOG.md
@@ -1,3 +1,6 @@
+## source-20260705-3 (05-07-2026)
+- Harden the `output.sqlite.path` rewrite added for the persistence fix: reject paths containing `..` traversal segments (shared `validate_safe_path` check), and create the destination's parent directory under `/config` when the relative path includes a subdirectory (e.g. `db/birdnet.db`), since SQLite does not create missing parent directories itself.
+
 ## source-20260705-2 (05-07-2026)
 - Fix detections/database not persisting across restarts on a fresh install: upstream's default `config.yaml` ships `output.sqlite.path: birdnet.db` (relative) explicitly, so the missing-only (`//=`) seeding introduced previously never rewrote it to an absolute path. A relative path resolves against the app's ephemeral working directory, so the database was silently recreated empty on every restart. Any relative `output.sqlite.path` is now rewritten to live under the persistent `/config` on startup; values already set to an absolute path are left untouched. (https://github.com/tphakala/birdnet-go/discussions/3774)
 

--- a/birdnet-go-dev/config.yaml
+++ b/birdnet-go-dev/config.yaml
@@ -127,5 +127,5 @@ slug: birdnet-go-dev
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "source-20260705-2"
+version: "source-20260705-3"
 video: true

--- a/birdnet-go-dev/rootfs/etc/cont-init.d/01-structure.sh
+++ b/birdnet-go-dev/rootfs/etc/cont-init.d/01-structure.sh
@@ -17,12 +17,22 @@ normalize_path() {
 
 # Reject paths containing characters that would break the SQL/YAML literals
 # we substitute into below. We deliberately allow only "safe" filename chars.
+# Also reject ".." path segments so a relative path can't traverse outside
+# the directory we prefix it with (e.g. "/config") when we rewrite it below.
 validate_safe_path() {
     local p="$1"
     if [[ ! "$p" =~ ^[A-Za-z0-9._/-]+$ ]]; then
         bashio::log.fatal "Refusing unsafe path: '$p' (only [A-Za-z0-9._/-] allowed)"
         exit 1
     fi
+    local segment
+    local IFS=/
+    for segment in $p; do
+        if [[ "$segment" == ".." ]]; then
+            bashio::log.fatal "Refusing unsafe path: '$p' (path traversal '..' is not allowed)"
+            exit 1
+        fi
+    done
 }
 
 if [ ! -f "$CONFIG_LOCATION" ]; then
@@ -149,8 +159,12 @@ bashio::log.info "Seeding default configuration values (only if missing)"
 CURRENT_SQLITE_PATH="$(yq -r '.output.sqlite.path // ""' "$CONFIG_LOCATION")"
 if [[ -n "$CURRENT_SQLITE_PATH" && "$CURRENT_SQLITE_PATH" != /* ]]; then
     validate_safe_path "$CURRENT_SQLITE_PATH"
-    bashio::log.warning "output.sqlite.path ('$CURRENT_SQLITE_PATH') is relative and would not persist across restarts; rewriting to /config/$CURRENT_SQLITE_PATH"
-    yq -i -y ".output.sqlite.path = \"/config/${CURRENT_SQLITE_PATH}\"" "$CONFIG_LOCATION"
+    NEW_SQLITE_PATH="/config/${CURRENT_SQLITE_PATH}"
+    bashio::log.warning "output.sqlite.path ('$CURRENT_SQLITE_PATH') is relative and would not persist across restarts; rewriting to $NEW_SQLITE_PATH"
+    # SQLite does not create missing parent directories, so ensure one exists
+    # if the (validated, traversal-free) path includes a subdirectory.
+    mkdir -p "$(dirname "$NEW_SQLITE_PATH")"
+    yq -i -y ".output.sqlite.path = \"${NEW_SQLITE_PATH}\"" "$CONFIG_LOCATION"
 fi
 
 yq -i -y '.output.sqlite.path //= "/config/birdnet.db"' "$CONFIG_LOCATION"

--- a/birdnet-go/CHANGELOG.md
+++ b/birdnet-go/CHANGELOG.md
@@ -1,3 +1,6 @@
+## nightly-20260615-3 (05-07-2026)
+- Harden the `output.sqlite.path` rewrite added for the persistence fix: reject paths containing `..` traversal segments (shared `validate_safe_path` check), and create the destination's parent directory under `/config` when the relative path includes a subdirectory (e.g. `db/birdnet.db`), since SQLite does not create missing parent directories itself.
+
 ## nightly-20260615-2 (05-07-2026)
 - Minor bugs fixed
  - Fix detections/database not persisting across restarts on a fresh install: upstream's default `config.yaml` ships `output.sqlite.path: birdnet.db` (relative) explicitly, so the missing-only (`//=`) seeding introduced previously never rewrote it to an absolute path. A relative path resolves against the app's ephemeral working directory, so the database was silently recreated empty on every restart. Any relative `output.sqlite.path` is now rewritten to live under the persistent `/config` on startup; values already set to an absolute path are left untouched. (https://github.com/tphakala/birdnet-go/discussions/3774)

--- a/birdnet-go/config.yaml
+++ b/birdnet-go/config.yaml
@@ -128,4 +128,4 @@ slug: birdnet-go
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-go
 usb: true
-version: "nightly-20260615-2"
+version: "nightly-20260615-3"

--- a/birdnet-go/rootfs/etc/cont-init.d/01-structure.sh
+++ b/birdnet-go/rootfs/etc/cont-init.d/01-structure.sh
@@ -17,12 +17,22 @@ normalize_path() {
 
 # Reject paths containing characters that would break the SQL/YAML literals
 # we substitute into below. We deliberately allow only "safe" filename chars.
+# Also reject ".." path segments so a relative path can't traverse outside
+# the directory we prefix it with (e.g. "/config") when we rewrite it below.
 validate_safe_path() {
     local p="$1"
     if [[ ! "$p" =~ ^[A-Za-z0-9._/-]+$ ]]; then
         bashio::log.fatal "Refusing unsafe path: '$p' (only [A-Za-z0-9._/-] allowed)"
         exit 1
     fi
+    local segment
+    local IFS=/
+    for segment in $p; do
+        if [[ "$segment" == ".." ]]; then
+            bashio::log.fatal "Refusing unsafe path: '$p' (path traversal '..' is not allowed)"
+            exit 1
+        fi
+    done
 }
 
 if [ ! -f "$CONFIG_LOCATION" ]; then
@@ -145,8 +155,12 @@ bashio::log.info "Seeding default configuration values (only if missing)"
 CURRENT_SQLITE_PATH="$(yq -r '.output.sqlite.path // ""' "$CONFIG_LOCATION")"
 if [[ -n "$CURRENT_SQLITE_PATH" && "$CURRENT_SQLITE_PATH" != /* ]]; then
     validate_safe_path "$CURRENT_SQLITE_PATH"
-    bashio::log.warning "output.sqlite.path ('$CURRENT_SQLITE_PATH') is relative and would not persist across restarts; rewriting to /config/$CURRENT_SQLITE_PATH"
-    yq -i -y ".output.sqlite.path = \"/config/${CURRENT_SQLITE_PATH}\"" "$CONFIG_LOCATION"
+    NEW_SQLITE_PATH="/config/${CURRENT_SQLITE_PATH}"
+    bashio::log.warning "output.sqlite.path ('$CURRENT_SQLITE_PATH') is relative and would not persist across restarts; rewriting to $NEW_SQLITE_PATH"
+    # SQLite does not create missing parent directories, so ensure one exists
+    # if the (validated, traversal-free) path includes a subdirectory.
+    mkdir -p "$(dirname "$NEW_SQLITE_PATH")"
+    yq -i -y ".output.sqlite.path = \"${NEW_SQLITE_PATH}\"" "$CONFIG_LOCATION"
 fi
 
 yq -i -y '.output.sqlite.path //= "/config/birdnet.db"' "$CONFIG_LOCATION"


### PR DESCRIPTION
## Summary

Follow-up to #2812 (merged), addressing two review comments (Copilot / codex) on the `output.sqlite.path` persistence fix in `birdnet-go` and `birdnet-go-dev`'s `01-structure.sh`:

- **Path traversal**: a relative `output.sqlite.path` containing `..` segments (e.g. `../../etc/passwd`) was rewritten to `/config/../../etc/passwd`, which can escape the intended persistent directory. `validate_safe_path` now rejects any path with a `..` segment, in addition to its existing character allowlist. This check is shared with the pre-existing `BIRDSONGS_FOLDER` validation.
- **Missing parent directory**: a relative path with a subdirectory (e.g. `db/birdnet.db`) was rewritten to `/config/db/birdnet.db`, but SQLite does not create missing parent directories, so the app would fail to open the database. The rewrite now runs `mkdir -p` on the destination's parent directory first.

The default path is unaffected and remains `/config/birdnet.db` (not `/config/db/birdnet.db`) — the new `mkdir -p` call only matters when a user has an existing relative path with a subdirectory component.

## Test plan

- [x] `bash -n` syntax check on both modified `01-structure.sh` scripts
- [x] Isolated shell test of the updated `validate_safe_path` confirming `../../etc/passwd` is rejected and normal relative paths (e.g. `db/birdnet.db`, legacy `birdnet.db`) are still accepted
- [ ] Addon container build / boot test (not run in this environment)

Claude-Session: https://claude.ai/code/session_01KHJ4o22cdcgdNtb81tBTPJ


---
_Generated by [Claude Code](https://claude.ai/code/session_01KHJ4o22cdcgdNtb81tBTPJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of database path settings during startup.
  * Relative database paths with subfolders now create missing parent directories automatically.
  * Unsafe paths containing directory traversal segments are now rejected to prevent invalid path rewrites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->