### PR TITLE
Fix builder after app updates

### DIFF
--- a/bazarr/config.yaml
+++ b/bazarr/config.yaml
@@ -113,4 +113,3 @@ slug: bazarr_nas
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/bazarr
 version: "1.6.0"
-webui: "[PROTO:ssl]://[HOST]:[PORT:6767]"

--- a/prowlarr/config.yaml
+++ b/prowlarr/config.yaml
@@ -111,4 +111,3 @@ slug: prowlarr
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 version: "nightly-2.5.1.5460-ls4"
-webui: "[PROTO:ssl]://[HOST]:[PORT:9696]"

--- a/qbittorrent/Dockerfile
+++ b/qbittorrent/Dockerfile
@@ -52,7 +52,7 @@ RUN \
     && echo 'WebUI\LocalHostAuth=false' >> /defaults/qBittorrent.conf \
     \
     # Add vuetorrent
-    && curl -f -s -S -O -J -L "$(curl -f -s -L https://api.github.com/repos/WDaan/VueTorrent/releases | grep -o "http.*vuetorrent.zip" | head -1)" >/dev/null \
+    && curl -f -s -S -O -J -L https://github.com/VueTorrent/VueTorrent/releases/latest/download/vuetorrent.zip >/dev/null \
     && unzip -o vuetorrent.zip -d / >/dev/null \
     && rm vuetorrent.zip >/dev/null
 

--- a/qbittorrent/rootfs/etc/cont-init.d/91-qbittorrent_configuration.sh
+++ b/qbittorrent/rootfs/etc/cont-init.d/91-qbittorrent_configuration.sh
@@ -198,7 +198,7 @@ if [ "$CUSTOMUI" = default ]; then
     sed -i '/AlternativeUIEnabled/d' qBittorrent.conf
     sed -i '/RootFolder/d' qBittorrent.conf
     # Update ingress webui
-    curl -f -s -S -O -J -L "$(curl -f -s -L https://api.github.com/repos/WDaan/VueTorrent/releases | grep -o "http.*vuetorrent.zip" | head -1)" > /dev/null
+    curl -f -s -S -O -J -L https://github.com/VueTorrent/VueTorrent/releases/latest/download/vuetorrent.zip > /dev/null
     unzip -o vuetorrent.zip -d / > /dev/null
     rm vuetorrent.zip
 fi
@@ -211,7 +211,7 @@ if bashio::config.has_value 'customUI' && [ ! "$CUSTOMUI" = default ] && [ ! "$C
     ### Download WebUI
     case $CUSTOMUI in
         "vuetorrent")
-            curl -f -s -S -J -L -o /webui/release.zip "$(curl -f -s -L https://api.github.com/repos/WDaan/VueTorrent/releases/latest | grep -o "http.*vuetorrent.zip" | head -1)" > /dev/null
+            curl -f -s -S -J -L -o /webui/release.zip https://github.com/VueTorrent/VueTorrent/releases/latest/download/vuetorrent.zip > /dev/null
             ;;
 
         "qbit-matUI")


### PR DESCRIPTION
﻿# Proposed Changes

Fix the builder failures seen after #2832 was merged:

- remove `webui` from Bazarr and Prowlarr because Ingress is enabled and the Home Assistant add-on linter rejects that combination
- download VueTorrent from the stable `releases/latest/download/vuetorrent.zip` URL instead of scraping the GitHub releases API, which returned an empty URL during the aarch64 qBittorrent build

These fixes should allow the Builder workflow to publish the new Bazarr, Prowlarr, and qBittorrent images that Home Assistant is trying to pull.

## Related Issues

Follow-up to #2832.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed explicit web interface URL templates from two add-on configurations, relying on the add-on’s default web UI behavior instead.
  * Improved the torrent client’s bundled VueTorrent web UI download by switching to a direct “latest release” link, improving reliability during setup/initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->