### PR TITLE
Add Manyfold public hostname option

### DIFF
--- a/manyfold/CHANGELOG.md
+++ b/manyfold/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## 0.146.1 (2026-07-06)
+- Add configurable Manyfold public hostname with Home Assistant external URL and homeassistant.local fallbacks.
+
 ## 0.146.0 (2026-07-04)
 - Update to latest version from manyfold3d/manyfold (changelog : https://github.com/manyfold3d/manyfold/releases)
 ## 0.145.1 (24-06-2026)

--- a/manyfold/config.yaml
+++ b/manyfold/config.yaml
@@ -10,6 +10,7 @@ arch:
 startup: services
 init: false
 hassio_api: true
+homeassistant_api: true
 
 ports:
   3214/tcp: 3214

--- a/manyfold/config.yaml
+++ b/manyfold/config.yaml
@@ -1,7 +1,7 @@
 name: "Manyfold"
 slug: manyfold
 description: "Manyfold 3D model manager as a Home Assistant add-on, using the upstream image with configurable library/index paths."
-version: "0.146.0"
+version: "0.146.1"
 url: "https://github.com/alexbelgium/hassio-addons/tree/master/manyfold"
 image: ghcr.io/alexbelgium/manyfold-{arch}
 arch:
@@ -9,6 +9,7 @@ arch:
   - aarch64
 startup: services
 init: false
+hassio_api: true
 
 ports:
   3214/tcp: 3214
@@ -27,6 +28,7 @@ options:
   puid: 1000
   pgid: 1000
   multiuser: true
+  public_hostname: ""
   library_path: "/share/manyfold/models"
   thumbnails_path: "/config/thumbnails"
   log_level: "info"
@@ -41,6 +43,7 @@ schema:
   secret_key_base: str
   puid: int
   pgid: int
+  public_hostname: str?
   multiuser: bool
   library_path: str
   thumbnails_path: str

--- a/manyfold/run.sh
+++ b/manyfold/run.sh
@@ -14,6 +14,7 @@ DEFAULT_DEFAULT_WORKER_CONCURRENCY="4"
 DEFAULT_PERFORMANCE_WORKER_CONCURRENCY="1"
 DEFAULT_MAX_FILE_UPLOAD_SIZE="1073741824"
 DEFAULT_MAX_FILE_EXTRACT_SIZE="1073741824"
+DEFAULT_PUBLIC_HOSTNAME="homeassistant.local"
 
 log() {
   echo "[manyfold-addon] $*"
@@ -27,6 +28,40 @@ die() {
 read_opt() {
   local key="$1"
   jq -er --arg k "$key" '.[$k]' "$OPTIONS_JSON" 2>/dev/null || true
+}
+
+strip_hostname() {
+  local raw="$1"
+
+  raw="${raw#http://}"
+  raw="${raw#https://}"
+  raw="${raw%%/*}"
+  raw="${raw%%:*}"
+
+  printf '%s\n' "$raw"
+}
+
+detect_ha_public_hostname() {
+  local supervisor_url="${SUPERVISOR:-http://supervisor}"
+  local response external_url external_host
+
+  if [[ -z "${SUPERVISOR_TOKEN:-}" ]] || ! command -v curl >/dev/null 2>&1; then
+    printf '%s\n' "$DEFAULT_PUBLIC_HOSTNAME"
+    return
+  fi
+
+  response="$(curl -fsSL \
+    -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
+    "${supervisor_url}/core/api/config" 2>/dev/null || true)"
+  external_url="$(jq -er '.external_url // empty' <<< "$response" 2>/dev/null || true)"
+  external_host="$(strip_hostname "$external_url")"
+
+  if [[ -n "$external_host" && "$external_host" != "null" ]]; then
+    printf '%s\n' "$external_host"
+    return
+  fi
+
+  printf '%s\n' "$DEFAULT_PUBLIC_HOSTNAME"
 }
 
 normalize_path() {
@@ -176,6 +211,7 @@ PERFORMANCE_WORKER_CONCURRENCY="$(read_opt performance_worker_concurrency)"; PER
 MAX_FILE_UPLOAD_SIZE="$(read_opt max_file_upload_size)"; MAX_FILE_UPLOAD_SIZE="${MAX_FILE_UPLOAD_SIZE:-$DEFAULT_MAX_FILE_UPLOAD_SIZE}"
 MAX_FILE_EXTRACT_SIZE="$(read_opt max_file_extract_size)"; MAX_FILE_EXTRACT_SIZE="${MAX_FILE_EXTRACT_SIZE:-$DEFAULT_MAX_FILE_EXTRACT_SIZE}"
 SECRET_KEY_BASE="$(read_opt secret_key_base)"; SECRET_KEY_BASE="${SECRET_KEY_BASE:-}"
+PUBLIC_HOSTNAME_RAW="$(read_opt public_hostname)"; PUBLIC_HOSTNAME_RAW="${PUBLIC_HOSTNAME_RAW:-}"
 
 [[ "$PUID" =~ ^[0-9]+$ ]] || die "puid must be a non-negative integer"
 [[ "$PGID" =~ ^[0-9]+$ ]] || die "pgid must be a non-negative integer"
@@ -188,6 +224,13 @@ SECRET_KEY_BASE="$(read_opt secret_key_base)"; SECRET_KEY_BASE="${SECRET_KEY_BAS
 
 LIBRARY_PATH="$(require_mapped_path "library_path" "$LIBRARY_PATH_RAW")"
 THUMBNAILS_PATH="$(require_mapped_path "thumbnails_path" "$THUMBNAILS_PATH_RAW")"
+
+if [[ -n "$PUBLIC_HOSTNAME_RAW" ]]; then
+  PUBLIC_HOSTNAME="$(strip_hostname "$PUBLIC_HOSTNAME_RAW")"
+else
+  PUBLIC_HOSTNAME="$(detect_ha_public_hostname)"
+fi
+[[ -n "$PUBLIC_HOSTNAME" && "$PUBLIC_HOSTNAME" != "null" ]] || PUBLIC_HOSTNAME="$DEFAULT_PUBLIC_HOSTNAME"
 
 case "$THUMBNAILS_PATH" in
   /config|/config/*) ;;
@@ -223,6 +266,7 @@ export MULTIUSER
 export MANYFOLD_MULTIUSER="$MULTIUSER"
 export MANYFOLD_LIBRARY_PATH="$LIBRARY_PATH"
 export MANYFOLD_THUMBNAILS_PATH="$THUMBNAILS_PATH"
+export PUBLIC_HOSTNAME
 export RAILS_LOG_LEVEL="$LOG_LEVEL"
 export MANYFOLD_LOG_LEVEL="$LOG_LEVEL"
 export WEB_CONCURRENCY

--- a/manyfold/run.sh
+++ b/manyfold/run.sh
@@ -36,7 +36,12 @@ strip_hostname() {
   raw="${raw#http://}"
   raw="${raw#https://}"
   raw="${raw%%/*}"
-  raw="${raw%%:*}"
+
+  if [[ "$raw" =~ ^(\[[^]]+\])(:[0-9]+)?$ ]]; then
+    raw="${BASH_REMATCH[1]}"
+  else
+    raw="${raw%%:*}"
+  fi
 
   printf '%s\n' "$raw"
 }

--- a/manyfold/translations/en.yaml
+++ b/manyfold/translations/en.yaml
@@ -11,6 +11,9 @@ configuration:
   multiuser:
     name: Multiuser mode
     description: Enable or disable Manyfold multiuser login.
+  public_hostname:
+    name: Public hostname
+    description: Public hostname used by Manyfold for generated links. Leave blank to use Home Assistant external URL host, or homeassistant.local if unavailable.
   library_path:
     name: Library path
     description: Folder scanned/indexed by Manyfold. Must be under /share, /media, or /config.


### PR DESCRIPTION
### Motivation
- Allow configuring the public hostname used by Manyfold for generated links from the add-on UI.
- Provide automatic detection of Home Assistant's public host when the option is left blank so links remain correct without manual setup.
- Fall back to `homeassistant.local` when Home Assistant external URL is unavailable to preserve a sane default.

### Description
- Add a `public_hostname` add-on option and schema entry in `manyfold/config.yaml` and enable `hassio_api` for Supervisor access, and bump the add-on `version` to `0.146.1`.
- Add runtime logic in `manyfold/run.sh`: introduce `DEFAULT_PUBLIC_HOSTNAME`, `strip_hostname()` helper, and `detect_ha_public_hostname()` which calls the Supervisor API (using `SUPERVISOR`/`SUPERVISOR_TOKEN`) to read `external_url` and extract the host.
- Read `public_hostname` from the add-on options as `PUBLIC_HOSTNAME_RAW`, choose the option if present, otherwise detect via Supervisor, and fall back to `homeassistant.local`; then export `PUBLIC_HOSTNAME` for the Manyfold container.
- Add English UI labels for the new `public_hostname` option in `manyfold/translations/en.yaml` and update `manyfold/CHANGELOG.md` describing the change.

### Testing
- Ran a shell syntax check with `bash -n manyfold/run.sh` and it succeeded.
- Validated YAML files with `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f} ok" }' manyfold/config.yaml manyfold/translations/en.yaml` and both loaded successfully.
- Ran `git diff --check` to ensure no whitespace or diff issues and it returned clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b3ed08794832592c1e7394ab75c1f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a configurable public hostname for Manyfold.
  * When available, the add-on can now use Home Assistant’s external URL automatically, with sensible fallbacks if it isn’t set.
* **Bug Fixes**
  * Improved public hostname handling by normalizing user-supplied or detected URLs/hosts.
* **Documentation**
  * Added a new changelog entry for version `0.146.1`.
* **Chores**
  * Updated the add-on configuration version to `0.146.1`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->