### PR TITLE
Fix Claude Desktop Selkies startup

### DIFF
--- a/claude_desktop/Dockerfile
+++ b/claude_desktop/Dockerfile
@@ -74,8 +74,10 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /root/.cache
 
-# Fix startup
-RUN sed "1a\set +e" /etc/s6-overlay/s6-rc.d/svc-selkies/run
+# Fix Selkies startup when PulseAudio module initialization fails
+RUN if [ -f /etc/s6-overlay/s6-rc.d/svc-selkies/run ]; then \
+        sed -i "1a\set +e" /etc/s6-overlay/s6-rc.d/svc-selkies/run; \
+    fi
 
 # Modules
 ARG MODULES="00-banner.sh 00-global_var.sh 01-custom_script.sh 00-local_mounts.sh 00-smb_mounts.sh 90-dns_set.sh"

--- a/claude_desktop/config.yaml
+++ b/claude_desktop/config.yaml
@@ -90,5 +90,5 @@ slug: claude_desktop
 tmpfs: true
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "1.11"
+version: "1.12"
 video: true


### PR DESCRIPTION
### Motivation
- The Selkies s6 service can fail when PulseAudio module initialization errors cause the service `run` script to abort, triggering restarts and addon startup failures.
- The previous Dockerfile `sed` line did not reliably edit the Selkies `run` script in place during image build, so the `set +e` workaround was not applied.

### Description
- Modify `claude_desktop/Dockerfile` to conditionally insert `set +e` into `/etc/s6-overlay/s6-rc.d/svc-selkies/run` only if the file exists and using `sed -i` to edit the file in place.
- Bump the add-on version in `claude_desktop/config.yaml` from `1.11` to `1.12`.
- Commit the changes (commit message: "Fix Claude Desktop Selkies startup").

### Testing
- Ran `git diff --check` and it reported no whitespace errors, which succeeded.
- Validated the `version: "1.12"` change by running a Python snippet that checked the file contents, which succeeded.
- Verified the `sed` insertion behavior with a small shell test that prepended `set +e` to a temporary script, which showed the expected output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fb527f1ac83258af9a1438e7f3990)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup handling so the service tweak is applied only when the expected startup script is present, reducing the chance of launch failures.
  * Updated the surrounding startup note to better reflect the related audio/service issue.

* **Chores**
  * Bumped the add-on version to **1.12**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->