### PR TITLE
Fix Claude Desktop Selkies startup by creating s6 envdir and XDG runtime dir

### DIFF
--- a/claude_desktop/CHANGELOG.md
+++ b/claude_desktop/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2 (07-07-2026)
+
+- Fix Selkies startup by creating the s6 environment directory and XDG runtime directory before services start.
+
 ## 1.0 (07-07-2026)
 - Minor bugs fixed
 # Changelog

--- a/claude_desktop/config.yaml
+++ b/claude_desktop/config.yaml
@@ -71,5 +71,5 @@ slug: claude_desktop
 tmpfs: true
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "1.0"
+version: "1.2"
 video: true

--- a/claude_desktop/rootfs/etc/cont-init.d/20-folders.sh
+++ b/claude_desktop/rootfs/etc/cont-init.d/20-folders.sh
@@ -28,6 +28,17 @@ fi
 
 bashio::log.info "Setting data location to $LOCATION"
 
+# LinuxServer Selkies services expect the s6 envdir at /run/s6/container_environment.
+# Home Assistant add-on startup can run without s6-overlay PID1, so create the envdir
+# ourselves before those services start and before scripts write required variables.
+S6_ENVDIR="/run/s6/container_environment"
+mkdir -p "$S6_ENVDIR"
+chmod 755 /run/s6 "$S6_ENVDIR"
+
+XDG_RUNTIME_DIR="/run/user/$PUID"
+mkdir -p "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR"
+
 for file in /etc/s6-overlay/s6-rc.d/*/run; do
     if [ "$(sed -n '1{/bash/p};q' "$file")" ] && ! grep -q '^export XDG_CACHE_HOME=/tmp/cache$' "$file"; then
         sed -i "1a export HOME=$LOCATION" "$file"
@@ -44,9 +55,10 @@ done
 
 sed -i "s|^\(abc:[^:]*:[^:]*:[^:]*:[^:]*:\)[^:]*|\1$LOCATION|" /etc/passwd
 
-if [ -d /var/run/s6/container_environment ]; then printf "%s" "$LOCATION" > /var/run/s6/container_environment/HOME; fi
-if [ -d /var/run/s6/container_environment ]; then printf "%s" "$LOCATION" > /var/run/s6/container_environment/FM_HOME; fi
-if [ -d /var/run/s6/container_environment ]; then printf "%s" "/tmp/cache" > /var/run/s6/container_environment/XDG_CACHE_HOME; fi
+printf "%s" "$LOCATION" > "$S6_ENVDIR/HOME"
+printf "%s" "$LOCATION" > "$S6_ENVDIR/FM_HOME"
+printf "%s" "/tmp/cache" > "$S6_ENVDIR/XDG_CACHE_HOME"
+printf "%s" "$XDG_RUNTIME_DIR" > "$S6_ENVDIR/XDG_RUNTIME_DIR"
 grep -qxF "export HOME=\"$LOCATION\"" ~/.bashrc 2>/dev/null || {
     printf "%s\n" "export HOME=\"$LOCATION\""
     printf "%s\n" "export FM_HOME=\"$LOCATION\""
@@ -54,8 +66,9 @@ grep -qxF "export HOME=\"$LOCATION\"" ~/.bashrc 2>/dev/null || {
 } >> ~/.bashrc
 
 bashio::log.info "Creating $LOCATION"
-mkdir -p "$LOCATION" /tmp/cache
+mkdir -p "$LOCATION" /tmp/cache "$XDG_RUNTIME_DIR"
 chmod 755 /tmp/cache
+chmod 700 "$XDG_RUNTIME_DIR"
 
 if [ -e "$LOCATION/.cache" ] && [ ! -L "$LOCATION/.cache" ]; then
     rm -rf "$LOCATION/.cache"
@@ -63,5 +76,5 @@ fi
 ln -sfn /tmp/cache "$LOCATION/.cache"
 
 bashio::log.info "Setting ownership to $PUID:$PGID"
-chown -R "$PUID":"$PGID" "$LOCATION" /tmp/cache
+chown -R "$PUID":"$PGID" "$LOCATION" /tmp/cache "$XDG_RUNTIME_DIR"
 chmod -R 700 "$LOCATION"


### PR DESCRIPTION
### Motivation
- The add-on failed at runtime with `s6-envdir: fatal: unable to envdir /run/s6/container_environment` and related Selkies service crashes because the expected s6 envdir and `XDG_RUNTIME_DIR` were not present during startup. 

### Description
- Create the s6 environment directory at `/run/s6/container_environment` and set permissions early in `claude_desktop/rootfs/etc/cont-init.d/20-folders.sh` so Selkies services can read runtime variables. 
- Create an XDG runtime directory at `/run/user/$PUID`, set appropriate permissions, and write `XDG_RUNTIME_DIR` plus `HOME`, `FM_HOME`, and `XDG_CACHE_HOME` to the s6 envdir so services can discover them. 
- Ensure the runtime directory is created and included in ownership/chown operations alongside the configured data and cache paths. 
- Bump the add-on `version` to `1.2` in `claude_desktop/config.yaml` and add a short entry to `claude_desktop/CHANGELOG.md`. 

### Testing
- Ran shell syntax checks with `bash -n claude_desktop/rootfs/etc/cont-init.d/*.sh` which completed without syntax errors. 
- Parsed `claude_desktop/config.yaml` with Ruby YAML (`ruby -e 'require "yaml"; YAML.load_file("claude_desktop/config.yaml")'`) which returned successfully. 
- Ran `git diff --check` to ensure no leftover whitespace errors and verified the changes are clean; `shellcheck` was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cc71472048325be656e01c895a053)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by ensuring required runtime and environment directories are created before services begin.
  * Fixed cases where user sessions could fail due to missing runtime paths or cache locations.
  * Added safer handling for home and cache settings to keep the app environment consistent across launches.

* **Chores**
  * Updated the add-on version to 1.2.
  * Added a new changelog entry for this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->