### PR TITLE
Persist NPM Let's Encrypt certificates

### DIFF
--- a/nginx_webserver_proxy/CHANGELOG.md
+++ b/nginx_webserver_proxy/CHANGELOG.md
@@ -1,15 +1,13 @@
-## 2.14.1 (19-06-2026)
-- Minor bugs fixed
 # Changelog
 
-## 2.14.1
+## 2.14.1-1 (11-07-2026)
+- Persist Let's Encrypt certificates across restarts by symlinking /etc/letsencrypt to /data/letsencrypt (#2828) — thanks to @crazyrokr for reporting and suggesting the fix
+
+## 2.14.1 (19-06-2026)
 - Fix startup failure on aarch64/HAos: "/usr/bin/env: 'bash': Permission denied" (#2777)
 - Add s6-overlay/env/with-contenv exec rules to AppArmor profile
 
-## 2.14.0 
-- Minor bugs fixed
-
-## 2.14.0
+## 2.14.0 (01-05-2026)
 - Initial release wrapping jc21/nginx-proxy-manager:latest
 - NPM Admin UI on port 81; HTTP on port 80; HTTPS on port 443
 - Configurable static file server via NPM's default_host nginx config

--- a/nginx_webserver_proxy/config.yaml
+++ b/nginx_webserver_proxy/config.yaml
@@ -1,14 +1,13 @@
 name: "Nginx Proxy Manager + Static Web Server"
 slug: nginx_webserver_proxy
 description: "Nginx Proxy Manager with a built-in configurable static file server. Manage reverse proxies via NPM UI on port 81 while serving files from HA storage on port 80."
-version: "2.14.1"
+version: "2.14.1-1"
 url: "https://github.com/alexbelgium/hassio-addons/tree/master/nginx_webserver_proxy"
 arch:
   - amd64
   - aarch64
 startup: services
 init: false
-
 ports:
   80/tcp: 80
   81/tcp: 81
@@ -17,24 +16,19 @@ ports_description:
   80/tcp: "HTTP (static site + NPM proxy hosts)"
   81/tcp: "NPM Admin Web UI"
   443/tcp: "HTTPS (NPM proxy hosts)"
-
 webui: "http://[HOST]:[PORT:81]"
-
 map:
   - addon_config:rw
   - share:rw
   - media:rw
-
 options:
   static_site_enabled: true
   static_site_root: "/share/www"
   static_site_prefix: "/"
   log_level: "info"
-
 schema:
   static_site_enabled: bool
   static_site_root: str
   static_site_prefix: str
   log_level: list(info|debug|warn|error)
-
 image: "ghcr.io/alexbelgium/nginx_webserver_proxy-{arch}"

--- a/nginx_webserver_proxy/run.sh
+++ b/nginx_webserver_proxy/run.sh
@@ -115,7 +115,10 @@ log "static_site_root=${STATIC_ROOT} prefix=${STATIC_PREFIX} log_level=${LOG_LEV
 # Supervisor persists /data as a Docker volume; /etc/letsencrypt would otherwise be ephemeral.
 if [ ! -L /etc/letsencrypt ]; then
     if [ -d /etc/letsencrypt ] && [ "$(ls -A /etc/letsencrypt 2> /dev/null)" ]; then
-        cp -a /etc/letsencrypt/. /data/letsencrypt/ 2> /dev/null || true
+        # Abort migration on copy failure so we never rm -rf certs that weren't copied.
+        mkdir -p /data/letsencrypt
+        cp -a /etc/letsencrypt/. /data/letsencrypt/ \
+            || die "Failed to migrate /etc/letsencrypt to /data/letsencrypt; leaving existing certs intact"
     fi
     rm -rf /etc/letsencrypt
     ln -sf /data/letsencrypt /etc/letsencrypt

--- a/nginx_webserver_proxy/run.sh
+++ b/nginx_webserver_proxy/run.sh
@@ -111,8 +111,16 @@ fi
 # ---------------------------------------------------------------------------
 log "static_site_root=${STATIC_ROOT} prefix=${STATIC_PREFIX} log_level=${LOG_LEVEL}"
 # NPM's prepare service requires /etc/letsencrypt to exist.
-# HA Supervisor maps the ssl volume there automatically; for other environments create it.
-mkdir -p /etc/letsencrypt
+# Symlink /etc/letsencrypt to /data/letsencrypt for persistence across restarts.
+# Supervisor persists /data as a Docker volume; /etc/letsencrypt would otherwise be ephemeral.
+if [ ! -L /etc/letsencrypt ]; then
+    if [ -d /etc/letsencrypt ] && [ "$(ls -A /etc/letsencrypt 2> /dev/null)" ]; then
+        cp -a /etc/letsencrypt/. /data/letsencrypt/ 2> /dev/null || true
+    fi
+    rm -rf /etc/letsencrypt
+    ln -sf /data/letsencrypt /etc/letsencrypt
+fi
+mkdir -p /data/letsencrypt
 
 log "Handing off to NPM: exec /init"
 exec /init


### PR DESCRIPTION
Fixes #2828. Certbot writes LE certs (and DNS-challenge credentials) to /etc/letsencrypt, which is ephemeral in the container, so certs vanished on every restart and NPM failed to start any proxy host referencing them with "cannot load certificate ... No such file or directory".

run.sh now symlinks /etc/letsencrypt to /data/letsencrypt before handing off to NPM's boot, so certs live on the persisted /data volume. Existing certs from a real /etc/letsencrypt dir are migrated into /data on first run, and the step is idempotent when the symlink is already in place. This also covers the DNS-challenge credentials NPM writes under /etc/letsencrypt/credentials.

Audited every path NPM writes to and confirmed /etc/letsencrypt was the only persistence gap: everything else (database, keys, nginx  confs, custom_ssl, access lists, certbot --logs-dir) already lives under /data, and certbot's --work-dir at /tmp is correctly ephemeral.

Tested locally by building the image against jc21/nginx-proxy-manager:latest and exercising three cases: fresh install (symlink created), restart with a cert in the volume (cert readable at /etc/letsencrypt/live/npm-4/fullchain.pem — the exact path from the reported error), and upgrade from an existing real /etc/letsencrypt dir (certs migrated into /data, path swapped to symlink). 

Version bumped to 2.14.1-1 (docker release counter) and CHANGELOG updated.

Thanks to @crazyrokr for reporting and proposing the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent Let’s Encrypt certificate storage so certificates remain available after restarts or updates.

* **Bug Fixes**
  * Improved startup behavior by migrating existing Let’s Encrypt data to the persistent location when needed.
  * Updated add-on release metadata and changelog for the latest version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->