### PR TITLE
Improve Claude Desktop tooling setup: add git/gh and ensure rtk/headroom ready

### DIFF
--- a/claude_desktop/CHANGELOG.md
+++ b/claude_desktop/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 1.2 (07-07-2026)
+- Add baked-in git/GitHub CLI support with optional startup credential configuration.
 
 - Fix Selkies startup by creating the s6 environment directory and XDG runtime directory before services start.
 

--- a/claude_desktop/Dockerfile
+++ b/claude_desktop/Dockerfile
@@ -56,7 +56,7 @@ RUN if [ ! -f /bin/sh ] && [ -f /usr/bin/sh ]; then ln -s /usr/bin/sh /bin/sh; f
 RUN curl -fsSLo /usr/share/keyrings/claude-desktop-archive-keyring.asc https://downloads.claude.ai/claude-desktop/key.asc && \
     echo "deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/claude-desktop-archive-keyring.asc] https://downloads.claude.ai/claude-desktop/apt/stable stable main" > /etc/apt/sources.list.d/claude-desktop.list && \
     apt-get update && \
-    apt-get install -y --no-install-recommends claude-desktop python3-pip && \
+    apt-get install -y --no-install-recommends claude-desktop python3-pip git gh && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/claude_desktop/README.md
+++ b/claude_desktop/README.md
@@ -22,6 +22,7 @@ Claude Desktop sign-in requires a claude.ai plan that supports the Desktop app. 
 - Persistent `$HOME` under `/config/data`, preserving Claude Desktop and Claude Code sign-in state across restarts.
 - Optional runtime Claude Desktop updates from Anthropic's apt repository.
 - Optional extra apt and pip package installation.
+- Baked-in `git` and GitHub CLI (`gh`) with optional startup credential configuration.
 - Custom script support through the repository standard `claude_desktop.sh` script.
 - Optional bundled Claude Code optimization tools: headroom, rtk, and caveman.
 - Low-power defaults: GPU device mapping, `AUTO_GPU=1`, `SELKIES_FRAMERATE=30`, `/tmp` tmpfs, and `$HOME/.cache` redirected to `/tmp/cache`.
@@ -40,6 +41,10 @@ Claude Desktop sign-in requires a claude.ai plan that supports the Desktop app. 
 | `install_headroom` | `true` | Make the baked-in `headroom` command available and log a usage hint. |
 | `install_rtk` | `true` | Configure the rtk Claude Code `PreToolUse` hook in the persistent Claude Code settings. |
 | `install_caveman` | `true` | Install the caveman Claude Code plugin into the persistent Claude Code home. |
+| `install_github_cli` | `true` | Enable first-start checks and setup for the baked-in `git` and `gh` commands. |
+| `github_token` | | Optional GitHub personal access token used to authenticate `gh` and configure Git credentials for GitHub. |
+| `github_username` | | Optional global Git author name. |
+| `github_email` | | Optional global Git author email. |
 | `additional_apps` | | Comma-separated Debian apt packages to install at startup, for example `htop,git`. |
 | `additional_pip` | | Comma-separated pip packages to install at startup. Installs use `--break-system-packages`. |
 | `data_location` | `/config/data` | Persistent home directory location. Keep this persistent so Claude sign-in survives restarts. |

--- a/claude_desktop/config.yaml
+++ b/claude_desktop/config.yaml
@@ -36,7 +36,11 @@ options:
   additional_apps: ""
   additional_pip: ""
   auto_update: true
+  github_email: ""
+  github_token: ""
+  github_username: ""
   install_caveman: true
+  install_github_cli: true
   install_headroom: true
   install_rtk: true
 panel_admin: false
@@ -64,7 +68,11 @@ schema:
   additional_apps: str?
   additional_pip: str?
   auto_update: bool?
+  github_email: str?
+  github_token: password?
+  github_username: str?
   install_caveman: bool
+  install_github_cli: bool
   install_headroom: bool
   install_rtk: bool
 slug: claude_desktop

