### PR TITLE
Fix/manyfold assume ssl redirect

### DIFF
--- a/manyfold/CHANGELOG.md
+++ b/manyfold/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.146.1-3 (2026-07-08)
+- Fix forced HTTPS redirect loop on the plain-HTTP UI by re-adding the `assume_ssl` disable workaround.
+- Export `PUBLIC_PORT` alongside `public_hostname` so generated links point at port 3214.
+- Document `public_hostname` in README (accepts hostname or server IP).
+
 ## 0.146.1-2 (06-07-2026)
 - Minor bugs fixed
  

--- a/manyfold/Dockerfile
+++ b/manyfold/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/manyfold3d/manyfold-solo:0.135.0
+ARG BUILD_FROM=ghcr.io/manyfold3d/manyfold-solo:latest
 FROM ${BUILD_FROM}
 
 # hadolint ignore=DL3041

--- a/manyfold/README.md
+++ b/manyfold/README.md
@@ -53,6 +53,7 @@ Local development alternative on the HA host:
 ## Options
 
 - `secret_key_base`: App secret used by Rails to sign/encrypt sessions and tokens. See [Secret Key Base](#secret-key-base) below.
+- `public_hostname`: Hostname or server IP used to generate links (mailer and "Open in slicer" download URLs). Leave blank to auto-detect from Home Assistant's configured external URL, falling back to `homeassistant.local`.
 - `puid` / `pgid`: Ownership applied to writable mapped directories (`/config` paths).
 - `multiuser`: Toggle Manyfold multiuser mode.
 - `library_path`: Scanned/indexed path.

--- a/manyfold/config.yaml
+++ b/manyfold/config.yaml
@@ -1,7 +1,7 @@
 name: "Manyfold"
 slug: manyfold
 description: "Manyfold 3D model manager as a Home Assistant add-on, using the upstream image with configurable library/index paths."
-version: "0.146.1-2"
+version: "0.146.1-3"
 url: "https://github.com/alexbelgium/hassio-addons/tree/master/manyfold"
 image: ghcr.io/alexbelgium/manyfold-{arch}
 arch:

--- a/manyfold/run.sh
+++ b/manyfold/run.sh
@@ -153,16 +153,39 @@ generate_secret() {
   head -c 64 /dev/urandom | od -An -tx1 | tr -d ' \n'
 }
 
+# Manyfold's production.rb sets config.assume_ssl = PUBLIC_HOSTNAME.present?,
+# with no separate env var to opt out. assume_ssl makes Rails treat every
+# request as if it arrived over HTTPS (for a proxy that terminates SSL
+# upstream), which is wrong here: this add-on serves plain HTTP directly on
+# port 3214 with no TLS termination, so it produces bad https:// redirects
+# (e.g. to /users/sign_in) that browsers can't complete. Force it back off
+# via an initializer dropped into whichever app directory is found, since we
+# still need PUBLIC_HOSTNAME set for correct link generation elsewhere.
+disable_assume_ssl() {
+  local app_dir="$1"
+  local initializer_dir="${app_dir}/config/initializers"
+  [[ -d "$initializer_dir" ]] || return 0
+
+  cat > "${initializer_dir}/manyfold_addon_disable_assume_ssl.rb" << 'EOF'
+# Added by the Manyfold Home Assistant add-on: this add-on has no
+# SSL-terminating reverse proxy in front of it, so assuming SSL produces
+# incorrect https:// redirects on a plain-HTTP port.
+Rails.application.config.assume_ssl = false
+EOF
+}
+
 start_manyfold() {
   if [[ -x /usr/src/app/bin/docker-entrypoint.sh ]]; then
     log "Starting Manyfold via /usr/src/app/bin/docker-entrypoint.sh foreman start"
     cd /usr/src/app
+    disable_assume_ssl /usr/src/app
     exec ./bin/docker-entrypoint.sh foreman start
   fi
 
   if [[ -x /app/bin/docker-entrypoint.sh ]]; then
     log "Starting Manyfold via /app/bin/docker-entrypoint.sh foreman start"
     cd /app
+    disable_assume_ssl /app
     exec ./bin/docker-entrypoint.sh foreman start
   fi
 
@@ -189,8 +212,10 @@ start_manyfold() {
 
   if [[ -d /usr/src/app ]]; then
     cd /usr/src/app
+    disable_assume_ssl /usr/src/app
   elif [[ -d /app ]]; then
     cd /app
+    disable_assume_ssl /app
   fi
 
   if command -v bundle >/dev/null 2>&1; then
@@ -272,6 +297,7 @@ export MANYFOLD_MULTIUSER="$MULTIUSER"
 export MANYFOLD_LIBRARY_PATH="$LIBRARY_PATH"
 export MANYFOLD_THUMBNAILS_PATH="$THUMBNAILS_PATH"
 export PUBLIC_HOSTNAME
+export PUBLIC_PORT="3214"
 export RAILS_LOG_LEVEL="$LOG_LEVEL"
 export MANYFOLD_LOG_LEVEL="$LOG_LEVEL"
 export WEB_CONCURRENCY


### PR DESCRIPTION
 ## Summary

- Re-add the `assume_ssl` disable workaround dropped during the public_hostname rewrite;  Manyfold's `config.assume_ssl = PUBLIC_HOSTNAME.present?` was forcing https:// redirects  on this add-on's plain-HTTP port, causing login redirect loops.
- Export `PUBLIC_PORT=3214` alongside `PUBLIC_HOSTNAME` so generated links (mailer, "Open in slicer") point at the right port instead of defaulting to 80/443.
- Document `public_hostname` in README — accepts hostname or server IP.
- Bump version to 0.146.1-3.
- Switch BUILD_FROM to manyfold-solo:latest so the pinned tag can no longer drift out of sync with config.yaml's version, since the addons_updater bot bumps version metadata but never touches the Dockerfile.

  ## Test plan on local machine according to [HAOS doc](https://developers.home-assistant.io/docs/apps/testing)
  - [x] Start add-on with `public_hostname` blank, confirm no forced https redirect on  login
  - [x] Set `public_hostname` to a LAN IP, confirm generated links use `http://<ip>:3214`
  - [x] Set `public_hostname` to a hostname, confirm same

For: https://github.com/alexbelgium/hassio-addons/issues/2808

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an HTTPS redirect loop when using the app over plain HTTP.
  * Generated links now consistently use the correct external port.

* **New Features**
  * Added support for configuring a public hostname or server IP for externally reachable links.

* **Documentation**
  * Updated setup guidance to explain the new hostname/IP option and how it behaves when left blank.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->