### PR TITLE
[codex] Fix NetBird server startup

### DIFF
--- a/netbird-server/CHANGELOG.md
+++ b/netbird-server/CHANGELOG.md
@@ -1,0 +1,4 @@
+## 0.64.5-8 (2026-07-06)
+- Fix NetBird management startup by adding glibc compatibility for the upstream binary.
+- Assign separate metrics ports for management, signal, and relay to avoid startup port conflicts.
+- Quote dashboard OIDC scopes so the generated env file can be sourced correctly.

--- a/netbird-server/Dockerfile
+++ b/netbird-server/Dockerfile
@@ -74,7 +74,7 @@ COPY ha_automodules.sh /ha_automodules.sh
 RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_automodules.sh
 
 # Manual apps
-ENV PACKAGES="nginx gettext ca-certificates caddy openssl"
+ENV PACKAGES="nginx gettext ca-certificates caddy openssl gcompat"
 
 # Automatic apps & bashio
 COPY ha_autoapps.sh /ha_autoapps.sh

--- a/netbird-server/config.yaml
+++ b/netbird-server/config.yaml
@@ -23,5 +23,5 @@ ports_description:
 schema:
   domain: str
 url: https://github.com/alexbelgium/hassio-addons/tree/master/netbird-server
-version: 0.64.5-7
+version: 0.64.5-8
 webui: "[PROTO:ssl]://[HOST]:[PORT:443]"

--- a/netbird-server/rootfs/etc/cont-init.d/00-config.sh
+++ b/netbird-server/rootfs/etc/cont-init.d/00-config.sh
@@ -31,6 +31,7 @@ DASHBOARD_PORT=8080
 SIGNAL_PORT=8083
 SIGNAL_GRPC_PORT=10000
 RELAY_PORT=8084
+RELAY_METRICS_PORT=9093
 
 if [[ -z "$DOMAIN" || "$DOMAIN" == "netbird.example.com" ]]; then
   result=$(bashio::api.supervisor GET /core/api/config true || true)
@@ -110,10 +111,14 @@ NB_LOG_LEVEL=info
 NB_LISTEN_ADDRESS=:${RELAY_PORT}
 NB_EXPOSED_ADDRESS=${NETBIRD_RELAY_PROTO}://${DOMAIN}:${NETBIRD_PORT}
 NB_AUTH_SECRET=${RELAY_AUTH_SECRET}
+NB_METRICS_PORT=${RELAY_METRICS_PORT}
 NB_ENABLE_STUN=true
 NB_STUN_LOG_LEVEL=info
 NB_STUN_PORTS=${NETBIRD_STUN_PORT}
 CONFIG
+fi
+if ! grep -q '^NB_METRICS_PORT=' "$RELAY_ENV_FILE"; then
+  echo "NB_METRICS_PORT=${RELAY_METRICS_PORT}" >> "$RELAY_ENV_FILE"
 fi
 
 # Generate dashboard env file if missing
@@ -130,7 +135,7 @@ AUTH_CLIENT_ID=netbird-dashboard
 AUTH_CLIENT_SECRET=
 AUTH_AUTHORITY=${NETBIRD_HTTP_PROTOCOL}://${DOMAIN}/oauth2
 USE_AUTH0=false
-AUTH_SUPPORTED_SCOPES=openid profile email groups
+AUTH_SUPPORTED_SCOPES="openid profile email groups"
 AUTH_REDIRECT_URI=/nb-auth
 AUTH_SILENT_REDIRECT_URI=/nb-silent-auth
 # SSL
@@ -140,6 +145,7 @@ LETSENCRYPT_DOMAIN=none
 CONFIG
   chmod 600 "$DASHBOARD_ENV_FILE"
 fi
+sed -i 's/^AUTH_SUPPORTED_SCOPES=openid profile email groups$/AUTH_SUPPORTED_SCOPES="openid profile email groups"/' "$DASHBOARD_ENV_FILE"
 
 # Generate Caddyfile if missing
 CADDYFILE="$DATA_DIR/Caddyfile"

--- a/netbird-server/rootfs/etc/services.d/management/run
+++ b/netbird-server/rootfs/etc/services.d/management/run
@@ -11,6 +11,7 @@ DATA_DIR="/config/netbird"
 LOG_LEVEL="info"
 MANAGEMENT_CONFIG="$DATA_DIR/management/management.json"
 MANAGEMENT_PORT=8081
+MANAGEMENT_METRICS_PORT=9091
 
 if [[ ! -f "$MANAGEMENT_CONFIG" ]]; then
   bashio::log.error "Missing management configuration at ${MANAGEMENT_CONFIG}."
@@ -21,6 +22,7 @@ bashio::log.info "Starting NetBird Management..."
 exec /usr/local/bin/netbird-mgmt management \
   --config "$MANAGEMENT_CONFIG" \
   --port "$MANAGEMENT_PORT" \
+  --metrics-port "$MANAGEMENT_METRICS_PORT" \
   --log-level "$LOG_LEVEL" \
   --log-file console \
   --disable-anonymous-metrics=false \

--- a/netbird-server/rootfs/etc/services.d/signal/run
+++ b/netbird-server/rootfs/etc/services.d/signal/run
@@ -8,10 +8,12 @@ set -euo pipefail
 # ==============================================================================
 
 SIGNAL_PORT=8083
+SIGNAL_METRICS_PORT=9092
 LOG_LEVEL="info"
 
 bashio::log.info "Starting NetBird Signal on port ${SIGNAL_PORT} (legacy gRPC on 10000)..."
 exec /usr/local/bin/netbird-signal run \
   --port "$SIGNAL_PORT" \
+  --metrics-port "$SIGNAL_METRICS_PORT" \
   --log-level "$LOG_LEVEL" \
   --log-file console


### PR DESCRIPTION
## Summary

Fixes the NetBird Server add-on startup failures reported in #2817.

## Changes

- Add `gcompat` to the image packages so the upstream Ubuntu-built `netbird-mgmt` binary has the expected glibc compatibility on the add-on base image.
- Assign separate internal metrics ports for management, signal, and relay so they no longer all bind to `:9090`.
- Quote `AUTH_SUPPORTED_SCOPES` in the generated dashboard env file and repair existing generated files during startup.
- Bump the add-on version to `0.64.5-8` and add a changelog entry.

## Root Cause

The add-on copied NetBird binaries from upstream images into a different base image. The management binary could fail at exec time due to missing runtime compatibility, while NetBird management, signal, and relay all default their metrics server to port `9090`. The dashboard env file also wrote a multi-word value unquoted, causing `profile` to be interpreted as a shell command when sourced.

## Validation

- `git diff --cached --check`
- Git Bash syntax check for the NetBird init and service scripts

Docker is not available in this workspace, so I could not run an image build locally.

Closes #2817

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by adding compatibility support for environments using glibc.
  * Prevented service startup conflicts by assigning separate metrics ports for management, signal, and relay.
  * Fixed dashboard environment generation so OIDC scopes are quoted correctly and can be sourced without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->