### PR TITLE
Fix Free Games Claimer PR build context

### DIFF
--- a/.github/workflows/onpr_check-pr.yaml
+++ b/.github/workflows/onpr_check-pr.yaml
@@ -93,6 +93,21 @@ jobs:
       - name: ↩️ Checkout
         uses: actions/checkout@v7
 
+      - name: Copy templates into addon build context
+        env:
+          ADDON: ${{ matrix.addon }}
+        run: |
+          set -euo pipefail
+          TEMPLATES_DIR=".templates"
+          ADDON_DIR="./$ADDON"
+
+          # Keep PR builds aligned with the production builder.
+          for script in ha_automodules.sh ha_autoapps.sh ha_entrypoint.sh bashio-standalone.sh ha_lsio.sh; do
+            if [ -f "$TEMPLATES_DIR/$script" ]; then
+              cp "$TEMPLATES_DIR/$script" "$ADDON_DIR/$script"
+            fi
+          done
+
       - name: ℹ️ Gather addon info
         id: information
         uses: frenck/action-addon-information@v1.4

--- a/free_games_claimer/CHANGELOG.md
+++ b/free_games_claimer/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.1 (2026-07-17)
+
+- Aligned the pull-request build context with the production builder by copying
+  the shared Home Assistant helper scripts before building the add-on.
+- Fixed aarch64 and amd64 PR validation failing on unresolved Dockerfile
+  `COPY` instructions. Runtime and migration behavior are unchanged.
+
 ## 2.0.0 (2026-07-17)
 
 - Replaced the abandoned `vogler/free-games-claimer` upstream with

--- a/free_games_claimer/config.yaml
+++ b/free_games_claimer/config.yaml
@@ -1,3 +1,4 @@
+# Free Games Claimer Remaster
 arch:
   - aarch64
   - amd64
@@ -95,5 +96,5 @@ schema:
 slug: free_games_claimer
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "2.0.0"
+version: "2.0.1"
 webui: "[PROTO:ssl]://[HOST]:[PORT:6080]"


### PR DESCRIPTION
## Summary

- make the pull-request add-on builder copy the same shared Home Assistant helper scripts as the production builder
- fix the Free Games Claimer aarch64 build failing on unresolved Dockerfile `COPY` inputs
- bump Free Games Claimer to `2.0.1` and document the validation-only correction

## Root cause

The production workflow copies `ha_automodules.sh`, `ha_autoapps.sh`, `ha_entrypoint.sh`, `bashio-standalone.sh`, and `ha_lsio.sh` into each add-on Docker context before building. The PR workflow used only the add-on directory as context but omitted this preparation step. Consequently, the first architecture build failed before it could validate the remaster image.

## Scope

This aligns PR validation with the existing production behavior. It does not change the Free Games Claimer runtime, data migration, store selection, or authentication logic introduced in #2874.

## Validation

Free Games Claimer passed in workflow run `29564050875`:

- Home Assistant add-on lint: passed
- changelog check: passed
- aarch64 image build: passed
- amd64 image build: passed
- workflow Super-Linter: passed

The branch was then rebased onto the current `master` without changing any of the three validated blobs. It is one commit ahead, zero behind, and GitHub reports it mergeable. The post-rebase synchronization run only redetected the concurrent `birdnet-go-dev` base changes; those unrelated checks do not affect the validated Free Games Claimer result.

Follow-up to #2874.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pull-request validation failures on aarch64 and amd64 builds.
  * Improved build consistency by including required shared helper scripts during validation.

* **Chores**
  * Updated the Free Games Claimer add-on version to 2.0.1.
  * Added release notes documenting the build validation fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->