### PR TITLE
Fix Gitea HEALTHCHECK in case of SSL setup

### DIFF
--- a/gitea/Dockerfile
+++ b/gitea/Dockerfile
@@ -133,4 +133,4 @@ HEALTHCHECK \
     --retries=5 \
     --start-period=30s \
     --timeout=25s \
-    CMD curl -A "HealthCheck: Docker/1.0" -s -f "http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f -k --http1.1 "$(cat /run/health_protocol 2>/dev/null || echo http)://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}" &>/dev/null || exit 1

--- a/gitea/rootfs/etc/cont-init.d/99-run.sh
+++ b/gitea/rootfs/etc/cont-init.d/99-run.sh
@@ -55,6 +55,7 @@ for file in /config/app.ini /etc/templates/app.ini; do
         PROTOCOL=http
         sed -i "/server/a PROTOCOL=http" "$file"
     fi
+    echo -n "${PROTOCOL}" > /run/health_protocol
 
     ##################
     # ADAPT ROOT_URL #


### PR DESCRIPTION
## What

Fix the Gitea add-on `HEALTHCHECK` to work correctly when SSL is enabled, so Home Assistant can accurately report the add-on's health status regardless of whether the instance uses HTTP or HTTPS.

## Why

The previous `HEALTHCHECK` command was hardcoded to use `http://` for its curl probe. When SSL is configured (`PROTOCOL=https`), the health check would fail because it connects over plain HTTP while the server expects HTTPS — causing Home Assistant to mark the add-on as "unhealthy" even though Gitea itself is running fine.

## How

1. `gitea/rootfs/etc/cont-init.d/99-run.sh` — After determining the protocol (http or https), write it to `/run/health_protocol`. This file acts as a small runtime hint that the `Dockerfile`'s health check reads at probe time.
2. `gitea/Dockerfile` — Update the `HEALTHCHECK` curl command to:
  - Read the protocol from `/run/health_protocol` (falling back to `http` if the file doesn't exist yet)
  - Add `-k` to skip SSL certificate verification (the health probe targets `localhost`, so we don't need to validate the cert chain)
  - Add `--http1.1` for compatibility with older curl/libcurl versions

## Changes

- `gitea/Dockerfile`: Make `HEALTHCHECK` protocol-aware with dynamic URL + `-k --http1.1` flags
- `gitea/rootfs/etc/cont-init.d/99-run.sh`: Write determined `PROTOCOL` to `/run/health_protocol`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container health checks to support both HTTP and HTTPS configurations.
  * Added compatibility for HTTP/1.1 and environments using TLS certificates that cannot be verified.
  * Health checks now automatically use the protocol configured during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->