### PR TITLE
Clean up Claude terminal validation workflow

### DIFF
--- a/.github/workflows/pr2841-diagnostic.yml
+++ b/.github/workflows/pr2841-diagnostic.yml
@@ -1,5 +1,5 @@
 ---
-name: PR 2841 Build Diagnostic
+name: Claude Add-on Build Diagnostic
 
 on:
   pull_request:
@@ -8,7 +8,6 @@ on:
 
 jobs:
   diagnose:
-    if: ${{ github.event.pull_request.number == 2841 }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,16 +19,19 @@ jobs:
         with:
           path: ./claude_desktop/
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Build amd64 and capture tail
+      - name: Build aarch64 and capture tail
         shell: bash
         run: |
           set +e
-          BUILD_FROM="$(jq -r '.build_from.amd64 // empty' '${{ steps.information.outputs.build }}')"
+          BUILD_FROM="$(jq -r '.build_from.aarch64 // empty' '${{ steps.information.outputs.build }}')"
           docker buildx build \
-            --platform linux/amd64 \
+            --platform linux/arm64 \
             --progress=plain \
             --build-arg "BUILD_FROM=${BUILD_FROM}" \
             --file claude_desktop/Dockerfile \
@@ -42,7 +44,7 @@ jobs:
       - name: Upload diagnostic log
         uses: actions/upload-artifact@v4
         with:
-          name: pr2841-amd64-build-log
+          name: claude-aarch64-build-log
           path: |
             build-tail.log
             build-status.txt

--- a/claude_desktop/CHANGELOG.md
+++ b/claude_desktop/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Add `claude-headroom` for Headroom's supported wrapper, reusing the supervised proxy with `--no-proxy` while leaving RTK management to the add-on.
 - Keep Claude Desktop on the MCP-only Headroom integration and remove the ineffective `ANTHROPIC_BASE_URL` export from its launch environment.
 - Preserve ownership of Claude settings for the configured runtime user and remove only the exact add-on-managed RTK hook when RTK is disabled.
+- Fetch the repository-standard helper templates during image construction so the add-on builds from its actual Docker context.
+- Install only Headroom's proxy, code-compression, and MCP features instead of unused CUDA, voice, image, memory, and evaluation stacks.
 - Document the shared-home architecture, separate Desktop/CLI sessions, direct HTTP terminal security, shared concurrent sessions, and configurable data location.
 
 ## 1.12 (09-07-2026)


### PR DESCRIPTION
## Summary

Follow up on merged PR #2841 to complete aarch64 image validation and remove the temporary diagnostic workflow that was merged with the implementation.

## Current validation step

This draft temporarily runs an explicit `linux/arm64` Docker build and uploads the final build log. The workflow will be deleted from this branch after the aarch64 result is inspected, leaving only:

- removal of the temporary diagnostic workflow from `master`;
- changelog documentation for the repository helper-template build fix;
- changelog documentation for the reduced Headroom runtime feature set.

## Already validated

- Final amd64 Docker image: successful end-to-end build.
- Home Assistant add-on linter: successful.
- Repository Super Linter: successful.
- Shell syntax and YAML schema checks: successful.

## Context

PR #2841 was merged while its final validation was still running. Its functional fixes are now in `master`, including the lean `headroom-ai[proxy,code,mcp]` installation and the Docker-context helper fix. This follow-up ensures the temporary diagnostic workflow is not retained as production repository configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ARM64 build diagnostics for pull requests targeting the main branch.
  * Build logs are now uploaded as downloadable diagnostic artifacts.

* **Documentation**
  * Updated the changelog with details about repository-standard build templates and a streamlined Headroom installation containing only required features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->