### PR TITLE
Fix Claude Desktop optional tool startup

### DIFF
--- a/claude_desktop/rootfs/defaults/autostart
+++ b/claude_desktop/rootfs/defaults/autostart
@@ -13,4 +13,9 @@ dbus-update-activation-environment --all >/dev/null 2>&1 || true
 
 # --password-store=gnome-libsecret forces Electron onto the libsecret backend instead of
 # falling back to plaintext (and warning that the sign-in will not be saved).
-claude-desktop --no-sandbox --disable-dev-shm-usage --password-store=gnome-libsecret
+CLAUDE_DESKTOP_COMMAND_FILE="/tmp/claude-desktop-command"
+if [ -s "$CLAUDE_DESKTOP_COMMAND_FILE" ]; then
+    sh -c "$(cat "$CLAUDE_DESKTOP_COMMAND_FILE")"
+else
+    claude-desktop --no-sandbox --disable-dev-shm-usage --password-store=gnome-libsecret
+fi

--- a/claude_desktop/rootfs/etc/cont-init.d/82-claude_tools.sh
+++ b/claude_desktop/rootfs/etc/cont-init.d/82-claude_tools.sh
@@ -4,9 +4,14 @@ set -e
 set -o pipefail
 mkdir -p "$HOME/.claude"
 
+CLAUDE_DESKTOP_COMMAND_FILE="/tmp/claude-desktop-command"
+DEFAULT_CLAUDE_DESKTOP_COMMAND='claude-desktop --no-sandbox --disable-dev-shm-usage --password-store=gnome-libsecret'
+printf '%s\n' "$DEFAULT_CLAUDE_DESKTOP_COMMAND" > "$CLAUDE_DESKTOP_COMMAND_FILE"
+
 if bashio::config.true 'install_headroom'; then
     if command -v headroom &> /dev/null; then
-        bashio::log.info "headroom $(headroom --version 2> /dev/null || true) available. Use 'headroom wrap claude' or MCP mode from Claude Code."
+        bashio::log.info "headroom $(headroom --version 2> /dev/null || true) available; launching Claude Desktop through headroom"
+        printf '%s\n' "headroom wrap $DEFAULT_CLAUDE_DESKTOP_COMMAND" > "$CLAUDE_DESKTOP_COMMAND_FILE"
     else
         bashio::log.warning "headroom is not available"
     fi
@@ -14,11 +19,31 @@ fi
 
 if bashio::config.true 'install_rtk'; then
     if command -v rtk &> /dev/null; then
-        if [ -f "$HOME/.claude/settings.json" ] && grep -q 'rtk' "$HOME/.claude/settings.json"; then
+        if [ -f "$HOME/.claude/settings.json" ] && grep -q 'rtk hook claude' "$HOME/.claude/settings.json"; then
             bashio::log.info "rtk Claude Code hook already configured"
         else
             bashio::log.info "Configuring rtk Claude Code hook"
-            rtk init -g || bashio::log.warning "rtk hook configuration failed"
+            RTK_NONINTERACTIVE=1 rtk init -g || bashio::log.warning "rtk global files configuration failed"
+            python3 - <<'PY' || bashio::log.warning "Unable to configure rtk hook automatically"
+import json
+from pathlib import Path
+path = Path.home() / ".claude" / "settings.json"
+try:
+    data = json.loads(path.read_text()) if path.exists() else {}
+    if not isinstance(data, dict):
+        data = {}
+except Exception:
+    if path.exists():
+        path.rename(path.with_suffix(path.suffix + ".bak"))
+    data = {}
+hooks = data.setdefault("hooks", {})
+pre = hooks.setdefault("PreToolUse", [])
+rtk_entry = {"matcher": "Bash", "hooks": [{"type": "command", "command": "rtk hook claude"}]}
+if not any("rtk hook claude" in json.dumps(entry) for entry in pre if isinstance(entry, dict)):
+    pre.append(rtk_entry)
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps(data, indent=2) + "\n")
+PY
         fi
     else
         bashio::log.warning "rtk is not available"

