### PR TITLE
fix(elasticsearch): force fresh image pull for users stuck on a stale 7.17.9 image

### DIFF
--- a/elasticsearch/CHANGELOG.md
+++ b/elasticsearch/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.19.18-3 (14-07-2026)
+- Force a fresh image pull for users left on a stale cached image (some upgrades kept running the old Elasticsearch 7.17.9 image, failing with `mv: cannot move '/data/config' ... Permission denied` and `AccessDeniedException[/usr/share/elasticsearch/data/nodes/0]`). Fully stop and update the add-on so Home Assistant pulls this build.
+- Replaced the cryptic `Permission denied` failure with a clear message when the add-on is not running as root (the state that caused the failure above).
+
 ## 8.19.18-2 (14-07-2026)
 - Minor bugs fixed
 ## 8.19.18 (2026-07-14)

--- a/elasticsearch/config.yaml
+++ b/elasticsearch/config.yaml
@@ -90,4 +90,4 @@ slug: elasticsearch
 startup: services
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/elasticsearch
-version: 8.19.18-2
+version: 8.19.18-3

--- a/elasticsearch/rootfs/usr/local/bin/addon-init.sh
+++ b/elasticsearch/rootfs/usr/local/bin/addon-init.sh
@@ -31,6 +31,17 @@ PERSISTENT_HOME="/data"
 VERSION_MARKER="$PERSISTENT_HOME/.addon-upstream-version"
 OPTIONS_JSON="/data/options.json"
 
+# This first pass must be root so it can relocate and take ownership of
+# pre-existing /data content written by an earlier (root) install. If it
+# is not root (e.g. an old cached image that pinned USER 1000:0, or the
+# container being forced to another user), the moves/chowns below fail
+# with a cryptic "Permission denied"; fail loudly with the real reason.
+if [ "$(id -u)" -ne 0 ]; then
+    echo "FATAL: the Elasticsearch add-on must start as root (currently uid $(id -u))."
+    echo "If you upgraded from an older version, the running image is likely stale - fully stop and update/reinstall the add-on so Home Assistant pulls the current image."
+    exit 1
+fi
+
 ############################
 # 1 Export user env_vars   #
 ############################
@@ -94,7 +105,11 @@ if [ -n "$data_version" ] && [[ $current_major =~ ^[0-9]+$ ]]; then
         if [ -d "$PERSISTENT_HOME/config" ] && [ ! -L "$PERSISTENT_HOME/config" ]; then
             config_backup="$PERSISTENT_HOME/config.bak-$data_version"
             if [ ! -e "$config_backup" ]; then
-                mv "$PERSISTENT_HOME/config" "$config_backup"
+                if ! mv "$PERSISTENT_HOME/config" "$config_backup"; then
+                    echo "FATAL: could not archive the old config to $config_backup."
+                    echo "This add-on must run as root to migrate a previous install. Restore a Home Assistant backup and ensure the add-on is not forced to a non-root user."
+                    exit 1
+                fi
                 echo "NOTICE: previous config archived to $config_backup. Re-apply any custom settings to the new config."
             fi
         fi


### PR DESCRIPTION
## Context

Follow-up to #2853 / #2854. A user reported the add-on still failing after those merged, with this log:

```
NOTICE: one-time automatic data migration from Elasticsearch 7.17.9 to 8.19.18.
mv: cannot move '/data/config' to '/data/config.bak-7.17.9': Permission denied
...
version[7.17.9], build[...2023-01-31...]
AccessDeniedException[/usr/share/elasticsearch/data/nodes/0]
```

## Investigation

I verified the **published** images directly from ghcr (streamed the layers):

- `ghcr.io/alexbelgium/elasticsearch-amd64:8.19.18` and `:8.19.18-2` both contain **`elasticsearch-8.19.18.jar`** (real ES 8.19.18, not 7.17.9).
- Both have image config `User: root`.
- `master`'s `addon-init.sh` has the migration guard + `chroot --userspec=1000:0` privilege drop.

So the published image is correct. The reported log runs ES **7.17.9** and starts as a non-root user (hence the `mv` / `AccessDenied` on root-owned `/data`) — it is a **stale cached image** that Home Assistant / Docker never refreshed to the current build.

## Fix

- **Bump `8.19.18-2` → `8.19.18-3`** so HA pulls a fresh image tag instead of reusing the cached one. This is the actual remedy for affected users.
- **Add an explicit root check** on the first init pass (before any `mv`/`chown`) and wrap the config-archive `mv`, so a non-root start fails with a clear, actionable message ("the running image is likely stale — fully stop and update/reinstall") instead of the cryptic `Permission denied`. The re-exec'd uid-1000 pass returns before this check, so the privilege drop is unaffected.

## User remediation

Fully **stop** the add-on and **update** it (or uninstall/reinstall if no update shows) so HA pulls `8.19.18-3`. On the correct image, the init script runs as root, archives the old 7.17 config, `chown`s the data to uid 1000, then drops privileges and Elasticsearch 8.19.18 upgrades the indices.

## Testing

- shellcheck + shfmt (4-space) clean; hadolint (repo config) clean; config.yaml / updater.json validated.
- 25 sandbox tests pass (migration branches, env_vars, 401-healthy, real `chroot` privilege drop to uid 1000).
- New non-root first-pass verified to abort with the clear FATAL message; the `_ADDON_INIT_REEXEC` uid-1000 pass still returns early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clearer startup errors when the add-on is not running with root permissions.
  * Improved handling of configuration migration failures during upgrades.
  * Updated the add-on version to ensure fresh image pulls resolve stale-cache and permission issues.

* **Documentation**
  * Added changelog details for the updated release and migration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->