### PR TITLE
Rebuild qBittorrent 5.2.3 images

### DIFF
--- a/qbittorrent/CHANGELOG.md
+++ b/qbittorrent/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 5.2.3-1 (2026-07-09)
+
+- Rebuild images after VueTorrent download path fix
+
 ## 5.2.3 (2026-07-08)
 
 - Update to latest version from linuxserver/docker-qbittorrent (changelog : https://github.com/linuxserver/docker-qbittorrent/releases)

--- a/qbittorrent/config.yaml
+++ b/qbittorrent/config.yaml
@@ -143,4 +143,4 @@ schema:
 slug: qbittorrent
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "5.2.3"
+version: "5.2.3-1"


### PR DESCRIPTION
# Proposed Changes

Trigger a qBittorrent rebuild as 5.2.3-1 after the VueTorrent download path fix merged in #2833.

The previous 5.2.3 update changed qBittorrent files but the follow-up fix did not touch qbittorrent/config.yaml. The Builder workflow only processes add-ons whose config.* changes on master, so the aarch64 qBittorrent image was never published and Home Assistant keeps receiving 404 manifest unknown for ghcr.io/alexbelgium/qbittorrent-aarch64:5.2.3.

This keeps the upstream application version at 5.2.3 and publishes a rebuild tag for the add-on.

## Related Issues

Follow-up to #2832 and #2833.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rebuilt the container images to include the latest download path fix, improving download handling in VueTorrent.
* **Chores**
  * Updated the add-on release version to `5.2.3-1`.
  * Added a new changelog entry for the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->