### PR TITLE
feat(claude_desktop): expose SUDO_PASSWORD option (LinuxServer.io convention)

### DIFF
--- a/claude_desktop/CHANGELOG.md
+++ b/claude_desktop/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.23 (15-07-2026)
+
+- Expose `SUDO_PASSWORD`, per LinuxServer.io's base-image convention: setting it grants the `abc` user sudo access gated by that password. Sudo access stays disabled by default when left unset. Passed straight through by the existing option-to-env-var mechanism; no rootfs changes needed.
+
 ## 1.21 (15-07-2026)
 
 - Fix Claude Code bypass permissions being rejected when the add-on uses its default root `PUID`.

--- a/claude_desktop/README.md
+++ b/claude_desktop/README.md
@@ -92,6 +92,7 @@ Git synchronization hooks. A repository is indexed only when it is listed in
 | `TZ` | | Optional timezone, for example `Europe/Brussels`. |
 | `KEYBOARD` | | Optional Selkies keyboard layout. |
 | `PASSWORD` | | Optional password for direct Selkies ports. |
+| `SUDO_PASSWORD` | | LinuxServer.io convention: grants the `abc` user sudo access gated by this password. Sudo access is disabled by default when left unset. |
 | `DRINODE` | | Optional GPU device override for Selkies. |
 | `DNS_server` | `8.8.8.8` | DNS server used by the standard DNS module. |
 | `auto_update` | `true` | Upgrade `claude-desktop` from Anthropic's apt repository at startup. |

--- a/claude_desktop/config.yaml
+++ b/claude_desktop/config.yaml
@@ -74,6 +74,7 @@ schema:
   DRINODE: list(/dev/dri/card0|/dev/dri/card1|/dev/dri/card2|/dev/dri/renderD128|/dev/dri/renderD129|)?
   KEYBOARD: list(da-dk-qwerty|de-de-qwertz|en-gb-qwerty|en-us-qwerty|es-es-qwerty|fr-ch-qwertz|fr-fr-azerty|it-it-qwerty|ja-jp-qwerty|pt-br-qwerty|sv-se-qwerty|tr-tr-qwerty)?
   PASSWORD: str?
+  SUDO_PASSWORD: password?
   TZ: match([A-Z][a-z]*./[A-Z][a-z]*.)?
   additional_apps: str?
   additional_pip: str?
@@ -103,5 +104,5 @@ slug: claude_desktop
 tmpfs: true
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "1.22"
+version: "1.23"
 video: true


### PR DESCRIPTION
## What

Adds `SUDO_PASSWORD` as an add-on option, following LinuxServer.io's own convention: setting it grants the `abc` user sudo access gated by that password. Left unset (default), sudo access stays disabled.

## Why

The base image already supports this env var natively; the add-on just wasn't exposing it as a configurable option.

## How

- `config.yaml` — `SUDO_PASSWORD: password?` added to `schema` only, matching the existing `PASSWORD`/`TZ` pattern (advanced, optional, blank by default, no `options:` default needed). Version → 1.23.
- No rootfs changes: the existing `00-global_var.sh` module already exports every scalar key from `/data/options.json` as an environment variable, so `SUDO_PASSWORD` reaches the LinuxServer.io base image exactly like `PUID`/`PGID`/`TZ` do today, where its own init handles gating sudo.
- `README.md` / `CHANGELOG.md` updated.

## Testing

Config-only change (schema + docs), no code path added. Not build-tested; CI's Docker build / addon-linter cover that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `SUDO_PASSWORD` setting for enabling password-protected sudo access.
  * Sudo remains disabled by default when the setting is not provided.

* **Documentation**
  * Updated configuration documentation and the changelog to describe the new option.
  * Released as version 1.23.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->