### PR TITLE
Fix Scrutiny startup without s6 supervision

### DIFF
--- a/scrutiny/CHANGELOG.md
+++ b/scrutiny/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## v1.67.0-2 (2026-07-18)
+- Fix startup with the Home Assistant entrypoint by removing the upstream collector's unsupported s6 service wait. The collector still waits for the Scrutiny API health endpoint before running.
+
 ## v1.67.0 (2026-07-18)
 - Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
  

--- a/scrutiny/Dockerfile
+++ b/scrutiny/Dockerfile
@@ -35,6 +35,12 @@ ENV S6_CMD_WAIT_FOR_SERVICES=1 \
 COPY rootfs/ /
 RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
 
+# The Home Assistant entrypoint starts services directly instead of running s6.
+# Scrutiny's collector already waits for the API health endpoint, so remove its s6-only wait.
+RUN if grep -q 's6-svwait -u /run/service/scrutiny' /etc/services.d/collector-once/run; then \
+        sed -i '\|s6-svwait -u /run/service/scrutiny|d' /etc/services.d/collector-once/run; \
+    fi
+
 # Uses /bin for compatibility purposes
 # hadolint ignore=DL4005
 RUN if [ ! -f /bin/sh ] && [ -f /usr/bin/sh ]; then ln -s /usr/bin/sh /bin/sh; fi && \

--- a/scrutiny/config.yaml
+++ b/scrutiny/config.yaml
@@ -113,4 +113,4 @@ schema:
 slug: scrutiny
 udev: true
 url: https://github.com/Starosdev/scrutiny
-version: "v1.67.0"
+version: "v1.67.0-2"

--- a/scrutiny_fa/CHANGELOG.md
+++ b/scrutiny_fa/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## v1.67.0-2 (2026-07-18)
+- Fix startup with the Home Assistant entrypoint by removing the upstream collector's unsupported s6 service wait. The collector still waits for the Scrutiny API health endpoint before running.
+
 ## v1.67.0 (2026-07-18)
 - Update to latest version from Starosdev/scrutiny (changelog : https://github.com/Starosdev/scrutiny/releases)
  

--- a/scrutiny_fa/Dockerfile
+++ b/scrutiny_fa/Dockerfile
@@ -35,6 +35,12 @@ ENV S6_CMD_WAIT_FOR_SERVICES=1 \
 COPY rootfs/ /
 RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
 
+# The Home Assistant entrypoint starts services directly instead of running s6.
+# Scrutiny's collector already waits for the API health endpoint, so remove its s6-only wait.
+RUN if grep -q 's6-svwait -u /run/service/scrutiny' /etc/services.d/collector-once/run; then \
+        sed -i '\|s6-svwait -u /run/service/scrutiny|d' /etc/services.d/collector-once/run; \
+    fi
+
 # Uses /bin for compatibility purposes
 # hadolint ignore=DL4005
 RUN if [ ! -f /bin/sh ] && [ -f /usr/bin/sh ]; then ln -s /usr/bin/sh /bin/sh; fi && \

--- a/scrutiny_fa/config.yaml
+++ b/scrutiny_fa/config.yaml
@@ -45,4 +45,4 @@ schema:
 slug: scrutiny_fa
 udev: true
 url: https://github.com/Starosdev/scrutiny
-version: "v1.67.0"
+version: "v1.67.0-2"


### PR DESCRIPTION
## Summary

- remove Scrutiny's inherited `s6-svwait -u /run/service/scrutiny` startup dependency in both `scrutiny` and `scrutiny_fa`
- retain the upstream `/api/health` readiness loop before the first collector run
- bump both add-ons to `v1.67.0-2` and document the fix

## Root cause

The Home Assistant add-on replaces upstream `/init` with `ha_entrypoint.sh`, which starts `/etc/services.d/*/run` scripts directly rather than creating an s6 supervision tree. Scrutiny 1.67's `collector-once` service still calls `s6-svwait` against `/run/service/scrutiny`, so it exits with code 111 because that service directory does not exist.

The following health-check loop in the same upstream script already provides the required synchronization with the web/API service, so removing only the s6-specific wait restores startup without weakening readiness handling.

## Validation

- verified the branch changes only the two Scrutiny variants
- exercised the Dockerfile `grep`/`sed` transformation against the upstream 1.67 `collector-once` script
- confirmed the `s6-svwait` line is removed while the `/api/health` wait remains

Closes #2877

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could prevent the Home Assistant integration from starting correctly.
  * Improved collector startup reliability while continuing to verify that the Scrutiny API is healthy before proceeding.
  * Updated the container health-check behavior for more dependable readiness detection.

* **Release**
  * Published patch version **v1.67.0-2** with the startup improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->