### PR TITLE
ci: bump builder build-image action to 2026.06.0

### DIFF
--- a/.github/workflows/onpush_builder.yaml
+++ b/.github/workflows/onpush_builder.yaml
@@ -300,7 +300,7 @@ jobs:
 
       - name: Build ${{ matrix.addon }} add-on
         if: steps.info.outputs.build_arch == 'true' && steps.info.outputs.has_dockerfile == 'true'
-        uses: home-assistant/builder/actions/build-image@2026.03.2
+        uses: home-assistant/builder/actions/build-image@2026.06.0
         with:
           arch: ${{ matrix.arch }}
           cache-gha: "false"
@@ -433,4 +433,3 @@ jobs:
           done
 
           git push origin HEAD:master
-  


### PR DESCRIPTION
## What

One-line pin bump in `.github/workflows/onpush_builder.yaml`:

`home-assistant/builder/actions/build-image@2026.03.2` → `@2026.06.0` (latest tag). Plus trailing-whitespace cleanup at EOF (yamllint).

## Why

home-assistant/builder deprecated the legacy monolithic builder in 2026.03.0 and removed it entirely in 2026.06.0. This repo already migrated to the modular `build-image` action in March 2026 — only the version pin needed updating.

## Compatibility

Diffed `actions/build-image/action.yml` between 2026.03.2 and 2026.06.0: no input/output changes, only internal dependency bumps (docker/login-action v4.2.0, setup-buildx v4.1.0, cosign-installer v4.1.2, build-push-action v7.2.0). All 13 inputs used by the workflow validated against the 2026.06.0 schema — no unknown inputs, no missing required inputs. Drop-in compatible.

Not adopted (intentionally): `prepare-multi-arch-matrix`/`publish-multi-arch-manifest` — repo publishes per-arch image names (`ghcr.io/alexbelgium/{slug}-{arch}`), manifest actions would force renaming `image:` in 120+ config.yaml files for no benefit. `cosign: false` and `cache-gha: false` kept as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)