--- a/claude_desktop/rootfs/etc/cont-init.d/83-github_cli.sh
+++ b/claude_desktop/rootfs/etc/cont-init.d/83-github_cli.sh
@@ -29,15 +29,13 @@ if bashio::config.has_value 'github_token'; then
     token="$(bashio::config 'github_token')"
     mkdir -p "$HOME/.config/gh"
     chmod 700 "$HOME/.config/gh"
-    export GH_TOKEN="$token"
-    export GITHUB_TOKEN="$token"
-    if gh auth status --hostname github.com > /dev/null 2>&1; then
+    if env -u GH_TOKEN -u GITHUB_TOKEN gh auth status --hostname github.com > /dev/null 2>&1; then
         bashio::log.info "GitHub CLI already authenticated for github.com"
     else
         bashio::log.info "Configuring GitHub CLI authentication for github.com"
-        printf '%s\n' "$token" | gh auth login --hostname github.com --with-token || bashio::log.warning "GitHub CLI authentication failed"
+        printf '%s\n' "$token" | env -u GH_TOKEN -u GITHUB_TOKEN gh auth login --hostname github.com --with-token || bashio::log.warning "GitHub CLI authentication failed"
     fi
-    gh auth setup-git --hostname github.com || bashio::log.warning "GitHub CLI git credential setup failed"
+    env -u GH_TOKEN -u GITHUB_TOKEN gh auth setup-git --hostname github.com || bashio::log.warning "GitHub CLI git credential setup failed"
 else
     bashio::log.info "GitHub CLI available. Set github_token to authenticate gh and git operations."
 fi


### PR DESCRIPTION
### Motivation
- Ensure `headroom` is used to launch Claude Desktop when the `install_headroom` option is enabled so headroom features (MCP/wrapping) are active by default.
- Configure the `rtk` Claude Code hook non-interactively and persistently to avoid a manual prompt leaving users with incomplete setup instructions.
- Allow `gh auth login --with-token` to persist credentials by avoiding `GH_TOKEN`/`GITHUB_TOKEN` in the environment during `gh` calls.

### Description
- Add runtime generation of a `/tmp/claude-desktop-command` file and set a default command in `claude_desktop/rootfs/etc/cont-init.d/82-claude_tools.sh` so other init logic can modify the command before launch.
- When `install_headroom` is enabled and `headroom` is available, write `headroom wrap <claude-command>` into the command file so the autostart will run Claude Desktop under `headroom`.
- Run `RTK_NONINTERACTIVE=1 rtk init -g` and inject the `PreToolUse` `rtk hook claude` entry directly into `~/.claude/settings.json` from the init script to ensure the RTK hook is registered persistently.
- Update `claude_desktop/rootfs/defaults/autostart` to execute the generated `/tmp/claude-desktop-command` if present, falling back to the default `claude-desktop` invocation.
- Update `claude_desktop/rootfs/etc/cont-init.d/83-github_cli.sh` to call `gh auth` and `gh auth setup-git` with `GH_TOKEN`/`GITHUB_TOKEN` unset (using `env -u`) so `gh` can store credentials instead of refusing due to environment tokens.

### Testing
- Verified shell syntax for the modified scripts with `bash -n claude_desktop/rootfs/etc/cont-init.d/82-claude_tools.sh` and `bash -n claude_desktop/rootfs/etc/cont-init.d/83-github_cli.sh`, which succeeded.
- Verified `sh -n claude_desktop/rootfs/defaults/autostart` succeeded and ran without syntax errors.
- Ran `git diff --check` to ensure no trailing whitespace or diff issues, which produced no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cf7b69c7883258b3a8ee959df3bb5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude Desktop can now launch a custom command from a temporary command file when one is provided.
  * Automatic setup now better supports optional tooling by applying configuration changes when available.

* **Bug Fixes**
  * Improved GitHub CLI sign-in reliability by ignoring pre-existing token environment settings.
  * Added safer handling for malformed settings so configuration can be recreated instead of failing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->