--- a/claude_desktop/rootfs/etc/cont-init.d/83-github_cli.sh
+++ b/claude_desktop/rootfs/etc/cont-init.d/83-github_cli.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+set -o pipefail
+
+if ! bashio::config.true 'install_github_cli'; then
+    bashio::log.info "GitHub CLI setup disabled"
+    exit 0
+fi
+
+if ! command -v git > /dev/null 2>&1; then
+    bashio::log.warning "git is not available"
+fi
+
+if ! command -v gh > /dev/null 2>&1; then
+    bashio::log.warning "gh is not available"
+    exit 0
+fi
+
+if bashio::config.has_value 'github_username'; then
+    git config --global user.name "$(bashio::config 'github_username')"
+fi
+
+if bashio::config.has_value 'github_email'; then
+    git config --global user.email "$(bashio::config 'github_email')"
+fi
+
+if bashio::config.has_value 'github_token'; then
+    token="$(bashio::config 'github_token')"
+    mkdir -p "$HOME/.config/gh"
+    chmod 700 "$HOME/.config/gh"
+    export GH_TOKEN="$token"
+    export GITHUB_TOKEN="$token"
+    if gh auth status --hostname github.com > /dev/null 2>&1; then
+        bashio::log.info "GitHub CLI already authenticated for github.com"
+    else
+        bashio::log.info "Configuring GitHub CLI authentication for github.com"
+        printf '%s\n' "$token" | gh auth login --hostname github.com --with-token || bashio::log.warning "GitHub CLI authentication failed"
+    fi
+    gh auth setup-git --hostname github.com || bashio::log.warning "GitHub CLI git credential setup failed"
+else
+    bashio::log.info "GitHub CLI available. Set github_token to authenticate gh and git operations."
+fi


### PR DESCRIPTION
### Motivation
- Provide baked-in `git` and GitHub CLI (`gh`) with optional credential configuration so users can perform Git/GitHub operations from the add-on without rebuilding the image. 
- Ensure bundled Claude Code tooling (`rtk`, `headroom`, and `caveman`) are installed and usable from first start so Claude Code optimizations work immediately. 
- Expose configuration options to securely supply GitHub credentials and basic git identity for automated first-start setup.

### Description
- Install `git` and `gh` in the image by adding them to the apt install list in `claude_desktop/Dockerfile`. 
- Add add-on options `install_github_cli`, `github_token`, `github_username`, and `github_email` (and update schema defaults) in `claude_desktop/config.yaml`. 
- Add a first-start cont-init module `claude_desktop/rootfs/etc/cont-init.d/83-github_cli.sh` that configures global git name/email, authenticates `gh` using `github_token`, and runs `gh auth setup-git` when enabled. 
- Leave and rely on the existing `claude_desktop/rootfs/etc/cont-init.d/82-claude_tools.sh` and `Dockerfile` rtk/headroom install steps which install `headroom-ai[all]` (via pip) and run the official `rtk` installer at build time, move the `rtk` binary onto PATH, and configure hooks at first start when requested. 
- Update `README.md` to document the new options and `CHANGELOG.md` to note the change.

### Testing
- Performed shell syntax checks with `bash -n` on `82-claude_tools.sh`, `83-github_cli.sh`, and `80-configuration.sh`, and they passed. 
- Verified `claude_desktop/config.yaml` contains the new `install_github_cli` option using a Python assertion, which passed. 
- Validated the YAML loads successfully with `ruby -e 'require "yaml"; YAML.load_file("claude_desktop/config.yaml")'`, which succeeded. 
- No automated runtime integration tests were run; the changes are limited to image packages, cont-init startup scripts, config schema, and documentation and passed the static checks above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ce0ebedac832594c2cebe7ff5adc0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in support for Git and GitHub CLI.
  * Added optional startup configuration for GitHub credentials and Git identity details.
  * Included new setup options for GitHub username, email, token, and CLI installation control.

* **Documentation**
  * Updated the changelog and README to reflect the new GitHub-related setup options and defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->