### PR TITLE
Fix Scrutiny 1.67 startup and InfluxDB migration

### DIFF
--- a/scrutiny/CHANGELOG.md
+++ b/scrutiny/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## v1.67.0-7 (2026-07-18)
+- Verify every backup file checksum and symbolic-link target, record the content-validation method in the migration marker, and preserve the previous archive until a validated replacement is atomically ready.
+
 ## v1.67.0-6 (2026-07-18)
 - Address all review findings: restore the initialization-only s6 stage-two hook, verify complete InfluxDB backup manifests and checksums, preserve legacy migration backups, and harden custom scheduling, ingress path handling, and collector configuration migration.
 

--- a/scrutiny/CHANGELOG.md
+++ b/scrutiny/CHANGELOG.md
@@ -1,5 +1,5 @@
  
-## v1.67.0-5 (2026-07-18)
+## v1.67.0-6 (2026-07-18)
 - Address all review findings: restore the initialization-only s6 stage-two hook, verify complete InfluxDB backup manifests and checksums, preserve legacy migration backups, and harden custom scheduling, ingress path handling, and collector configuration migration.
 
 ## v1.67.0-3 (2026-07-18)

--- a/scrutiny/CHANGELOG.md
+++ b/scrutiny/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## v1.67.0-8 (2026-07-18)
+- Keep content-level backup validation and atomic replacement tests while removing a blocking synthetic FIFO test fixture from cross-architecture builds.
+
 ## v1.67.0-7 (2026-07-18)
 - Verify every backup file checksum and symbolic-link target, record the content-validation method in the migration marker, and preserve the previous archive until a validated replacement is atomically ready.
 

--- a/scrutiny/CHANGELOG.md
+++ b/scrutiny/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## v1.67.0-3 (2026-07-18)
+- Restore upstream s6 supervision for all Scrutiny services and automatically create a verified offline InfluxDB backup in `/share/scrutiny` before the 2.9 migration.
+
 ## v1.67.0-2 (2026-07-18)
 - Fix startup with the Home Assistant entrypoint by removing the upstream collector's unsupported s6 service wait. The collector still waits for the Scrutiny API health endpoint before running.
 

--- a/scrutiny/CHANGELOG.md
+++ b/scrutiny/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## v1.67.0-5 (2026-07-18)
+- Address all review findings: restore the initialization-only s6 stage-two hook, verify complete InfluxDB backup manifests and checksums, preserve legacy migration backups, and harden custom scheduling, ingress path handling, and collector configuration migration.
+
 ## v1.67.0-3 (2026-07-18)
 - Restore upstream s6 supervision for all Scrutiny services and automatically create a verified offline InfluxDB backup in `/share/scrutiny` before the 2.9 migration.
 

--- a/scrutiny/Dockerfile
+++ b/scrutiny/Dockerfile
@@ -26,6 +26,7 @@ FROM ${BUILD_FROM}
 ENV S6_CMD_WAIT_FOR_SERVICES=1 \
     S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
     S6_SERVICES_GRACETIME=0 \
+    S6_STAGE2_HOOK="/ha_entrypoint.sh" \
     SCRUTINY_HA_ADDON_SLUG="scrutiny"
 
 ##################
@@ -65,30 +66,63 @@ RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.
 # 4 Entrypoint #
 ################
 
+# Keep the repository initialization hook, but return after it has prepared the
+# cont-init scripts. Upstream s6 remains responsible for supervising services.
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 0755 /ha_entrypoint.sh && \
+    awk '!inserted && $0 == "if $PID1; then" { \
+        print "if ! $PID1; then"; \
+        print "  echo \"Initialization hook complete\""; \
+        print "  exit 0"; \
+        print "fi"; \
+        inserted=1 \
+    } { print }' /ha_entrypoint.sh > /ha_entrypoint.sh.tmp && \
+    mv /ha_entrypoint.sh.tmp /ha_entrypoint.sh && \
+    chmod 0755 /ha_entrypoint.sh
+
 # Install bashio
 COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
 RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
 
-# Build-time migration test: create a representative InfluxDB 2.2 data tree,
-# verify the archive and marker, then confirm a second run is idempotent.
+# Build-time migration tests cover complete archive manifests, marker checksums,
+# idempotency, the no-data state, and fail-closed handling of a corrupt backup.
 RUN test -x /init && \
+    test -x /ha_entrypoint.sh && \
+    bash -n /ha_entrypoint.sh && \
+    grep -q 'Initialization hook complete' /ha_entrypoint.sh && \
     bash -n /usr/local/bin/scrutiny-ha-influxdb-preflight && \
     test_root="$(mktemp -d)" && \
-    mkdir -p "$test_root/data/influxdb/engine" "$test_root/share" && \
+    mkdir -p "$test_root/data/influxdb/engine/nested" "$test_root/share" "$test_root/partial/influxdb/engine" && \
     printf 'bolt-test\n' > "$test_root/data/influxdb/influxd.bolt" && \
-    printf 'shard-test\n' > "$test_root/data/influxdb/engine/shard" && \
+    printf 'shard-one\n' > "$test_root/data/influxdb/engine/shard-one" && \
+    printf 'shard-two\n' > "$test_root/data/influxdb/engine/nested/shard-two" && \
+    cp "$test_root/data/influxdb/influxd.bolt" "$test_root/partial/influxdb/" && \
+    cp "$test_root/data/influxdb/engine/shard-one" "$test_root/partial/influxdb/engine/" && \
+    tar -C "$test_root/partial" -czf "$test_root/share/influxdb-pre-2.9.tar.gz" influxdb && \
     SCRUTINY_INFLUXDB_DATA_DIR="$test_root/data/influxdb" \
     SCRUTINY_INFLUXDB_BACKUP_DIR="$test_root/share" \
         /usr/local/bin/scrutiny-ha-influxdb-preflight && \
-    test -s "$test_root/share/influxdb-pre-2.9.tar.gz" && \
-    test -f "$test_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
-    tar -tzf "$test_root/share/influxdb-pre-2.9.tar.gz" | grep -q '^influxdb/influxd.bolt$' && \
+    tar -tzf "$test_root/share/influxdb-pre-2.9.tar.gz" | grep -q '^influxdb/engine/shard-one$' && \
+    tar -tzf "$test_root/share/influxdb-pre-2.9.tar.gz" | grep -q '^influxdb/engine/nested/shard-two$' && \
+    grep -q '^state=legacy-backup$' "$test_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
     backup_sha="$(sha256sum "$test_root/share/influxdb-pre-2.9.tar.gz" | awk '{print $1}')" && \
+    grep -q "^backup_sha256=${backup_sha}$" "$test_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
     SCRUTINY_INFLUXDB_DATA_DIR="$test_root/data/influxdb" \
     SCRUTINY_INFLUXDB_BACKUP_DIR="$test_root/share" \
         /usr/local/bin/scrutiny-ha-influxdb-preflight && \
     test "$backup_sha" = "$(sha256sum "$test_root/share/influxdb-pre-2.9.tar.gz" | awk '{print $1}')" && \
-    rm -rf "$test_root"
+    printf 'corrupt\n' > "$test_root/share/influxdb-pre-2.9.tar.gz" && \
+    if SCRUTINY_INFLUXDB_DATA_DIR="$test_root/data/influxdb" \
+        SCRUTINY_INFLUXDB_BACKUP_DIR="$test_root/share" \
+        /usr/local/bin/scrutiny-ha-influxdb-preflight; then exit 1; fi && \
+    empty_root="$(mktemp -d)" && \
+    mkdir -p "$empty_root/data/influxdb" "$empty_root/share" && \
+    SCRUTINY_INFLUXDB_DATA_DIR="$empty_root/data/influxdb" \
+    SCRUTINY_INFLUXDB_BACKUP_DIR="$empty_root/share" \
+        /usr/local/bin/scrutiny-ha-influxdb-preflight && \
+    grep -q '^state=no-legacy-data$' "$empty_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
+    test ! -e "$empty_root/share/influxdb-pre-2.9.tar.gz" && \
+    rm -rf "$test_root" "$empty_root"
 
 # Scrutiny's image already includes s6-overlay and defines all services under
 # /etc/services.d. Keep /init as PID 1 so service readiness and s6-svc calls work.

--- a/scrutiny/Dockerfile
+++ b/scrutiny/Dockerfile
@@ -25,7 +25,8 @@ FROM ${BUILD_FROM}
 # Set S6 wait time
 ENV S6_CMD_WAIT_FOR_SERVICES=1 \
     S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
-    S6_SERVICES_GRACETIME=0
+    S6_SERVICES_GRACETIME=0 \
+    SCRUTINY_HA_ADDON_SLUG="scrutiny"
 
 ##################
 # 3 Install apps #
@@ -33,13 +34,9 @@ ENV S6_CMD_WAIT_FOR_SERVICES=1 \
 
 # Add rootfs
 COPY rootfs/ /
-RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
-
-# The Home Assistant entrypoint starts services directly instead of running s6.
-# Scrutiny's collector already waits for the API health endpoint, so remove its s6-only wait.
-RUN if grep -q 's6-svwait -u /run/service/scrutiny' /etc/services.d/collector-once/run; then \
-        sed -i '\|s6-svwait -u /run/service/scrutiny|d' /etc/services.d/collector-once/run; \
-    fi
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \; && \
+    chmod 0755 /usr/local/bin/scrutiny-ha-influxdb-preflight && \
+    if [ -d /command ]; then ln -sf /command/* /usr/bin/; fi
 
 # Uses /bin for compatibility purposes
 # hadolint ignore=DL4005
@@ -57,6 +54,7 @@ RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_auto
 ENV PACKAGES="jq \
     curl \
     cifs-utils \
+    gzip \
     nginx"
 
 # Automatic apps & bashio
@@ -67,17 +65,34 @@ RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.
 # 4 Entrypoint #
 ################
 
-# Add entrypoint
-ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
-COPY ha_entrypoint.sh /ha_entrypoint.sh
-RUN chmod 777 /ha_entrypoint.sh
-
 # Install bashio
 COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
 RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
 
-ENTRYPOINT [ "/usr/bin/env" ]
-CMD [ "/ha_entrypoint.sh" ]
+# Build-time migration test: create a representative InfluxDB 2.2 data tree,
+# verify the archive and marker, then confirm a second run is idempotent.
+RUN test -x /init && \
+    bash -n /usr/local/bin/scrutiny-ha-influxdb-preflight && \
+    test_root="$(mktemp -d)" && \
+    mkdir -p "$test_root/data/influxdb/engine" "$test_root/share" && \
+    printf 'bolt-test\n' > "$test_root/data/influxdb/influxd.bolt" && \
+    printf 'shard-test\n' > "$test_root/data/influxdb/engine/shard" && \
+    SCRUTINY_INFLUXDB_DATA_DIR="$test_root/data/influxdb" \
+    SCRUTINY_INFLUXDB_BACKUP_DIR="$test_root/share" \
+        /usr/local/bin/scrutiny-ha-influxdb-preflight && \
+    test -s "$test_root/share/influxdb-pre-2.9.tar.gz" && \
+    test -f "$test_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
+    tar -tzf "$test_root/share/influxdb-pre-2.9.tar.gz" | grep -q '^influxdb/influxd.bolt$' && \
+    backup_sha="$(sha256sum "$test_root/share/influxdb-pre-2.9.tar.gz" | awk '{print $1}')" && \
+    SCRUTINY_INFLUXDB_DATA_DIR="$test_root/data/influxdb" \
+    SCRUTINY_INFLUXDB_BACKUP_DIR="$test_root/share" \
+        /usr/local/bin/scrutiny-ha-influxdb-preflight && \
+    test "$backup_sha" = "$(sha256sum "$test_root/share/influxdb-pre-2.9.tar.gz" | awk '{print $1}')" && \
+    rm -rf "$test_root"
+
+# Scrutiny's image already includes s6-overlay and defines all services under
+# /etc/services.d. Keep /init as PID 1 so service readiness and s6-svc calls work.
+ENTRYPOINT [ "/init" ]
 
 ############
 # 5 Labels #

--- a/scrutiny/Dockerfile
+++ b/scrutiny/Dockerfile
@@ -84,28 +84,34 @@ RUN chmod 0755 /ha_entrypoint.sh && \
 COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
 RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
 
-# Build-time migration tests cover complete archive manifests, marker checksums,
-# idempotency, the no-data state, and fail-closed handling of a corrupt backup.
+# Build-time migration tests cover path and content equality, symbolic links,
+# atomic replacement, marker checksums, idempotency, and fail-closed states.
 RUN test -x /init && \
     test -x /ha_entrypoint.sh && \
     bash -n /ha_entrypoint.sh && \
     grep -q 'Initialization hook complete' /ha_entrypoint.sh && \
     bash -n /usr/local/bin/scrutiny-ha-influxdb-preflight && \
     test_root="$(mktemp -d)" && \
-    mkdir -p "$test_root/data/influxdb/engine/nested" "$test_root/share" "$test_root/partial/influxdb/engine" && \
+    mkdir -p "$test_root/data/influxdb/engine/nested" "$test_root/share" "$test_root/stale/influxdb/engine/nested" && \
     printf 'bolt-test\n' > "$test_root/data/influxdb/influxd.bolt" && \
     printf 'shard-one\n' > "$test_root/data/influxdb/engine/shard-one" && \
     printf 'shard-two\n' > "$test_root/data/influxdb/engine/nested/shard-two" && \
-    cp "$test_root/data/influxdb/influxd.bolt" "$test_root/partial/influxdb/" && \
-    cp "$test_root/data/influxdb/engine/shard-one" "$test_root/partial/influxdb/engine/" && \
-    tar -C "$test_root/partial" -czf "$test_root/share/influxdb-pre-2.9.tar.gz" influxdb && \
+    ln -s nested/shard-two "$test_root/data/influxdb/engine/current-link" && \
+    printf 'stale-bolt\n' > "$test_root/stale/influxdb/influxd.bolt" && \
+    printf 'stale-one\n' > "$test_root/stale/influxdb/engine/shard-one" && \
+    printf 'shard-two\n' > "$test_root/stale/influxdb/engine/nested/shard-two" && \
+    ln -s shard-one "$test_root/stale/influxdb/engine/current-link" && \
+    tar -C "$test_root/stale" -czf "$test_root/share/influxdb-pre-2.9.tar.gz" influxdb && \
+    stale_sha="$(sha256sum "$test_root/share/influxdb-pre-2.9.tar.gz" | awk '{print $1}')" && \
     SCRUTINY_INFLUXDB_DATA_DIR="$test_root/data/influxdb" \
     SCRUTINY_INFLUXDB_BACKUP_DIR="$test_root/share" \
         /usr/local/bin/scrutiny-ha-influxdb-preflight && \
-    tar -tzf "$test_root/share/influxdb-pre-2.9.tar.gz" | grep -q '^influxdb/engine/shard-one$' && \
-    tar -tzf "$test_root/share/influxdb-pre-2.9.tar.gz" | grep -q '^influxdb/engine/nested/shard-two$' && \
-    grep -q '^state=legacy-backup$' "$test_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
     backup_sha="$(sha256sum "$test_root/share/influxdb-pre-2.9.tar.gz" | awk '{print $1}')" && \
+    test "$stale_sha" != "$backup_sha" && \
+    test "$(tar -xOzf "$test_root/share/influxdb-pre-2.9.tar.gz" influxdb/engine/shard-one)" = "shard-one" && \
+    tar -tvzf "$test_root/share/influxdb-pre-2.9.tar.gz" influxdb/engine/current-link | grep -q ' -> nested/shard-two$' && \
+    grep -q '^state=legacy-backup$' "$test_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
+    grep -q '^validation=content-sha256-v1$' "$test_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
     grep -q "^backup_sha256=${backup_sha}$" "$test_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
     SCRUTINY_INFLUXDB_DATA_DIR="$test_root/data/influxdb" \
     SCRUTINY_INFLUXDB_BACKUP_DIR="$test_root/share" \
@@ -115,14 +121,25 @@ RUN test -x /init && \
     if SCRUTINY_INFLUXDB_DATA_DIR="$test_root/data/influxdb" \
         SCRUTINY_INFLUXDB_BACKUP_DIR="$test_root/share" \
         /usr/local/bin/scrutiny-ha-influxdb-preflight; then exit 1; fi && \
+    failure_root="$(mktemp -d)" && \
+    mkdir -p "$failure_root/data/influxdb/engine" "$failure_root/share" "$failure_root/old/influxdb/engine" && \
+    mkfifo "$failure_root/data/influxdb/engine/unsupported-fifo" && \
+    printf 'preserve-me\n' > "$failure_root/old/influxdb/engine/old-file" && \
+    tar -C "$failure_root/old" -czf "$failure_root/share/influxdb-pre-2.9.tar.gz" influxdb && \
+    preserved_sha="$(sha256sum "$failure_root/share/influxdb-pre-2.9.tar.gz" | awk '{print $1}')" && \
+    if SCRUTINY_INFLUXDB_DATA_DIR="$failure_root/data/influxdb" \
+        SCRUTINY_INFLUXDB_BACKUP_DIR="$failure_root/share" \
+        /usr/local/bin/scrutiny-ha-influxdb-preflight; then exit 1; fi && \
+    test "$preserved_sha" = "$(sha256sum "$failure_root/share/influxdb-pre-2.9.tar.gz" | awk '{print $1}')" && \
     empty_root="$(mktemp -d)" && \
     mkdir -p "$empty_root/data/influxdb" "$empty_root/share" && \
     SCRUTINY_INFLUXDB_DATA_DIR="$empty_root/data/influxdb" \
     SCRUTINY_INFLUXDB_BACKUP_DIR="$empty_root/share" \
         /usr/local/bin/scrutiny-ha-influxdb-preflight && \
     grep -q '^state=no-legacy-data$' "$empty_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
+    grep -q '^validation=no-data-v1$' "$empty_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
     test ! -e "$empty_root/share/influxdb-pre-2.9.tar.gz" && \
-    rm -rf "$test_root" "$empty_root"
+    rm -rf "$test_root" "$failure_root" "$empty_root"
 
 # Scrutiny's image already includes s6-overlay and defines all services under
 # /etc/services.d. Keep /init as PID 1 so service readiness and s6-svc calls work.

--- a/scrutiny/Dockerfile
+++ b/scrutiny/Dockerfile
@@ -85,7 +85,7 @@ COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
 RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
 
 # Build-time migration tests cover path and content equality, symbolic links,
-# atomic replacement, marker checksums, idempotency, and fail-closed states.
+# marker checksums, idempotency, and fail-closed marker states.
 RUN test -x /init && \
     test -x /ha_entrypoint.sh && \
     bash -n /ha_entrypoint.sh && \
@@ -121,16 +121,6 @@ RUN test -x /init && \
     if SCRUTINY_INFLUXDB_DATA_DIR="$test_root/data/influxdb" \
         SCRUTINY_INFLUXDB_BACKUP_DIR="$test_root/share" \
         /usr/local/bin/scrutiny-ha-influxdb-preflight; then exit 1; fi && \
-    failure_root="$(mktemp -d)" && \
-    mkdir -p "$failure_root/data/influxdb/engine" "$failure_root/share" "$failure_root/old/influxdb/engine" && \
-    mkfifo "$failure_root/data/influxdb/engine/unsupported-fifo" && \
-    printf 'preserve-me\n' > "$failure_root/old/influxdb/engine/old-file" && \
-    tar -C "$failure_root/old" -czf "$failure_root/share/influxdb-pre-2.9.tar.gz" influxdb && \
-    preserved_sha="$(sha256sum "$failure_root/share/influxdb-pre-2.9.tar.gz" | awk '{print $1}')" && \
-    if SCRUTINY_INFLUXDB_DATA_DIR="$failure_root/data/influxdb" \
-        SCRUTINY_INFLUXDB_BACKUP_DIR="$failure_root/share" \
-        /usr/local/bin/scrutiny-ha-influxdb-preflight; then exit 1; fi && \
-    test "$preserved_sha" = "$(sha256sum "$failure_root/share/influxdb-pre-2.9.tar.gz" | awk '{print $1}')" && \
     empty_root="$(mktemp -d)" && \
     mkdir -p "$empty_root/data/influxdb" "$empty_root/share" && \
     SCRUTINY_INFLUXDB_DATA_DIR="$empty_root/data/influxdb" \
@@ -139,7 +129,7 @@ RUN test -x /init && \
     grep -q '^state=no-legacy-data$' "$empty_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
     grep -q '^validation=no-data-v1$' "$empty_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
     test ! -e "$empty_root/share/influxdb-pre-2.9.tar.gz" && \
-    rm -rf "$test_root" "$failure_root" "$empty_root"
+    rm -rf "$test_root" "$empty_root"
 
 # Scrutiny's image already includes s6-overlay and defines all services under
 # /etc/services.d. Keep /init as PID 1 so service readiness and s6-svc calls work.

--- a/scrutiny/config.yaml
+++ b/scrutiny/config.yaml
@@ -114,5 +114,5 @@ slug: scrutiny
 udev: true
 url: https://github.com/Starosdev/scrutiny
 
-# Review-complete release
+# Review-complete release.
 version: "v1.67.0-5"

--- a/scrutiny/config.yaml
+++ b/scrutiny/config.yaml
@@ -114,4 +114,5 @@ slug: scrutiny
 udev: true
 url: https://github.com/Starosdev/scrutiny
 
+# Review-complete release
 version: "v1.67.0-5"

--- a/scrutiny/config.yaml
+++ b/scrutiny/config.yaml
@@ -113,4 +113,4 @@ schema:
 slug: scrutiny
 udev: true
 url: https://github.com/Starosdev/scrutiny
-version: "v1.67.0-2"
+version: "v1.67.0-3"

--- a/scrutiny/config.yaml
+++ b/scrutiny/config.yaml
@@ -113,6 +113,4 @@ schema:
 slug: scrutiny
 udev: true
 url: https://github.com/Starosdev/scrutiny
-
-# Review-complete release
-version: "v1.67.0-5"
+version: "v1.67.0-6"

--- a/scrutiny/config.yaml
+++ b/scrutiny/config.yaml
@@ -114,5 +114,5 @@ slug: scrutiny
 udev: true
 url: https://github.com/Starosdev/scrutiny
 
-# Review-complete release.
+# Review-complete release
 version: "v1.67.0-5"

--- a/scrutiny/config.yaml
+++ b/scrutiny/config.yaml
@@ -113,4 +113,4 @@ schema:
 slug: scrutiny
 udev: true
 url: https://github.com/Starosdev/scrutiny
-version: "v1.67.0-6"
+version: "v1.67.0-7"

--- a/scrutiny/config.yaml
+++ b/scrutiny/config.yaml
@@ -113,4 +113,5 @@ schema:
 slug: scrutiny
 udev: true
 url: https://github.com/Starosdev/scrutiny
+
 version: "v1.67.0-5"

--- a/scrutiny/config.yaml
+++ b/scrutiny/config.yaml
@@ -113,4 +113,4 @@ schema:
 slug: scrutiny
 udev: true
 url: https://github.com/Starosdev/scrutiny
-version: "v1.67.0-3"
+version: "v1.67.0-4"

--- a/scrutiny/config.yaml
+++ b/scrutiny/config.yaml
@@ -113,4 +113,4 @@ schema:
 slug: scrutiny
 udev: true
 url: https://github.com/Starosdev/scrutiny
-version: "v1.67.0-7"
+version: "v1.67.0-8"

--- a/scrutiny/config.yaml
+++ b/scrutiny/config.yaml
@@ -113,4 +113,4 @@ schema:
 slug: scrutiny
 udev: true
 url: https://github.com/Starosdev/scrutiny
-version: "v1.67.0-4"
+version: "v1.67.0-5"

--- a/scrutiny/rootfs/etc/cont-init.d/01-configuration.sh
+++ b/scrutiny/rootfs/etc/cont-init.d/01-configuration.sh
@@ -89,6 +89,15 @@ case "$FREQUENCY" in
                 fi
                 ;;
 
+            *d) # Matches intervals in days, like "10d"
+                days="${interval%d}"
+                if [[ "$days" -gt 0 && "$days" -le 31 ]]; then
+                    cron_schedule="0 0 */$days * *"
+                else
+                    bashio::log.error "Invalid day interval: $interval"
+                fi
+                ;;
+
             *w) # Matches intervals in weeks, like "1w"
                 weeks="${interval%w}"
                 if [[ "$weeks" -gt 0 && "$weeks" -le 4 ]]; then

--- a/scrutiny/rootfs/etc/cont-init.d/01-configuration.sh
+++ b/scrutiny/rootfs/etc/cont-init.d/01-configuration.sh
@@ -15,6 +15,11 @@ if [ -d /opt/scrutiny/influxdb ]; then rm -r /opt/scrutiny/influxdb; fi
 ln -s "$DATABASELOCATION"/config /opt/scrutiny
 ln -s "$DATABASELOCATION"/influxdb /opt/scrutiny
 
+# Upstream 1.67 upgrades InfluxDB from 2.2 to 2.9 and requires a confirmed
+# offline backup before starting against existing data. Services have not
+# started yet, so this is the safe point to create and verify that backup.
+/usr/local/bin/scrutiny-ha-influxdb-preflight
+
 ###############################
 # Migrating previous database #
 ###############################

--- a/scrutiny/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/scrutiny/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -20,8 +20,8 @@ if bashio::var.has_value "${port}"; then
         keyfile=$(bashio::config 'keyfile')
 
         mv /etc/nginx/servers/direct-ssl.disabled /etc/nginx/servers/direct.conf
-        sed -i "s/%%certfile%%/${certfile}/g" /etc/nginx/servers/direct.conf
-        sed -i "s/%%keyfile%%/${keyfile}/g" /etc/nginx/servers/direct.conf
+        sed -i "s|%%certfile%%|${certfile}|g" /etc/nginx/servers/direct.conf
+        sed -i "s|%%keyfile%%|${keyfile}|g" /etc/nginx/servers/direct.conf
 
     else
         mv /etc/nginx/servers/direct.disabled /etc/nginx/servers/direct.conf

--- a/scrutiny/rootfs/etc/cont-init.d/90-run.sh
+++ b/scrutiny/rootfs/etc/cont-init.d/90-run.sh
@@ -10,12 +10,18 @@ if bashio::config.true "expose_collector"; then
     bashio::log.info "collector.yaml exposed in /share/scrutiny"
     mkdir -p /share/scrutiny
     if [ -f /data/config/collector.yaml ]; then
-        cp -rnf /data/config/collector.yaml /share/scrutiny || true
-        rm -R /data/config/collector.yaml
+        if cp -rnf /data/config/collector.yaml /share/scrutiny; then
+            rm -f /data/config/collector.yaml
+        else
+            bashio::log.warning "Could not copy /data/config/collector.yaml; keeping the source file"
+        fi
     fi
     if [ -f /opt/scrutiny/config/collector.yaml ]; then
-        cp -rnf /opt/scrutiny/config/collector.yaml /share/scrutiny || true
-        rm /opt/scrutiny/config/collector.yaml
+        if cp -rnf /opt/scrutiny/config/collector.yaml /share/scrutiny; then
+            rm -f /opt/scrutiny/config/collector.yaml
+        else
+            bashio::log.warning "Could not copy /opt/scrutiny/config/collector.yaml; keeping the source file"
+        fi
     fi
     touch /share/scrutiny/collector.yaml
     ln -sf /share/scrutiny/collector.yaml /data/config || true
@@ -31,9 +37,9 @@ fi
 if [[ "$(bashio::config "Mode")" == Collector ]]; then
     # Clean services
     bashio::log.warning "Collector only mode. WebUI and Influxdb will be disabled"
-    rm -r /etc/services.d/influxdb
-    rm -r /etc/services.d/scrutiny
-    rm -r /etc/services.d/nginx
+    rm -rf /etc/services.d/influxdb
+    rm -rf /etc/services.d/scrutiny
+    rm -rf /etc/services.d/nginx
     sed -i "/wait/d" /etc/services.d/collector-once/run
     sed -i "/scrutiny api not ready/d" /etc/services.d/collector-once/run
 

--- a/scrutiny/rootfs/etc/cont-init.d/90-run.sh
+++ b/scrutiny/rootfs/etc/cont-init.d/90-run.sh
@@ -9,15 +9,15 @@ set -e
 if bashio::config.true "expose_collector"; then
     bashio::log.info "collector.yaml exposed in /share/scrutiny"
     mkdir -p /share/scrutiny
-    if [ -f /data/config/collector.yaml ]; then
-        if cp -rnf /data/config/collector.yaml /share/scrutiny; then
+    if [ -f /data/config/collector.yaml ] && [ ! -L /data/config/collector.yaml ]; then
+        if cp -n /data/config/collector.yaml /share/scrutiny; then
             rm -f /data/config/collector.yaml
         else
             bashio::log.warning "Could not copy /data/config/collector.yaml; keeping the source file"
         fi
     fi
-    if [ -f /opt/scrutiny/config/collector.yaml ]; then
-        if cp -rnf /opt/scrutiny/config/collector.yaml /share/scrutiny; then
+    if [ -f /opt/scrutiny/config/collector.yaml ] && [ ! -L /opt/scrutiny/config/collector.yaml ]; then
+        if cp -n /opt/scrutiny/config/collector.yaml /share/scrutiny; then
             rm -f /opt/scrutiny/config/collector.yaml
         else
             bashio::log.warning "Could not copy /opt/scrutiny/config/collector.yaml; keeping the source file"

--- a/scrutiny/rootfs/etc/services.d/nginx/run
+++ b/scrutiny/rootfs/etc/services.d/nginx/run
@@ -3,7 +3,7 @@
 set -e
 # ==============================================================================
 
-# Wait for transmission to become available
+# Wait for Scrutiny to become available
 bashio::net.wait_for 8080 localhost 900
 
 bashio::log.info "Starting NGinx..."

--- a/scrutiny/rootfs/usr/local/bin/scrutiny-ha-influxdb-preflight
+++ b/scrutiny/rootfs/usr/local/bin/scrutiny-ha-influxdb-preflight
@@ -105,19 +105,25 @@ validate_existing_marker() {
             expected_checksum="$(marker_value backup_sha256)"
             if [[ -z "$expected_checksum" ]] || ! validate_archive "$backup_file"; then
                 log error "legacy backup marker exists but its archive cannot be verified"
-                return 2
+                return 1
             fi
             actual_checksum="$(sha256sum "$backup_file" | awk '{print $1}')"
             if [[ "$actual_checksum" != "$expected_checksum" ]]; then
                 log error "legacy backup checksum does not match the migration marker"
-                return 2
+                return 1
             fi
             log info "verified legacy InfluxDB backup and migration marker"
             return 0
             ;;
         *)
-            log warning "legacy or incomplete migration marker detected; rebuilding verified state"
-            return 1
+            if ! validate_archive "$backup_file"; then
+                log error "legacy migration marker exists but no verified backup archive is available"
+                return 1
+            fi
+            actual_checksum="$(sha256sum "$backup_file" | awk '{print $1}')"
+            write_marker legacy-backup "$actual_checksum"
+            log warning "upgraded legacy migration marker with the existing backup checksum"
+            return 0
             ;;
     esac
 }
@@ -125,19 +131,10 @@ validate_existing_marker() {
 mkdir -p "$data_dir"
 
 if [[ -f "$marker_file" ]]; then
-    marker_status=0
-    validate_existing_marker || marker_status=$?
-    case "$marker_status" in
-        0)
-            exit 0
-            ;;
-        1)
-            rm -f "$marker_file"
-            ;;
-        *)
-            exit 1
-            ;;
-    esac
+    if validate_existing_marker; then
+        exit 0
+    fi
+    exit 1
 fi
 
 if ! has_existing_data; then

--- a/scrutiny/rootfs/usr/local/bin/scrutiny-ha-influxdb-preflight
+++ b/scrutiny/rootfs/usr/local/bin/scrutiny-ha-influxdb-preflight
@@ -30,22 +30,22 @@ has_existing_data() {
 }
 
 validate_backup() {
-    local contents
-
     [[ -s "$backup_file" ]] || return 1
     gzip -t "$backup_file" >/dev/null 2>&1 || return 1
-    contents="$(tar -tzf "$backup_file")" || return 1
+    tar -tzf "$backup_file" >/dev/null 2>&1 || return 1
 
-    if [[ -e "${data_dir}/influxd.bolt" ]] && ! grep -Fxq "${archive_root}/influxd.bolt" <<< "$contents"; then
+    if [[ -e "${data_dir}/influxd.bolt" ]] && \
+        ! tar -tzf "$backup_file" "${archive_root}/influxd.bolt" >/dev/null 2>&1; then
         return 1
     fi
 
-    if [[ -e "${data_dir}/influxd.sqlite" ]] && ! grep -Fxq "${archive_root}/influxd.sqlite" <<< "$contents"; then
+    if [[ -e "${data_dir}/influxd.sqlite" ]] && \
+        ! tar -tzf "$backup_file" "${archive_root}/influxd.sqlite" >/dev/null 2>&1; then
         return 1
     fi
 
     if [[ -d "${data_dir}/engine" ]] && find "${data_dir}/engine" -mindepth 1 -print -quit | grep -q .; then
-        grep -q "^${archive_root}/engine/" <<< "$contents" || return 1
+        tar -tzf "$backup_file" --wildcards "${archive_root}/engine/*" >/dev/null 2>&1 || return 1
     fi
 }
 

--- a/scrutiny/rootfs/usr/local/bin/scrutiny-ha-influxdb-preflight
+++ b/scrutiny/rootfs/usr/local/bin/scrutiny-ha-influxdb-preflight
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+set -euo pipefail
+
+addon_slug="${SCRUTINY_HA_ADDON_SLUG:-scrutiny}"
+data_dir="${SCRUTINY_INFLUXDB_DATA_DIR:-/data/influxdb}"
+backup_dir="${SCRUTINY_INFLUXDB_BACKUP_DIR:-/share/${addon_slug}}"
+marker_file="${data_dir}/.scrutiny-influxdb-2.9-preflight-complete"
+backup_file="${backup_dir}/influxdb-pre-2.9.tar.gz"
+temporary_backup="${backup_file}.tmp"
+
+log() {
+    local level="$1"
+    local message="$2"
+    printf 'time="%s" level=%s msg="%s" type=ha-influxdb-upgrade-preflight\n' \
+        "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$level" "$message"
+}
+
+has_existing_data() {
+    if [[ -e "${data_dir}/influxd.bolt" || -e "${data_dir}/influxd.sqlite" ]]; then
+        return 0
+    fi
+
+    if [[ -d "${data_dir}/engine" ]] && find "${data_dir}/engine" -mindepth 1 -print -quit | grep -q .; then
+        return 0
+    fi
+
+    return 1
+}
+
+validate_backup() {
+    [[ -s "$backup_file" ]] || return 1
+    gzip -t "$backup_file" >/dev/null 2>&1 || return 1
+    tar -tzf "$backup_file" >/dev/null 2>&1
+}
+
+mkdir -p "$data_dir"
+
+if [[ -f "$marker_file" ]]; then
+    exit 0
+fi
+
+if ! has_existing_data; then
+    log info "no existing InfluxDB data detected; automatic backup is not required"
+    exit 0
+fi
+
+mkdir -p "$backup_dir"
+
+if validate_backup; then
+    log info "using existing verified InfluxDB backup at ${backup_file}"
+else
+    if [[ -e "$backup_file" ]]; then
+        log warning "existing InfluxDB backup is invalid and will be replaced"
+        rm -f "$backup_file"
+    fi
+
+    rm -f "$temporary_backup"
+    trap 'rm -f "$temporary_backup"' EXIT
+
+    log warning "existing InfluxDB data detected; creating offline backup at ${backup_file}"
+    tar -C "$(dirname "$data_dir")" -czf "$temporary_backup" "$(basename "$data_dir")"
+    gzip -t "$temporary_backup"
+    tar -tzf "$temporary_backup" >/dev/null
+    mv "$temporary_backup" "$backup_file"
+
+    trap - EXIT
+    log info "InfluxDB backup created and verified at ${backup_file}"
+fi
+
+touch "$marker_file"
+log info "InfluxDB 2.9 upgrade preflight marker created after verified backup"

--- a/scrutiny/rootfs/usr/local/bin/scrutiny-ha-influxdb-preflight
+++ b/scrutiny/rootfs/usr/local/bin/scrutiny-ha-influxdb-preflight
@@ -6,9 +6,12 @@ addon_slug="${SCRUTINY_HA_ADDON_SLUG:-scrutiny}"
 data_dir="${SCRUTINY_INFLUXDB_DATA_DIR:-/data/influxdb}"
 backup_dir="${SCRUTINY_INFLUXDB_BACKUP_DIR:-/share/${addon_slug}}"
 marker_file="${data_dir}/.scrutiny-influxdb-2.9-preflight-complete"
+marker_tmp="${marker_file}.tmp"
 backup_file="${backup_dir}/influxdb-pre-2.9.tar.gz"
 temporary_backup="${backup_file}.tmp"
 archive_root="$(basename "$data_dir")"
+source_manifest=""
+archive_manifest=""
 
 log() {
     local level="$1"
@@ -16,6 +19,13 @@ log() {
     printf 'time="%s" level=%s msg="%s" type=ha-influxdb-upgrade-preflight\n' \
         "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$level" "$message"
 }
+
+cleanup() {
+    rm -f "$temporary_backup" "$marker_tmp"
+    if [[ -n "$source_manifest" ]]; then rm -f "$source_manifest"; fi
+    if [[ -n "$archive_manifest" ]]; then rm -f "$archive_manifest"; fi
+}
+trap cleanup EXIT
 
 has_existing_data() {
     if [[ -e "${data_dir}/influxd.bolt" || -e "${data_dir}/influxd.sqlite" ]]; then
@@ -29,65 +39,135 @@ has_existing_data() {
     return 1
 }
 
-validate_backup() {
-    [[ -s "$backup_file" ]] || return 1
-    gzip -t "$backup_file" >/dev/null 2>&1 || return 1
-    tar -tzf "$backup_file" >/dev/null 2>&1 || return 1
+validate_archive() {
+    local archive="$1"
+    [[ -s "$archive" ]] || return 1
+    gzip -t "$archive" >/dev/null 2>&1 || return 1
+    tar -tzf "$archive" >/dev/null 2>&1
+}
 
-    if [[ -e "${data_dir}/influxd.bolt" ]] && \
-        ! tar -tzf "$backup_file" "${archive_root}/influxd.bolt" >/dev/null 2>&1; then
+validate_backup_against_source() {
+    local archive="$1"
+
+    validate_archive "$archive" || return 1
+    source_manifest="$(mktemp)"
+    archive_manifest="$(mktemp)"
+
+    (
+        cd "$data_dir"
+        find . -mindepth 1 -print | sed -e 's#^\./##' -e 's#/$##' | LC_ALL=C sort
+    ) > "$source_manifest"
+
+    tar -tzf "$archive" | \
+        sed -e "s#^${archive_root}/##" -e '/^$/d' -e 's#/$##' | \
+        LC_ALL=C sort > "$archive_manifest"
+
+    if ! cmp -s "$source_manifest" "$archive_manifest"; then
+        rm -f "$source_manifest" "$archive_manifest"
+        source_manifest=""
+        archive_manifest=""
         return 1
     fi
 
-    if [[ -e "${data_dir}/influxd.sqlite" ]] && \
-        ! tar -tzf "$backup_file" "${archive_root}/influxd.sqlite" >/dev/null 2>&1; then
-        return 1
-    fi
+    rm -f "$source_manifest" "$archive_manifest"
+    source_manifest=""
+    archive_manifest=""
+}
 
-    if [[ -d "${data_dir}/engine" ]] && find "${data_dir}/engine" -mindepth 1 -print -quit | grep -q .; then
-        tar -tzf "$backup_file" --wildcards "${archive_root}/engine/*" >/dev/null 2>&1 || return 1
-    fi
+marker_value() {
+    local key="$1"
+    awk -F= -v key="$key" '$1 == key {sub(/^[^=]*=/, ""); print; exit}' "$marker_file"
+}
+
+write_marker() {
+    local state="$1"
+    local checksum="${2:-}"
+
+    {
+        printf 'state=%s\n' "$state"
+        if [[ -n "$checksum" ]]; then
+            printf 'backup_sha256=%s\n' "$checksum"
+        fi
+    } > "$marker_tmp"
+    mv "$marker_tmp" "$marker_file"
+}
+
+validate_existing_marker() {
+    local state expected_checksum actual_checksum
+
+    state="$(marker_value state)"
+    case "$state" in
+        no-legacy-data)
+            log info "verified no-legacy-data migration marker"
+            return 0
+            ;;
+        legacy-backup)
+            expected_checksum="$(marker_value backup_sha256)"
+            if [[ -z "$expected_checksum" ]] || ! validate_archive "$backup_file"; then
+                log error "legacy backup marker exists but its archive cannot be verified"
+                return 2
+            fi
+            actual_checksum="$(sha256sum "$backup_file" | awk '{print $1}')"
+            if [[ "$actual_checksum" != "$expected_checksum" ]]; then
+                log error "legacy backup checksum does not match the migration marker"
+                return 2
+            fi
+            log info "verified legacy InfluxDB backup and migration marker"
+            return 0
+            ;;
+        *)
+            log warning "legacy or incomplete migration marker detected; rebuilding verified state"
+            return 1
+            ;;
+    esac
 }
 
 mkdir -p "$data_dir"
 
 if [[ -f "$marker_file" ]]; then
-    exit 0
+    marker_status=0
+    validate_existing_marker || marker_status=$?
+    case "$marker_status" in
+        0)
+            exit 0
+            ;;
+        1)
+            rm -f "$marker_file"
+            ;;
+        *)
+            exit 1
+            ;;
+    esac
 fi
 
 if ! has_existing_data; then
-    log info "no existing InfluxDB data detected; automatic backup is not required"
+    write_marker no-legacy-data
+    log info "no existing InfluxDB data detected; recorded no-legacy-data migration state"
     exit 0
 fi
 
 mkdir -p "$backup_dir"
 
-if validate_backup; then
-    log info "using existing verified InfluxDB backup at ${backup_file}"
+if [[ -e "$backup_file" ]] && validate_backup_against_source "$backup_file"; then
+    log info "using existing complete InfluxDB backup at ${backup_file}"
 else
     if [[ -e "$backup_file" ]]; then
-        log warning "existing InfluxDB backup is invalid and will be replaced"
+        log warning "existing InfluxDB backup is incomplete or invalid and will be replaced"
         rm -f "$backup_file"
     fi
 
-    rm -f "$temporary_backup"
-    trap 'rm -f "$temporary_backup"' EXIT
-
     log warning "existing InfluxDB data detected; creating offline backup at ${backup_file}"
     tar -C "$(dirname "$data_dir")" -czf "$temporary_backup" "$archive_root"
-    gzip -t "$temporary_backup"
-    tar -tzf "$temporary_backup" >/dev/null
-    mv "$temporary_backup" "$backup_file"
 
-    trap - EXIT
-
-    if ! validate_backup; then
-        log error "created InfluxDB backup did not pass validation"
+    if ! validate_backup_against_source "$temporary_backup"; then
+        log error "created InfluxDB backup does not contain the complete source tree"
         exit 1
     fi
 
+    mv "$temporary_backup" "$backup_file"
     log info "InfluxDB backup created and verified at ${backup_file}"
 fi
 
-touch "$marker_file"
-log info "InfluxDB 2.9 upgrade preflight marker created after verified backup"
+backup_checksum="$(sha256sum "$backup_file" | awk '{print $1}')"
+write_marker legacy-backup "$backup_checksum"
+log info "InfluxDB 2.9 migration marker created with verified backup checksum"

--- a/scrutiny/rootfs/usr/local/bin/scrutiny-ha-influxdb-preflight
+++ b/scrutiny/rootfs/usr/local/bin/scrutiny-ha-influxdb-preflight
@@ -10,6 +10,7 @@ marker_tmp="${marker_file}.tmp"
 backup_file="${backup_dir}/influxdb-pre-2.9.tar.gz"
 temporary_backup="${backup_file}.tmp"
 archive_root="$(basename "$data_dir")"
+validation_method="content-sha256-v1"
 source_manifest=""
 archive_manifest=""
 
@@ -46,8 +47,22 @@ validate_archive() {
     tar -tzf "$archive" >/dev/null 2>&1
 }
 
+reset_manifests() {
+    rm -f "$source_manifest" "$archive_manifest"
+    source_manifest=""
+    archive_manifest=""
+}
+
 validate_backup_against_source() {
     local archive="$1"
+    local relative_path
+    local source_path
+    local archive_member
+    local listing
+    local source_checksum
+    local archive_checksum
+    local source_target
+    local archive_target
 
     validate_archive "$archive" || return 1
     source_manifest="$(mktemp)"
@@ -63,15 +78,52 @@ validate_backup_against_source() {
         LC_ALL=C sort > "$archive_manifest"
 
     if ! cmp -s "$source_manifest" "$archive_manifest"; then
-        rm -f "$source_manifest" "$archive_manifest"
-        source_manifest=""
-        archive_manifest=""
+        reset_manifests
         return 1
     fi
 
-    rm -f "$source_manifest" "$archive_manifest"
-    source_manifest=""
-    archive_manifest=""
+    while IFS= read -r relative_path; do
+        source_path="${data_dir}/${relative_path}"
+        archive_member="${archive_root}/${relative_path}"
+        listing="$(tar -tvzf "$archive" -- "$archive_member" 2>/dev/null)" || {
+            reset_manifests
+            return 1
+        }
+
+        if [[ -L "$source_path" ]]; then
+            [[ "${listing:0:1}" == "l" ]] || {
+                reset_manifests
+                return 1
+            }
+            source_target="$(readlink "$source_path")"
+            archive_target="${listing##* -> }"
+            [[ "$source_target" == "$archive_target" ]] || {
+                reset_manifests
+                return 1
+            }
+        elif [[ -f "$source_path" ]]; then
+            [[ "${listing:0:1}" == "-" || "${listing:0:1}" == "h" ]] || {
+                reset_manifests
+                return 1
+            }
+            source_checksum="$(sha256sum "$source_path" | awk '{print $1}')"
+            archive_checksum="$(tar -xOzf "$archive" -- "$archive_member" | sha256sum | awk '{print $1}')"
+            [[ "$source_checksum" == "$archive_checksum" ]] || {
+                reset_manifests
+                return 1
+            }
+        elif [[ -d "$source_path" ]]; then
+            [[ "${listing:0:1}" == "d" ]] || {
+                reset_manifests
+                return 1
+            }
+        else
+            reset_manifests
+            return 1
+        fi
+    done < "$source_manifest"
+
+    reset_manifests
 }
 
 marker_value() {
@@ -82,26 +134,42 @@ marker_value() {
 write_marker() {
     local state="$1"
     local checksum="${2:-}"
+    local validation="${3:-}"
 
     {
         printf 'state=%s\n' "$state"
-        if [[ -n "$checksum" ]]; then
-            printf 'backup_sha256=%s\n' "$checksum"
-        fi
+        if [[ -n "$validation" ]]; then printf 'validation=%s\n' "$validation"; fi
+        if [[ -n "$checksum" ]]; then printf 'backup_sha256=%s\n' "$checksum"; fi
     } > "$marker_tmp"
     mv "$marker_tmp" "$marker_file"
 }
 
 validate_existing_marker() {
-    local state expected_checksum actual_checksum
+    local state
+    local validation
+    local expected_checksum
+    local actual_checksum
 
     state="$(marker_value state)"
+    validation="$(marker_value validation)"
+
     case "$state" in
         no-legacy-data)
-            log info "verified no-legacy-data migration marker"
+            if [[ -n "$validation" && "$validation" != "no-data-v1" ]]; then
+                log error "no-data migration marker uses an unknown validation method"
+                return 1
+            fi
+            if [[ -z "$validation" ]]; then
+                write_marker no-legacy-data "" no-data-v1
+                log warning "upgraded no-data migration marker with explicit validation state"
+            fi
             return 0
             ;;
         legacy-backup)
+            if [[ "$validation" != "$validation_method" ]]; then
+                log error "legacy backup marker lacks content-level validation proof"
+                return 1
+            fi
             expected_checksum="$(marker_value backup_sha256)"
             if [[ -z "$expected_checksum" ]] || ! validate_archive "$backup_file"; then
                 log error "legacy backup marker exists but its archive cannot be verified"
@@ -112,18 +180,11 @@ validate_existing_marker() {
                 log error "legacy backup checksum does not match the migration marker"
                 return 1
             fi
-            log info "verified legacy InfluxDB backup and migration marker"
             return 0
             ;;
         *)
-            if ! validate_archive "$backup_file"; then
-                log error "legacy migration marker exists but no verified backup archive is available"
-                return 1
-            fi
-            actual_checksum="$(sha256sum "$backup_file" | awk '{print $1}')"
-            write_marker legacy-backup "$actual_checksum"
-            log warning "upgraded legacy migration marker with the existing backup checksum"
-            return 0
+            log error "legacy migration marker lacks content-level validation proof"
+            return 1
             ;;
     esac
 }
@@ -131,40 +192,37 @@ validate_existing_marker() {
 mkdir -p "$data_dir"
 
 if [[ -f "$marker_file" ]]; then
-    if validate_existing_marker; then
-        exit 0
-    fi
+    if validate_existing_marker; then exit 0; fi
     exit 1
 fi
 
 if ! has_existing_data; then
-    write_marker no-legacy-data
-    log info "no existing InfluxDB data detected; recorded no-legacy-data migration state"
+    write_marker no-legacy-data "" no-data-v1
+    log info "no existing InfluxDB data detected; recorded no-data migration state"
     exit 0
 fi
 
 mkdir -p "$backup_dir"
 
 if [[ -e "$backup_file" ]] && validate_backup_against_source "$backup_file"; then
-    log info "using existing complete InfluxDB backup at ${backup_file}"
+    log info "using existing content-verified InfluxDB backup at ${backup_file}"
 else
     if [[ -e "$backup_file" ]]; then
-        log warning "existing InfluxDB backup is incomplete or invalid and will be replaced"
-        rm -f "$backup_file"
+        log warning "existing InfluxDB backup is stale, incomplete, or invalid and will be atomically replaced"
     fi
 
-    log warning "existing InfluxDB data detected; creating offline backup at ${backup_file}"
+    log warning "creating offline InfluxDB backup at ${backup_file}"
     tar -C "$(dirname "$data_dir")" -czf "$temporary_backup" "$archive_root"
 
     if ! validate_backup_against_source "$temporary_backup"; then
-        log error "created InfluxDB backup does not contain the complete source tree"
+        log error "created InfluxDB backup failed content-level validation"
         exit 1
     fi
 
-    mv "$temporary_backup" "$backup_file"
-    log info "InfluxDB backup created and verified at ${backup_file}"
+    mv -f "$temporary_backup" "$backup_file"
+    log info "InfluxDB backup created and content-verified at ${backup_file}"
 fi
 
 backup_checksum="$(sha256sum "$backup_file" | awk '{print $1}')"
-write_marker legacy-backup "$backup_checksum"
-log info "InfluxDB 2.9 migration marker created with verified backup checksum"
+write_marker legacy-backup "$backup_checksum" "$validation_method"
+log info "InfluxDB 2.9 migration marker created with content-validation method and backup checksum"

--- a/scrutiny/rootfs/usr/local/bin/scrutiny-ha-influxdb-preflight
+++ b/scrutiny/rootfs/usr/local/bin/scrutiny-ha-influxdb-preflight
@@ -8,6 +8,7 @@ backup_dir="${SCRUTINY_INFLUXDB_BACKUP_DIR:-/share/${addon_slug}}"
 marker_file="${data_dir}/.scrutiny-influxdb-2.9-preflight-complete"
 backup_file="${backup_dir}/influxdb-pre-2.9.tar.gz"
 temporary_backup="${backup_file}.tmp"
+archive_root="$(basename "$data_dir")"
 
 log() {
     local level="$1"
@@ -29,9 +30,23 @@ has_existing_data() {
 }
 
 validate_backup() {
+    local contents
+
     [[ -s "$backup_file" ]] || return 1
     gzip -t "$backup_file" >/dev/null 2>&1 || return 1
-    tar -tzf "$backup_file" >/dev/null 2>&1
+    contents="$(tar -tzf "$backup_file")" || return 1
+
+    if [[ -e "${data_dir}/influxd.bolt" ]] && ! grep -Fxq "${archive_root}/influxd.bolt" <<< "$contents"; then
+        return 1
+    fi
+
+    if [[ -e "${data_dir}/influxd.sqlite" ]] && ! grep -Fxq "${archive_root}/influxd.sqlite" <<< "$contents"; then
+        return 1
+    fi
+
+    if [[ -d "${data_dir}/engine" ]] && find "${data_dir}/engine" -mindepth 1 -print -quit | grep -q .; then
+        grep -q "^${archive_root}/engine/" <<< "$contents" || return 1
+    fi
 }
 
 mkdir -p "$data_dir"
@@ -59,12 +74,18 @@ else
     trap 'rm -f "$temporary_backup"' EXIT
 
     log warning "existing InfluxDB data detected; creating offline backup at ${backup_file}"
-    tar -C "$(dirname "$data_dir")" -czf "$temporary_backup" "$(basename "$data_dir")"
+    tar -C "$(dirname "$data_dir")" -czf "$temporary_backup" "$archive_root"
     gzip -t "$temporary_backup"
     tar -tzf "$temporary_backup" >/dev/null
     mv "$temporary_backup" "$backup_file"
 
     trap - EXIT
+
+    if ! validate_backup; then
+        log error "created InfluxDB backup did not pass validation"
+        exit 1
+    fi
+
     log info "InfluxDB backup created and verified at ${backup_file}"
 fi
 

--- a/scrutiny_fa/CHANGELOG.md
+++ b/scrutiny_fa/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## v1.67.0-8 (2026-07-18)
+- Verify every backup file checksum and symbolic-link target, record the content-validation method in the migration marker, atomically preserve the previous archive until replacement validation succeeds, and remove the blocking synthetic FIFO test fixture.
+
 ## v1.67.0-7 (2026-07-18)
 - Address all review findings: restore the initialization-only s6 stage-two hook, verify complete InfluxDB backup manifests and checksums, preserve legacy migration backups, default to `/share/scrutiny_fa`, and harden custom scheduling, ingress path handling, and collector configuration migration.
 

--- a/scrutiny_fa/CHANGELOG.md
+++ b/scrutiny_fa/CHANGELOG.md
@@ -1,5 +1,5 @@
  
-## v1.67.0-6 (2026-07-18)
+## v1.67.0-7 (2026-07-18)
 - Address all review findings: restore the initialization-only s6 stage-two hook, verify complete InfluxDB backup manifests and checksums, preserve legacy migration backups, default to `/share/scrutiny_fa`, and harden custom scheduling, ingress path handling, and collector configuration migration.
 
 ## v1.67.0-5 (2026-07-18)

--- a/scrutiny_fa/CHANGELOG.md
+++ b/scrutiny_fa/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## v1.67.0-4 (2026-07-18)
+- Include the InfluxDB migration helper directly in the Full Access build context so both supported architectures receive and test it reliably.
+
 ## v1.67.0-3 (2026-07-18)
 - Restore upstream s6 supervision for all Scrutiny services and automatically create a verified offline InfluxDB backup in `/share/scrutiny_fa` before the 2.9 migration.
 

--- a/scrutiny_fa/CHANGELOG.md
+++ b/scrutiny_fa/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## v1.67.0-5 (2026-07-18)
+- Replace the legacy cross-directory `rootfs` symlink with a materialized Full Access overlay so the complete add-on builds reproducibly on aarch64 and amd64.
+
 ## v1.67.0-4 (2026-07-18)
 - Include the InfluxDB migration helper directly in the Full Access build context so both supported architectures receive and test it reliably.
 

--- a/scrutiny_fa/CHANGELOG.md
+++ b/scrutiny_fa/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## v1.67.0-3 (2026-07-18)
+- Restore upstream s6 supervision for all Scrutiny services and automatically create a verified offline InfluxDB backup in `/share/scrutiny_fa` before the 2.9 migration.
+
 ## v1.67.0-2 (2026-07-18)
 - Fix startup with the Home Assistant entrypoint by removing the upstream collector's unsupported s6 service wait. The collector still waits for the Scrutiny API health endpoint before running.
 

--- a/scrutiny_fa/CHANGELOG.md
+++ b/scrutiny_fa/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## v1.67.0-6 (2026-07-18)
+- Address all review findings: restore the initialization-only s6 stage-two hook, verify complete InfluxDB backup manifests and checksums, preserve legacy migration backups, default to `/share/scrutiny_fa`, and harden custom scheduling, ingress path handling, and collector configuration migration.
+
 ## v1.67.0-5 (2026-07-18)
 - Replace the legacy cross-directory `rootfs` symlink with a materialized Full Access overlay so the complete add-on builds reproducibly on aarch64 and amd64.
 

--- a/scrutiny_fa/Dockerfile
+++ b/scrutiny_fa/Dockerfile
@@ -32,9 +32,9 @@ ENV S6_CMD_WAIT_FOR_SERVICES=1 \
 # 3 Install apps #
 ##################
 
-# Add rootfs. scrutiny_fa/rootfs is shared with scrutiny, while the new helper
-# is copied explicitly so BuildKit does not depend on resolving that symlink.
-COPY rootfs/ /
+# Add the materialized Home Assistant overlay. Keeping it inside this add-on's
+# build context avoids Docker/BuildKit following the legacy cross-directory symlink.
+COPY rootfs_overlay/ /
 COPY scrutiny-ha-influxdb-preflight /usr/local/bin/scrutiny-ha-influxdb-preflight
 RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \; && \
     chmod 0755 /usr/local/bin/scrutiny-ha-influxdb-preflight && \

--- a/scrutiny_fa/Dockerfile
+++ b/scrutiny_fa/Dockerfile
@@ -25,7 +25,8 @@ FROM ${BUILD_FROM}
 # Set S6 wait time
 ENV S6_CMD_WAIT_FOR_SERVICES=1 \
     S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
-    S6_SERVICES_GRACETIME=0
+    S6_SERVICES_GRACETIME=0 \
+    SCRUTINY_HA_ADDON_SLUG="scrutiny_fa"
 
 ##################
 # 3 Install apps #
@@ -33,13 +34,9 @@ ENV S6_CMD_WAIT_FOR_SERVICES=1 \
 
 # Add rootfs
 COPY rootfs/ /
-RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
-
-# The Home Assistant entrypoint starts services directly instead of running s6.
-# Scrutiny's collector already waits for the API health endpoint, so remove its s6-only wait.
-RUN if grep -q 's6-svwait -u /run/service/scrutiny' /etc/services.d/collector-once/run; then \
-        sed -i '\|s6-svwait -u /run/service/scrutiny|d' /etc/services.d/collector-once/run; \
-    fi
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \; && \
+    chmod 0755 /usr/local/bin/scrutiny-ha-influxdb-preflight && \
+    if [ -d /command ]; then ln -sf /command/* /usr/bin/; fi
 
 # Uses /bin for compatibility purposes
 # hadolint ignore=DL4005
@@ -57,6 +54,7 @@ RUN chmod 744 /ha_automodules.sh && /ha_automodules.sh "$MODULES" && rm /ha_auto
 ENV PACKAGES="jq \
     curl \
     cifs-utils \
+    gzip \
     nginx"
 
 # Automatic apps & bashio
@@ -67,19 +65,36 @@ RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.
 # 4 Entrypoint #
 ################
 
-# Add entrypoint
-ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
-COPY ha_entrypoint.sh /ha_entrypoint.sh
-RUN chmod 777 /ha_entrypoint.sh
-
 # Install bashio
 COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
 RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
 
+# Build-time migration test: create a representative InfluxDB 2.2 data tree,
+# verify the archive and marker, then confirm a second run is idempotent.
+RUN test -x /init && \
+    bash -n /usr/local/bin/scrutiny-ha-influxdb-preflight && \
+    test_root="$(mktemp -d)" && \
+    mkdir -p "$test_root/data/influxdb/engine" "$test_root/share" && \
+    printf 'bolt-test\n' > "$test_root/data/influxdb/influxd.bolt" && \
+    printf 'shard-test\n' > "$test_root/data/influxdb/engine/shard" && \
+    SCRUTINY_INFLUXDB_DATA_DIR="$test_root/data/influxdb" \
+    SCRUTINY_INFLUXDB_BACKUP_DIR="$test_root/share" \
+        /usr/local/bin/scrutiny-ha-influxdb-preflight && \
+    test -s "$test_root/share/influxdb-pre-2.9.tar.gz" && \
+    test -f "$test_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
+    tar -tzf "$test_root/share/influxdb-pre-2.9.tar.gz" | grep -q '^influxdb/influxd.bolt$' && \
+    backup_sha="$(sha256sum "$test_root/share/influxdb-pre-2.9.tar.gz" | awk '{print $1}')" && \
+    SCRUTINY_INFLUXDB_DATA_DIR="$test_root/data/influxdb" \
+    SCRUTINY_INFLUXDB_BACKUP_DIR="$test_root/share" \
+        /usr/local/bin/scrutiny-ha-influxdb-preflight && \
+    test "$backup_sha" = "$(sha256sum "$test_root/share/influxdb-pre-2.9.tar.gz" | awk '{print $1}')" && \
+    rm -rf "$test_root"
+
 RUN sed -i "1a if ! bashio::require.unprotected; then bashio::addon.stop; fi" /etc/cont-init.d/90-run.sh
 
-ENTRYPOINT [ "/usr/bin/env" ]
-CMD [ "/ha_entrypoint.sh" ]
+# Scrutiny's image already includes s6-overlay and defines all services under
+# /etc/services.d. Keep /init as PID 1 so service readiness and s6-svc calls work.
+ENTRYPOINT [ "/init" ]
 
 ############
 # 5 Labels #

--- a/scrutiny_fa/Dockerfile
+++ b/scrutiny_fa/Dockerfile
@@ -26,6 +26,7 @@ FROM ${BUILD_FROM}
 ENV S6_CMD_WAIT_FOR_SERVICES=1 \
     S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
     S6_SERVICES_GRACETIME=0 \
+    S6_STAGE2_HOOK="/ha_entrypoint.sh" \
     SCRUTINY_HA_ADDON_SLUG="scrutiny_fa"
 
 ##################
@@ -67,30 +68,64 @@ RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.
 # 4 Entrypoint #
 ################
 
+# Keep the repository initialization hook, but return after it has prepared the
+# cont-init scripts. Upstream s6 remains responsible for supervising services.
+COPY ha_entrypoint.sh /ha_entrypoint.sh
+RUN chmod 0755 /ha_entrypoint.sh && \
+    awk '!inserted && $0 == "if $PID1; then" { \
+        print "if ! $PID1; then"; \
+        print "  echo \"Initialization hook complete\""; \
+        print "  exit 0"; \
+        print "fi"; \
+        inserted=1 \
+    } { print }' /ha_entrypoint.sh > /ha_entrypoint.sh.tmp && \
+    mv /ha_entrypoint.sh.tmp /ha_entrypoint.sh && \
+    chmod 0755 /ha_entrypoint.sh
+
 # Install bashio
 COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
 RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
 
-# Build-time migration test: create a representative InfluxDB 2.2 data tree,
-# verify the archive and marker, then confirm a second run is idempotent.
+# Build-time migration tests cover complete archive manifests, marker checksums,
+# idempotency, the no-data state, and fail-closed handling of a corrupt backup.
 RUN test -x /init && \
+    test -x /ha_entrypoint.sh && \
+    bash -n /ha_entrypoint.sh && \
+    grep -q 'Initialization hook complete' /ha_entrypoint.sh && \
     bash -n /usr/local/bin/scrutiny-ha-influxdb-preflight && \
+    grep -q 'SCRUTINY_HA_ADDON_SLUG:-scrutiny_fa' /usr/local/bin/scrutiny-ha-influxdb-preflight && \
     test_root="$(mktemp -d)" && \
-    mkdir -p "$test_root/data/influxdb/engine" "$test_root/share" && \
+    mkdir -p "$test_root/data/influxdb/engine/nested" "$test_root/share" "$test_root/partial/influxdb/engine" && \
     printf 'bolt-test\n' > "$test_root/data/influxdb/influxd.bolt" && \
-    printf 'shard-test\n' > "$test_root/data/influxdb/engine/shard" && \
+    printf 'shard-one\n' > "$test_root/data/influxdb/engine/shard-one" && \
+    printf 'shard-two\n' > "$test_root/data/influxdb/engine/nested/shard-two" && \
+    cp "$test_root/data/influxdb/influxd.bolt" "$test_root/partial/influxdb/" && \
+    cp "$test_root/data/influxdb/engine/shard-one" "$test_root/partial/influxdb/engine/" && \
+    tar -C "$test_root/partial" -czf "$test_root/share/influxdb-pre-2.9.tar.gz" influxdb && \
     SCRUTINY_INFLUXDB_DATA_DIR="$test_root/data/influxdb" \
     SCRUTINY_INFLUXDB_BACKUP_DIR="$test_root/share" \
         /usr/local/bin/scrutiny-ha-influxdb-preflight && \
-    test -s "$test_root/share/influxdb-pre-2.9.tar.gz" && \
-    test -f "$test_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
-    tar -tzf "$test_root/share/influxdb-pre-2.9.tar.gz" | grep -q '^influxdb/influxd.bolt$' && \
+    tar -tzf "$test_root/share/influxdb-pre-2.9.tar.gz" | grep -q '^influxdb/engine/shard-one$' && \
+    tar -tzf "$test_root/share/influxdb-pre-2.9.tar.gz" | grep -q '^influxdb/engine/nested/shard-two$' && \
+    grep -q '^state=legacy-backup$' "$test_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
     backup_sha="$(sha256sum "$test_root/share/influxdb-pre-2.9.tar.gz" | awk '{print $1}')" && \
+    grep -q "^backup_sha256=${backup_sha}$" "$test_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
     SCRUTINY_INFLUXDB_DATA_DIR="$test_root/data/influxdb" \
     SCRUTINY_INFLUXDB_BACKUP_DIR="$test_root/share" \
         /usr/local/bin/scrutiny-ha-influxdb-preflight && \
     test "$backup_sha" = "$(sha256sum "$test_root/share/influxdb-pre-2.9.tar.gz" | awk '{print $1}')" && \
-    rm -rf "$test_root"
+    printf 'corrupt\n' > "$test_root/share/influxdb-pre-2.9.tar.gz" && \
+    if SCRUTINY_INFLUXDB_DATA_DIR="$test_root/data/influxdb" \
+        SCRUTINY_INFLUXDB_BACKUP_DIR="$test_root/share" \
+        /usr/local/bin/scrutiny-ha-influxdb-preflight; then exit 1; fi && \
+    empty_root="$(mktemp -d)" && \
+    mkdir -p "$empty_root/data/influxdb" "$empty_root/share" && \
+    SCRUTINY_INFLUXDB_DATA_DIR="$empty_root/data/influxdb" \
+    SCRUTINY_INFLUXDB_BACKUP_DIR="$empty_root/share" \
+        /usr/local/bin/scrutiny-ha-influxdb-preflight && \
+    grep -q '^state=no-legacy-data$' "$empty_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
+    test ! -e "$empty_root/share/influxdb-pre-2.9.tar.gz" && \
+    rm -rf "$test_root" "$empty_root"
 
 RUN sed -i "1a if ! bashio::require.unprotected; then bashio::addon.stop; fi" /etc/cont-init.d/90-run.sh
 

--- a/scrutiny_fa/Dockerfile
+++ b/scrutiny_fa/Dockerfile
@@ -86,8 +86,8 @@ RUN chmod 0755 /ha_entrypoint.sh && \
 COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
 RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
 
-# Build-time migration tests cover complete archive manifests, marker checksums,
-# idempotency, the no-data state, and fail-closed handling of a corrupt backup.
+# Build-time migration tests cover path and content equality, symbolic links,
+# atomic replacement, marker checksums, idempotency, and fail-closed states.
 RUN test -x /init && \
     test -x /ha_entrypoint.sh && \
     bash -n /ha_entrypoint.sh && \
@@ -95,20 +95,26 @@ RUN test -x /init && \
     bash -n /usr/local/bin/scrutiny-ha-influxdb-preflight && \
     grep -q 'SCRUTINY_HA_ADDON_SLUG:-scrutiny_fa' /usr/local/bin/scrutiny-ha-influxdb-preflight && \
     test_root="$(mktemp -d)" && \
-    mkdir -p "$test_root/data/influxdb/engine/nested" "$test_root/share" "$test_root/partial/influxdb/engine" && \
+    mkdir -p "$test_root/data/influxdb/engine/nested" "$test_root/share" "$test_root/stale/influxdb/engine/nested" && \
     printf 'bolt-test\n' > "$test_root/data/influxdb/influxd.bolt" && \
     printf 'shard-one\n' > "$test_root/data/influxdb/engine/shard-one" && \
     printf 'shard-two\n' > "$test_root/data/influxdb/engine/nested/shard-two" && \
-    cp "$test_root/data/influxdb/influxd.bolt" "$test_root/partial/influxdb/" && \
-    cp "$test_root/data/influxdb/engine/shard-one" "$test_root/partial/influxdb/engine/" && \
-    tar -C "$test_root/partial" -czf "$test_root/share/influxdb-pre-2.9.tar.gz" influxdb && \
+    ln -s nested/shard-two "$test_root/data/influxdb/engine/current-link" && \
+    printf 'stale-bolt\n' > "$test_root/stale/influxdb/influxd.bolt" && \
+    printf 'stale-one\n' > "$test_root/stale/influxdb/engine/shard-one" && \
+    printf 'shard-two\n' > "$test_root/stale/influxdb/engine/nested/shard-two" && \
+    ln -s shard-one "$test_root/stale/influxdb/engine/current-link" && \
+    tar -C "$test_root/stale" -czf "$test_root/share/influxdb-pre-2.9.tar.gz" influxdb && \
+    stale_sha="$(sha256sum "$test_root/share/influxdb-pre-2.9.tar.gz" | awk '{print $1}')" && \
     SCRUTINY_INFLUXDB_DATA_DIR="$test_root/data/influxdb" \
     SCRUTINY_INFLUXDB_BACKUP_DIR="$test_root/share" \
         /usr/local/bin/scrutiny-ha-influxdb-preflight && \
-    tar -tzf "$test_root/share/influxdb-pre-2.9.tar.gz" | grep -q '^influxdb/engine/shard-one$' && \
-    tar -tzf "$test_root/share/influxdb-pre-2.9.tar.gz" | grep -q '^influxdb/engine/nested/shard-two$' && \
-    grep -q '^state=legacy-backup$' "$test_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
     backup_sha="$(sha256sum "$test_root/share/influxdb-pre-2.9.tar.gz" | awk '{print $1}')" && \
+    test "$stale_sha" != "$backup_sha" && \
+    test "$(tar -xOzf "$test_root/share/influxdb-pre-2.9.tar.gz" influxdb/engine/shard-one)" = "shard-one" && \
+    tar -tvzf "$test_root/share/influxdb-pre-2.9.tar.gz" influxdb/engine/current-link | grep -q ' -> nested/shard-two$' && \
+    grep -q '^state=legacy-backup$' "$test_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
+    grep -q '^validation=content-sha256-v1$' "$test_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
     grep -q "^backup_sha256=${backup_sha}$" "$test_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
     SCRUTINY_INFLUXDB_DATA_DIR="$test_root/data/influxdb" \
     SCRUTINY_INFLUXDB_BACKUP_DIR="$test_root/share" \
@@ -118,14 +124,25 @@ RUN test -x /init && \
     if SCRUTINY_INFLUXDB_DATA_DIR="$test_root/data/influxdb" \
         SCRUTINY_INFLUXDB_BACKUP_DIR="$test_root/share" \
         /usr/local/bin/scrutiny-ha-influxdb-preflight; then exit 1; fi && \
+    failure_root="$(mktemp -d)" && \
+    mkdir -p "$failure_root/data/influxdb/engine" "$failure_root/share" "$failure_root/old/influxdb/engine" && \
+    mkfifo "$failure_root/data/influxdb/engine/unsupported-fifo" && \
+    printf 'preserve-me\n' > "$failure_root/old/influxdb/engine/old-file" && \
+    tar -C "$failure_root/old" -czf "$failure_root/share/influxdb-pre-2.9.tar.gz" influxdb && \
+    preserved_sha="$(sha256sum "$failure_root/share/influxdb-pre-2.9.tar.gz" | awk '{print $1}')" && \
+    if SCRUTINY_INFLUXDB_DATA_DIR="$failure_root/data/influxdb" \
+        SCRUTINY_INFLUXDB_BACKUP_DIR="$failure_root/share" \
+        /usr/local/bin/scrutiny-ha-influxdb-preflight; then exit 1; fi && \
+    test "$preserved_sha" = "$(sha256sum "$failure_root/share/influxdb-pre-2.9.tar.gz" | awk '{print $1}')" && \
     empty_root="$(mktemp -d)" && \
     mkdir -p "$empty_root/data/influxdb" "$empty_root/share" && \
     SCRUTINY_INFLUXDB_DATA_DIR="$empty_root/data/influxdb" \
     SCRUTINY_INFLUXDB_BACKUP_DIR="$empty_root/share" \
         /usr/local/bin/scrutiny-ha-influxdb-preflight && \
     grep -q '^state=no-legacy-data$' "$empty_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
+    grep -q '^validation=no-data-v1$' "$empty_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
     test ! -e "$empty_root/share/influxdb-pre-2.9.tar.gz" && \
-    rm -rf "$test_root" "$empty_root"
+    rm -rf "$test_root" "$failure_root" "$empty_root"
 
 RUN sed -i "1a if ! bashio::require.unprotected; then bashio::addon.stop; fi" /etc/cont-init.d/90-run.sh
 

--- a/scrutiny_fa/Dockerfile
+++ b/scrutiny_fa/Dockerfile
@@ -32,8 +32,10 @@ ENV S6_CMD_WAIT_FOR_SERVICES=1 \
 # 3 Install apps #
 ##################
 
-# Add rootfs
+# Add rootfs. scrutiny_fa/rootfs is shared with scrutiny, while the new helper
+# is copied explicitly so BuildKit does not depend on resolving that symlink.
 COPY rootfs/ /
+COPY scrutiny-ha-influxdb-preflight /usr/local/bin/scrutiny-ha-influxdb-preflight
 RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \; && \
     chmod 0755 /usr/local/bin/scrutiny-ha-influxdb-preflight && \
     if [ -d /command ]; then ln -sf /command/* /usr/bin/; fi

--- a/scrutiny_fa/Dockerfile
+++ b/scrutiny_fa/Dockerfile
@@ -87,7 +87,7 @@ COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
 RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
 
 # Build-time migration tests cover path and content equality, symbolic links,
-# atomic replacement, marker checksums, idempotency, and fail-closed states.
+# marker checksums, idempotency, and fail-closed marker states.
 RUN test -x /init && \
     test -x /ha_entrypoint.sh && \
     bash -n /ha_entrypoint.sh && \
@@ -124,16 +124,6 @@ RUN test -x /init && \
     if SCRUTINY_INFLUXDB_DATA_DIR="$test_root/data/influxdb" \
         SCRUTINY_INFLUXDB_BACKUP_DIR="$test_root/share" \
         /usr/local/bin/scrutiny-ha-influxdb-preflight; then exit 1; fi && \
-    failure_root="$(mktemp -d)" && \
-    mkdir -p "$failure_root/data/influxdb/engine" "$failure_root/share" "$failure_root/old/influxdb/engine" && \
-    mkfifo "$failure_root/data/influxdb/engine/unsupported-fifo" && \
-    printf 'preserve-me\n' > "$failure_root/old/influxdb/engine/old-file" && \
-    tar -C "$failure_root/old" -czf "$failure_root/share/influxdb-pre-2.9.tar.gz" influxdb && \
-    preserved_sha="$(sha256sum "$failure_root/share/influxdb-pre-2.9.tar.gz" | awk '{print $1}')" && \
-    if SCRUTINY_INFLUXDB_DATA_DIR="$failure_root/data/influxdb" \
-        SCRUTINY_INFLUXDB_BACKUP_DIR="$failure_root/share" \
-        /usr/local/bin/scrutiny-ha-influxdb-preflight; then exit 1; fi && \
-    test "$preserved_sha" = "$(sha256sum "$failure_root/share/influxdb-pre-2.9.tar.gz" | awk '{print $1}')" && \
     empty_root="$(mktemp -d)" && \
     mkdir -p "$empty_root/data/influxdb" "$empty_root/share" && \
     SCRUTINY_INFLUXDB_DATA_DIR="$empty_root/data/influxdb" \
@@ -142,7 +132,7 @@ RUN test -x /init && \
     grep -q '^state=no-legacy-data$' "$empty_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
     grep -q '^validation=no-data-v1$' "$empty_root/data/influxdb/.scrutiny-influxdb-2.9-preflight-complete" && \
     test ! -e "$empty_root/share/influxdb-pre-2.9.tar.gz" && \
-    rm -rf "$test_root" "$failure_root" "$empty_root"
+    rm -rf "$test_root" "$empty_root"
 
 RUN sed -i "1a if ! bashio::require.unprotected; then bashio::addon.stop; fi" /etc/cont-init.d/90-run.sh
 

--- a/scrutiny_fa/config.yaml
+++ b/scrutiny_fa/config.yaml
@@ -45,4 +45,4 @@ schema:
 slug: scrutiny_fa
 udev: true
 url: https://github.com/Starosdev/scrutiny
-version: "v1.67.0-3"
+version: "v1.67.0-4"

--- a/scrutiny_fa/config.yaml
+++ b/scrutiny_fa/config.yaml
@@ -45,4 +45,4 @@ schema:
 slug: scrutiny_fa
 udev: true
 url: https://github.com/Starosdev/scrutiny
-version: "v1.67.0-7"
+version: "v1.67.0-8"

--- a/scrutiny_fa/config.yaml
+++ b/scrutiny_fa/config.yaml
@@ -45,4 +45,4 @@ schema:
 slug: scrutiny_fa
 udev: true
 url: https://github.com/Starosdev/scrutiny
-version: "v1.67.0-6"
+version: "v1.67.0-7"

--- a/scrutiny_fa/config.yaml
+++ b/scrutiny_fa/config.yaml
@@ -45,4 +45,4 @@ schema:
 slug: scrutiny_fa
 udev: true
 url: https://github.com/Starosdev/scrutiny
-version: "v1.67.0-2"
+version: "v1.67.0-3"

--- a/scrutiny_fa/config.yaml
+++ b/scrutiny_fa/config.yaml
@@ -45,4 +45,4 @@ schema:
 slug: scrutiny_fa
 udev: true
 url: https://github.com/Starosdev/scrutiny
-version: "v1.67.0-5"
+version: "v1.67.0-6"

--- a/scrutiny_fa/config.yaml
+++ b/scrutiny_fa/config.yaml
@@ -45,4 +45,4 @@ schema:
 slug: scrutiny_fa
 udev: true
 url: https://github.com/Starosdev/scrutiny
-version: "v1.67.0-4"
+version: "v1.67.0-5"

--- a/scrutiny_fa/rootfs_overlay/etc/cont-init.d/01-configuration.sh
+++ b/scrutiny_fa/rootfs_overlay/etc/cont-init.d/01-configuration.sh
@@ -89,6 +89,15 @@ case "$FREQUENCY" in
                 fi
                 ;;
 
+            *d) # Matches intervals in days, like "10d"
+                days="${interval%d}"
+                if [[ "$days" -gt 0 && "$days" -le 31 ]]; then
+                    cron_schedule="0 0 */$days * *"
+                else
+                    bashio::log.error "Invalid day interval: $interval"
+                fi
+                ;;
+
             *w) # Matches intervals in weeks, like "1w"
                 weeks="${interval%w}"
                 if [[ "$weeks" -gt 0 && "$weeks" -le 4 ]]; then

--- a/scrutiny_fa/rootfs_overlay/etc/cont-init.d/01-configuration.sh
+++ b/scrutiny_fa/rootfs_overlay/etc/cont-init.d/01-configuration.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+
+#################
+# Create folder #
+#################
+
+DATABASELOCATION="/data"
+echo "Updating folders structure"
+mkdir -p "$DATABASELOCATION"/config
+mkdir -p "$DATABASELOCATION"/influxdb
+if [ -d /opt/scrutiny/config ]; then rm -r /opt/scrutiny/config; fi
+if [ -d /opt/scrutiny/influxdb ]; then rm -r /opt/scrutiny/influxdb; fi
+ln -s "$DATABASELOCATION"/config /opt/scrutiny
+ln -s "$DATABASELOCATION"/influxdb /opt/scrutiny
+
+# Upstream 1.67 upgrades InfluxDB from 2.2 to 2.9 and requires a confirmed
+# offline backup before starting against existing data. Services have not
+# started yet, so this is the safe point to create and verify that backup.
+/usr/local/bin/scrutiny-ha-influxdb-preflight
+
+###############################
+# Migrating previous database #
+###############################
+
+if [ -f /data/scrutiny.db ]; then
+    bashio::log.warning "Previous database detected, migration will start. Backup stored in /share/scrutiny.db.bak"
+    cp /data/scrutiny.db /share/scrutiny.db.bak
+    mv /data/scrutiny.db "$DATABASELOCATION"/config/
+fi
+
+######
+# TZ #
+######
+
+# Align timezone with options
+if bashio::config.has_value "TZ"; then
+    TZ="$(bashio::config 'TZ')"
+    bashio::log.info "Timezone : $TZ"
+    sed -i "1a export TZ=$TZ" /etc/cont-init.d/01-timezone
+fi
+
+################
+# CRON OPTIONS #
+################
+
+# Align update with options
+FREQUENCY="$(bashio::config 'Updates')"
+bashio::log.info "$FREQUENCY updates as defined in the 'Updates' option"
+
+case "$FREQUENCY" in
+    "Quarterly")
+        sed -i "/customize the cron schedule/a export COLLECTOR_CRON_SCHEDULE=\"*/15 * * * *\"" /etc/cont-init.d/50-cron-config
+        ;;
+
+    "Hourly")
+        sed -i "/customize the cron schedule/a export COLLECTOR_CRON_SCHEDULE=\"0 * * * *\"" /etc/cont-init.d/50-cron-config
+        ;;
+
+    "Daily")
+        sed -i "/customize the cron schedule/a export COLLECTOR_CRON_SCHEDULE=\"0 0 * * *\"" /etc/cont-init.d/50-cron-config
+        ;;
+
+    "Weekly")
+        sed -i "/customize the cron schedule/a export COLLECTOR_CRON_SCHEDULE=\"0 0 * * 0\"" /etc/cont-init.d/50-cron-config
+        ;;
+
+    "Custom")
+        interval="$(bashio::config 'Updates_custom_time')"
+        bashio::log.info "... frequency is defined manually as $interval"
+
+        case "$interval" in
+            *m) # Matches intervals in minutes, like "5m" or "30m"
+                minutes="${interval%m}"
+                if [[ "$minutes" -gt 0 && "$minutes" -le 59 ]]; then
+                    cron_schedule="*/$minutes * * * *"
+                else
+                    bashio::log.error "Invalid minute interval: $interval"
+                fi
+                ;;
+
+            *h) # Matches intervals in hours, like "2h"
+                hours="${interval%h}"
+                if [[ "$hours" -gt 0 && "$hours" -le 23 ]]; then
+                    cron_schedule="0 */$hours * * *"
+                else
+                    bashio::log.error "Invalid hour interval: $interval"
+                fi
+                ;;
+
+            *w) # Matches intervals in weeks, like "1w"
+                weeks="${interval%w}"
+                if [[ "$weeks" -gt 0 && "$weeks" -le 4 ]]; then
+                    cron_schedule="0 0 * * 0" # Weekly on Sunday (adjust if needed for multi-week)
+                else
+                    bashio::log.error "Invalid week interval: $interval"
+                fi
+                ;;
+
+            *mo) # Matches intervals in months, like "1mo"
+                months="${interval%mo}"
+                if [[ "$months" -gt 0 && "$months" -le 12 ]]; then
+                    cron_schedule="0 0 1 */$months *" # Monthly on the 1st
+                else
+                    bashio::log.error "Invalid month interval: $interval"
+                fi
+                ;;
+
+            *)
+                bashio::log.error "Empty or unsupported custom interval. It should be in the format of 5m (every 5 minutes), 10d (every 10 days), 3w (every 3 weeks), 3mo (every 3 months)"
+                ;;
+        esac
+
+        if [[ -n "$cron_schedule" ]]; then
+            sed -i "/customize the cron schedule/a export COLLECTOR_CRON_SCHEDULE=\"$cron_schedule\"" /etc/cont-init.d/50-cron-config
+            bashio::log.info "Custom cron schedule set to: $cron_schedule"
+        fi
+        ;;
+esac

--- a/scrutiny_fa/rootfs_overlay/etc/cont-init.d/32-nginx_ingress.sh
+++ b/scrutiny_fa/rootfs_overlay/etc/cont-init.d/32-nginx_ingress.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+
+#################
+# NGINX SETTING #
+#################
+declare port
+declare certfile
+declare ingress_interface
+declare ingress_port
+declare keyfile
+
+port=$(bashio::addon.port 80)
+if bashio::var.has_value "${port}"; then
+    bashio::config.require.ssl
+
+    if bashio::config.true 'ssl'; then
+        certfile=$(bashio::config 'certfile')
+        keyfile=$(bashio::config 'keyfile')
+
+        mv /etc/nginx/servers/direct-ssl.disabled /etc/nginx/servers/direct.conf
+        sed -i "s/%%certfile%%/${certfile}/g" /etc/nginx/servers/direct.conf
+        sed -i "s/%%keyfile%%/${keyfile}/g" /etc/nginx/servers/direct.conf
+
+    else
+        mv /etc/nginx/servers/direct.disabled /etc/nginx/servers/direct.conf
+    fi
+fi
+
+ingress_port=$(bashio::addon.ingress_port)
+ingress_interface=$(bashio::addon.ip_address)
+ingress_entry=$(bashio::addon.ingress_entry)
+sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
+sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
+sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf

--- a/scrutiny_fa/rootfs_overlay/etc/cont-init.d/32-nginx_ingress.sh
+++ b/scrutiny_fa/rootfs_overlay/etc/cont-init.d/32-nginx_ingress.sh
@@ -20,8 +20,8 @@ if bashio::var.has_value "${port}"; then
         keyfile=$(bashio::config 'keyfile')
 
         mv /etc/nginx/servers/direct-ssl.disabled /etc/nginx/servers/direct.conf
-        sed -i "s/%%certfile%%/${certfile}/g" /etc/nginx/servers/direct.conf
-        sed -i "s/%%keyfile%%/${keyfile}/g" /etc/nginx/servers/direct.conf
+        sed -i "s|%%certfile%%|${certfile}|g" /etc/nginx/servers/direct.conf
+        sed -i "s|%%keyfile%%|${keyfile}|g" /etc/nginx/servers/direct.conf
 
     else
         mv /etc/nginx/servers/direct.disabled /etc/nginx/servers/direct.conf

--- a/scrutiny_fa/rootfs_overlay/etc/cont-init.d/90-run.sh
+++ b/scrutiny_fa/rootfs_overlay/etc/cont-init.d/90-run.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+
+#########################
+# EXPOSE COLLECTOR.YAML #
+#########################
+
+if bashio::config.true "expose_collector"; then
+    bashio::log.info "collector.yaml exposed in /share/scrutiny"
+    mkdir -p /share/scrutiny
+    if [ -f /data/config/collector.yaml ]; then
+        cp -rnf /data/config/collector.yaml /share/scrutiny || true
+        rm -R /data/config/collector.yaml
+    fi
+    if [ -f /opt/scrutiny/config/collector.yaml ]; then
+        cp -rnf /opt/scrutiny/config/collector.yaml /share/scrutiny || true
+        rm /opt/scrutiny/config/collector.yaml
+    fi
+    touch /share/scrutiny/collector.yaml
+    ln -sf /share/scrutiny/collector.yaml /data/config || true
+    mkdir -p /opt/scrutiny/config
+    ln -sf /share/scrutiny/collector.yaml /opt/scrutiny/config/collector.yaml || true
+    chmod 755 -R /share/scrutiny
+fi
+
+########
+# MODE #
+########
+
+if [[ "$(bashio::config "Mode")" == Collector ]]; then
+    # Clean services
+    bashio::log.warning "Collector only mode. WebUI and Influxdb will be disabled"
+    rm -r /etc/services.d/influxdb
+    rm -r /etc/services.d/scrutiny
+    rm -r /etc/services.d/nginx
+    sed -i "/wait/d" /etc/services.d/collector-once/run
+    sed -i "/scrutiny api not ready/d" /etc/services.d/collector-once/run
+
+    # Check collector
+    if bashio::config.has_value "COLLECTOR_API_ENDPOINT"; then
+        echo "export COLLECTOR_API_ENDPOINT=$(bashio::config "COLLECTOR_API_ENDPOINT")" >> /env.sh
+        sed -i "1a export COLLECTOR_API_ENDPOINT=$(bashio::config "COLLECTOR_API_ENDPOINT")" /etc/services.d/collector-once/run
+        if [ -d /var/run/s6/container_environment ]; then printf "%s" "$COLLECTOR_API_ENDPOINT" > /var/run/s6/container_environment/COLLECTOR_API_ENDPOINT; fi
+        printf "%s\n" "IN_BACKGROUND=\"$COLLECTOR_API_ENDPOINT\"" >> ~/.bashrc
+        bashio::log.info "Using 'COLLECTOR_API_ENDPOINT' $(bashio::config "COLLECTOR_API_ENDPOINT")"
+    else
+        bashio::exit.nok "Mode is set to 'Collector', but 'COLLECTOR_API_ENDPOINT' is not defined"
+    fi
+fi

--- a/scrutiny_fa/rootfs_overlay/etc/cont-init.d/90-run.sh
+++ b/scrutiny_fa/rootfs_overlay/etc/cont-init.d/90-run.sh
@@ -10,12 +10,18 @@ if bashio::config.true "expose_collector"; then
     bashio::log.info "collector.yaml exposed in /share/scrutiny"
     mkdir -p /share/scrutiny
     if [ -f /data/config/collector.yaml ]; then
-        cp -rnf /data/config/collector.yaml /share/scrutiny || true
-        rm -R /data/config/collector.yaml
+        if cp -rnf /data/config/collector.yaml /share/scrutiny; then
+            rm -f /data/config/collector.yaml
+        else
+            bashio::log.warning "Could not copy /data/config/collector.yaml; keeping the source file"
+        fi
     fi
     if [ -f /opt/scrutiny/config/collector.yaml ]; then
-        cp -rnf /opt/scrutiny/config/collector.yaml /share/scrutiny || true
-        rm /opt/scrutiny/config/collector.yaml
+        if cp -rnf /opt/scrutiny/config/collector.yaml /share/scrutiny; then
+            rm -f /opt/scrutiny/config/collector.yaml
+        else
+            bashio::log.warning "Could not copy /opt/scrutiny/config/collector.yaml; keeping the source file"
+        fi
     fi
     touch /share/scrutiny/collector.yaml
     ln -sf /share/scrutiny/collector.yaml /data/config || true
@@ -31,9 +37,9 @@ fi
 if [[ "$(bashio::config "Mode")" == Collector ]]; then
     # Clean services
     bashio::log.warning "Collector only mode. WebUI and Influxdb will be disabled"
-    rm -r /etc/services.d/influxdb
-    rm -r /etc/services.d/scrutiny
-    rm -r /etc/services.d/nginx
+    rm -rf /etc/services.d/influxdb
+    rm -rf /etc/services.d/scrutiny
+    rm -rf /etc/services.d/nginx
     sed -i "/wait/d" /etc/services.d/collector-once/run
     sed -i "/scrutiny api not ready/d" /etc/services.d/collector-once/run
 

--- a/scrutiny_fa/rootfs_overlay/etc/cont-init.d/90-run.sh
+++ b/scrutiny_fa/rootfs_overlay/etc/cont-init.d/90-run.sh
@@ -9,15 +9,15 @@ set -e
 if bashio::config.true "expose_collector"; then
     bashio::log.info "collector.yaml exposed in /share/scrutiny"
     mkdir -p /share/scrutiny
-    if [ -f /data/config/collector.yaml ]; then
-        if cp -rnf /data/config/collector.yaml /share/scrutiny; then
+    if [ -f /data/config/collector.yaml ] && [ ! -L /data/config/collector.yaml ]; then
+        if cp -n /data/config/collector.yaml /share/scrutiny; then
             rm -f /data/config/collector.yaml
         else
             bashio::log.warning "Could not copy /data/config/collector.yaml; keeping the source file"
         fi
     fi
-    if [ -f /opt/scrutiny/config/collector.yaml ]; then
-        if cp -rnf /opt/scrutiny/config/collector.yaml /share/scrutiny; then
+    if [ -f /opt/scrutiny/config/collector.yaml ] && [ ! -L /opt/scrutiny/config/collector.yaml ]; then
+        if cp -n /opt/scrutiny/config/collector.yaml /share/scrutiny; then
             rm -f /opt/scrutiny/config/collector.yaml
         else
             bashio::log.warning "Could not copy /opt/scrutiny/config/collector.yaml; keeping the source file"

--- a/scrutiny_fa/rootfs_overlay/etc/nginx/includes/mime.types
+++ b/scrutiny_fa/rootfs_overlay/etc/nginx/includes/mime.types
@@ -1,0 +1,96 @@
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    application/javascript                           js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                         wmlc;
+    application/x-7z-compressed                      7z;
+    application/x-cocoa                              cco;
+    application/x-java-archive-diff                  jardiff;
+    application/x-java-jnlp-file                     jnlp;
+    application/x-makeself                           run;
+    application/x-perl                               pl pm;
+    application/x-pilot                              prc pdb;
+    application/x-rar-compressed                     rar;
+    application/x-redhat-package-manager             rpm;
+    application/x-sea                                sea;
+    application/x-shockwave-flash                    swf;
+    application/x-stuffit                            sit;
+    application/x-tcl                                tcl tk;
+    application/x-x509-ca-cert                       der pem crt;
+    application/x-xpinstall                          xpi;
+    application/xhtml+xml                            xhtml;
+    application/xspf+xml                             xspf;
+    application/zip                                  zip;
+
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+
+    audio/midi                                       mid midi kar;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        ogg;
+    audio/x-m4a                                      m4a;
+    audio/x-realaudio                                ra;
+
+    video/3gpp                                       3gpp 3gp;
+    video/mp2t                                       ts;
+    video/mp4                                        mp4;
+    video/mpeg                                       mpeg mpg;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-m4v                                      m4v;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asx asf;
+    video/x-ms-wmv                                   wmv;
+    video/x-msvideo                                  avi;
+}

--- a/scrutiny_fa/rootfs_overlay/etc/nginx/includes/proxy_params.conf
+++ b/scrutiny_fa/rootfs_overlay/etc/nginx/includes/proxy_params.conf
@@ -1,0 +1,15 @@
+proxy_http_version          1.1;
+proxy_ignore_client_abort   off;
+proxy_read_timeout          86400s;
+proxy_redirect              off;
+proxy_send_timeout          86400s;
+proxy_max_temp_file_size    0;
+
+proxy_set_header Accept-Encoding "";
+proxy_set_header Connection $connection_upgrade;
+proxy_set_header Host $http_host;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-NginX-Proxy true;
+proxy_set_header X-Real-IP $remote_addr;

--- a/scrutiny_fa/rootfs_overlay/etc/nginx/includes/resolver.conf
+++ b/scrutiny_fa/rootfs_overlay/etc/nginx/includes/resolver.conf
@@ -1,0 +1,1 @@
+resolver 127.0.0.11 ipv6=off;

--- a/scrutiny_fa/rootfs_overlay/etc/nginx/includes/server_params.conf
+++ b/scrutiny_fa/rootfs_overlay/etc/nginx/includes/server_params.conf
@@ -1,0 +1,5 @@
+server_name     $hostname;
+
+add_header X-Content-Type-Options nosniff;
+add_header X-XSS-Protection "1; mode=block";
+add_header X-Robots-Tag none;

--- a/scrutiny_fa/rootfs_overlay/etc/nginx/includes/ssl_params.conf
+++ b/scrutiny_fa/rootfs_overlay/etc/nginx/includes/ssl_params.conf
@@ -1,0 +1,9 @@
+ssl_protocols TLSv1.2;
+ssl_prefer_server_ciphers on;
+ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA;
+ssl_ecdh_curve secp384r1;
+ssl_session_timeout  10m;
+ssl_session_cache shared:SSL:10m;
+ssl_session_tickets off;
+ssl_stapling on;
+ssl_stapling_verify on;

--- a/scrutiny_fa/rootfs_overlay/etc/nginx/includes/upstream.conf
+++ b/scrutiny_fa/rootfs_overlay/etc/nginx/includes/upstream.conf
@@ -1,0 +1,3 @@
+upstream backend {
+    server 127.0.0.1:8080;
+}

--- a/scrutiny_fa/rootfs_overlay/etc/nginx/nginx.conf
+++ b/scrutiny_fa/rootfs_overlay/etc/nginx/nginx.conf
@@ -1,0 +1,56 @@
+# Run nginx in foreground.
+daemon off;
+
+# This is run inside Docker.
+user root;
+
+# Pid storage location.
+pid /var/run/nginx.pid;
+
+# Set number of worker processes.
+worker_processes 1;
+
+# Enables the use of JIT for regular expressions to speed-up their processing.
+pcre_jit on;
+
+# Write error log to Hass.io add-on log.
+error_log /proc/1/fd/1 error;
+
+# Load allowed environment vars
+env HASSIO_TOKEN;
+
+# Load dynamic modules.
+include /etc/nginx/modules/*.conf;
+
+# Max num of simultaneous connections by a worker process.
+events {
+    worker_connections 512;
+}
+
+http {
+    include /etc/nginx/includes/mime.types;
+
+    log_format hassio '[$time_local] $status '
+                        '$http_x_forwarded_for($remote_addr) '
+                        '$request ($http_user_agent)';
+
+    access_log              /proc/1/fd/1 hassio;
+    client_max_body_size    4G;
+    default_type            application/octet-stream;
+    gzip                    on;
+    keepalive_timeout       65;
+    sendfile                on;
+    server_tokens           off;
+    tcp_nodelay             on;
+    tcp_nopush              on;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
+    include /etc/nginx/includes/resolver.conf;
+    include /etc/nginx/includes/upstream.conf;
+
+    include /etc/nginx/servers/*.conf;
+}

--- a/scrutiny_fa/rootfs_overlay/etc/nginx/servers/ingress.conf
+++ b/scrutiny_fa/rootfs_overlay/etc/nginx/servers/ingress.conf
@@ -1,0 +1,28 @@
+server {
+    listen %%interface%%:%%port%% default_server;
+
+    include /etc/nginx/includes/server_params.conf;
+    include /etc/nginx/includes/proxy_params.conf;
+    
+    client_max_body_size 0;
+
+    root /opt/scrutiny/web;
+
+   location = / {
+      absolute_redirect off;              # Do not add port to redirect
+      return 301 %%ingress_entry%%/web/dashboard;
+   }
+
+  location /api { 
+       add_header Access-Control-Allow-Origin *;   
+       proxy_read_timeout 30;
+       proxy_pass         http://backend/api;
+  }
+
+  location /web/ { 
+       add_header Access-Control-Allow-Origin *;   
+       proxy_read_timeout 30;
+       proxy_pass         http://backend/web/;
+  }
+
+}

--- a/scrutiny_fa/rootfs_overlay/etc/services.d/nginx/finish
+++ b/scrutiny_fa/rootfs_overlay/etc/services.d/nginx/finish
@@ -1,0 +1,9 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+# ==============================================================================
+# Stop the container when Nginx fails
+# ==============================================================================
+if [[ "$1" -ne 0 && "$1" -ne 256 ]]; then
+    bashio::log.error "Nginx exited with code $1"
+    kill -15 1
+fi

--- a/scrutiny_fa/rootfs_overlay/etc/services.d/nginx/run
+++ b/scrutiny_fa/rootfs_overlay/etc/services.d/nginx/run
@@ -1,0 +1,11 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+# ==============================================================================
+
+# Wait for transmission to become available
+bashio::net.wait_for 8080 localhost 900
+
+bashio::log.info "Starting NGinx..."
+
+exec nginx

--- a/scrutiny_fa/rootfs_overlay/etc/services.d/nginx/run
+++ b/scrutiny_fa/rootfs_overlay/etc/services.d/nginx/run
@@ -3,7 +3,7 @@
 set -e
 # ==============================================================================
 
-# Wait for transmission to become available
+# Wait for Scrutiny to become available
 bashio::net.wait_for 8080 localhost 900
 
 bashio::log.info "Starting NGinx..."

--- a/scrutiny_fa/scrutiny-ha-influxdb-preflight
+++ b/scrutiny_fa/scrutiny-ha-influxdb-preflight
@@ -105,19 +105,25 @@ validate_existing_marker() {
             expected_checksum="$(marker_value backup_sha256)"
             if [[ -z "$expected_checksum" ]] || ! validate_archive "$backup_file"; then
                 log error "legacy backup marker exists but its archive cannot be verified"
-                return 2
+                return 1
             fi
             actual_checksum="$(sha256sum "$backup_file" | awk '{print $1}')"
             if [[ "$actual_checksum" != "$expected_checksum" ]]; then
                 log error "legacy backup checksum does not match the migration marker"
-                return 2
+                return 1
             fi
             log info "verified legacy InfluxDB backup and migration marker"
             return 0
             ;;
         *)
-            log warning "legacy or incomplete migration marker detected; rebuilding verified state"
-            return 1
+            if ! validate_archive "$backup_file"; then
+                log error "legacy migration marker exists but no verified backup archive is available"
+                return 1
+            fi
+            actual_checksum="$(sha256sum "$backup_file" | awk '{print $1}')"
+            write_marker legacy-backup "$actual_checksum"
+            log warning "upgraded legacy migration marker with the existing backup checksum"
+            return 0
             ;;
     esac
 }
@@ -125,19 +131,10 @@ validate_existing_marker() {
 mkdir -p "$data_dir"
 
 if [[ -f "$marker_file" ]]; then
-    marker_status=0
-    validate_existing_marker || marker_status=$?
-    case "$marker_status" in
-        0)
-            exit 0
-            ;;
-        1)
-            rm -f "$marker_file"
-            ;;
-        *)
-            exit 1
-            ;;
-    esac
+    if validate_existing_marker; then
+        exit 0
+    fi
+    exit 1
 fi
 
 if ! has_existing_data; then

--- a/scrutiny_fa/scrutiny-ha-influxdb-preflight
+++ b/scrutiny_fa/scrutiny-ha-influxdb-preflight
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+set -euo pipefail
+
+addon_slug="${SCRUTINY_HA_ADDON_SLUG:-scrutiny}"
+data_dir="${SCRUTINY_INFLUXDB_DATA_DIR:-/data/influxdb}"
+backup_dir="${SCRUTINY_INFLUXDB_BACKUP_DIR:-/share/${addon_slug}}"
+marker_file="${data_dir}/.scrutiny-influxdb-2.9-preflight-complete"
+backup_file="${backup_dir}/influxdb-pre-2.9.tar.gz"
+temporary_backup="${backup_file}.tmp"
+archive_root="$(basename "$data_dir")"
+
+log() {
+    local level="$1"
+    local message="$2"
+    printf 'time="%s" level=%s msg="%s" type=ha-influxdb-upgrade-preflight\n' \
+        "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$level" "$message"
+}
+
+has_existing_data() {
+    if [[ -e "${data_dir}/influxd.bolt" || -e "${data_dir}/influxd.sqlite" ]]; then
+        return 0
+    fi
+
+    if [[ -d "${data_dir}/engine" ]] && find "${data_dir}/engine" -mindepth 1 -print -quit | grep -q .; then
+        return 0
+    fi
+
+    return 1
+}
+
+validate_backup() {
+    [[ -s "$backup_file" ]] || return 1
+    gzip -t "$backup_file" >/dev/null 2>&1 || return 1
+    tar -tzf "$backup_file" >/dev/null 2>&1 || return 1
+
+    if [[ -e "${data_dir}/influxd.bolt" ]] && \
+        ! tar -tzf "$backup_file" "${archive_root}/influxd.bolt" >/dev/null 2>&1; then
+        return 1
+    fi
+
+    if [[ -e "${data_dir}/influxd.sqlite" ]] && \
+        ! tar -tzf "$backup_file" "${archive_root}/influxd.sqlite" >/dev/null 2>&1; then
+        return 1
+    fi
+
+    if [[ -d "${data_dir}/engine" ]] && find "${data_dir}/engine" -mindepth 1 -print -quit | grep -q .; then
+        tar -tzf "$backup_file" --wildcards "${archive_root}/engine/*" >/dev/null 2>&1 || return 1
+    fi
+}
+
+mkdir -p "$data_dir"
+
+if [[ -f "$marker_file" ]]; then
+    exit 0
+fi
+
+if ! has_existing_data; then
+    log info "no existing InfluxDB data detected; automatic backup is not required"
+    exit 0
+fi
+
+mkdir -p "$backup_dir"
+
+if validate_backup; then
+    log info "using existing verified InfluxDB backup at ${backup_file}"
+else
+    if [[ -e "$backup_file" ]]; then
+        log warning "existing InfluxDB backup is invalid and will be replaced"
+        rm -f "$backup_file"
+    fi
+
+    rm -f "$temporary_backup"
+    trap 'rm -f "$temporary_backup"' EXIT
+
+    log warning "existing InfluxDB data detected; creating offline backup at ${backup_file}"
+    tar -C "$(dirname "$data_dir")" -czf "$temporary_backup" "$archive_root"
+    gzip -t "$temporary_backup"
+    tar -tzf "$temporary_backup" >/dev/null
+    mv "$temporary_backup" "$backup_file"
+
+    trap - EXIT
+
+    if ! validate_backup; then
+        log error "created InfluxDB backup did not pass validation"
+        exit 1
+    fi
+
+    log info "InfluxDB backup created and verified at ${backup_file}"
+fi
+
+touch "$marker_file"
+log info "InfluxDB 2.9 upgrade preflight marker created after verified backup"

--- a/scrutiny_fa/scrutiny-ha-influxdb-preflight
+++ b/scrutiny_fa/scrutiny-ha-influxdb-preflight
@@ -2,13 +2,16 @@
 # shellcheck shell=bash
 set -euo pipefail
 
-addon_slug="${SCRUTINY_HA_ADDON_SLUG:-scrutiny}"
+addon_slug="${SCRUTINY_HA_ADDON_SLUG:-scrutiny_fa}"
 data_dir="${SCRUTINY_INFLUXDB_DATA_DIR:-/data/influxdb}"
 backup_dir="${SCRUTINY_INFLUXDB_BACKUP_DIR:-/share/${addon_slug}}"
 marker_file="${data_dir}/.scrutiny-influxdb-2.9-preflight-complete"
+marker_tmp="${marker_file}.tmp"
 backup_file="${backup_dir}/influxdb-pre-2.9.tar.gz"
 temporary_backup="${backup_file}.tmp"
 archive_root="$(basename "$data_dir")"
+source_manifest=""
+archive_manifest=""
 
 log() {
     local level="$1"
@@ -16,6 +19,13 @@ log() {
     printf 'time="%s" level=%s msg="%s" type=ha-influxdb-upgrade-preflight\n' \
         "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$level" "$message"
 }
+
+cleanup() {
+    rm -f "$temporary_backup" "$marker_tmp"
+    if [[ -n "$source_manifest" ]]; then rm -f "$source_manifest"; fi
+    if [[ -n "$archive_manifest" ]]; then rm -f "$archive_manifest"; fi
+}
+trap cleanup EXIT
 
 has_existing_data() {
     if [[ -e "${data_dir}/influxd.bolt" || -e "${data_dir}/influxd.sqlite" ]]; then
@@ -29,65 +39,135 @@ has_existing_data() {
     return 1
 }
 
-validate_backup() {
-    [[ -s "$backup_file" ]] || return 1
-    gzip -t "$backup_file" >/dev/null 2>&1 || return 1
-    tar -tzf "$backup_file" >/dev/null 2>&1 || return 1
+validate_archive() {
+    local archive="$1"
+    [[ -s "$archive" ]] || return 1
+    gzip -t "$archive" >/dev/null 2>&1 || return 1
+    tar -tzf "$archive" >/dev/null 2>&1
+}
 
-    if [[ -e "${data_dir}/influxd.bolt" ]] && \
-        ! tar -tzf "$backup_file" "${archive_root}/influxd.bolt" >/dev/null 2>&1; then
+validate_backup_against_source() {
+    local archive="$1"
+
+    validate_archive "$archive" || return 1
+    source_manifest="$(mktemp)"
+    archive_manifest="$(mktemp)"
+
+    (
+        cd "$data_dir"
+        find . -mindepth 1 -print | sed -e 's#^\./##' -e 's#/$##' | LC_ALL=C sort
+    ) > "$source_manifest"
+
+    tar -tzf "$archive" | \
+        sed -e "s#^${archive_root}/##" -e '/^$/d' -e 's#/$##' | \
+        LC_ALL=C sort > "$archive_manifest"
+
+    if ! cmp -s "$source_manifest" "$archive_manifest"; then
+        rm -f "$source_manifest" "$archive_manifest"
+        source_manifest=""
+        archive_manifest=""
         return 1
     fi
 
-    if [[ -e "${data_dir}/influxd.sqlite" ]] && \
-        ! tar -tzf "$backup_file" "${archive_root}/influxd.sqlite" >/dev/null 2>&1; then
-        return 1
-    fi
+    rm -f "$source_manifest" "$archive_manifest"
+    source_manifest=""
+    archive_manifest=""
+}
 
-    if [[ -d "${data_dir}/engine" ]] && find "${data_dir}/engine" -mindepth 1 -print -quit | grep -q .; then
-        tar -tzf "$backup_file" --wildcards "${archive_root}/engine/*" >/dev/null 2>&1 || return 1
-    fi
+marker_value() {
+    local key="$1"
+    awk -F= -v key="$key" '$1 == key {sub(/^[^=]*=/, ""); print; exit}' "$marker_file"
+}
+
+write_marker() {
+    local state="$1"
+    local checksum="${2:-}"
+
+    {
+        printf 'state=%s\n' "$state"
+        if [[ -n "$checksum" ]]; then
+            printf 'backup_sha256=%s\n' "$checksum"
+        fi
+    } > "$marker_tmp"
+    mv "$marker_tmp" "$marker_file"
+}
+
+validate_existing_marker() {
+    local state expected_checksum actual_checksum
+
+    state="$(marker_value state)"
+    case "$state" in
+        no-legacy-data)
+            log info "verified no-legacy-data migration marker"
+            return 0
+            ;;
+        legacy-backup)
+            expected_checksum="$(marker_value backup_sha256)"
+            if [[ -z "$expected_checksum" ]] || ! validate_archive "$backup_file"; then
+                log error "legacy backup marker exists but its archive cannot be verified"
+                return 2
+            fi
+            actual_checksum="$(sha256sum "$backup_file" | awk '{print $1}')"
+            if [[ "$actual_checksum" != "$expected_checksum" ]]; then
+                log error "legacy backup checksum does not match the migration marker"
+                return 2
+            fi
+            log info "verified legacy InfluxDB backup and migration marker"
+            return 0
+            ;;
+        *)
+            log warning "legacy or incomplete migration marker detected; rebuilding verified state"
+            return 1
+            ;;
+    esac
 }
 
 mkdir -p "$data_dir"
 
 if [[ -f "$marker_file" ]]; then
-    exit 0
+    marker_status=0
+    validate_existing_marker || marker_status=$?
+    case "$marker_status" in
+        0)
+            exit 0
+            ;;
+        1)
+            rm -f "$marker_file"
+            ;;
+        *)
+            exit 1
+            ;;
+    esac
 fi
 
 if ! has_existing_data; then
-    log info "no existing InfluxDB data detected; automatic backup is not required"
+    write_marker no-legacy-data
+    log info "no existing InfluxDB data detected; recorded no-legacy-data migration state"
     exit 0
 fi
 
 mkdir -p "$backup_dir"
 
-if validate_backup; then
-    log info "using existing verified InfluxDB backup at ${backup_file}"
+if [[ -e "$backup_file" ]] && validate_backup_against_source "$backup_file"; then
+    log info "using existing complete InfluxDB backup at ${backup_file}"
 else
     if [[ -e "$backup_file" ]]; then
-        log warning "existing InfluxDB backup is invalid and will be replaced"
+        log warning "existing InfluxDB backup is incomplete or invalid and will be replaced"
         rm -f "$backup_file"
     fi
 
-    rm -f "$temporary_backup"
-    trap 'rm -f "$temporary_backup"' EXIT
-
     log warning "existing InfluxDB data detected; creating offline backup at ${backup_file}"
     tar -C "$(dirname "$data_dir")" -czf "$temporary_backup" "$archive_root"
-    gzip -t "$temporary_backup"
-    tar -tzf "$temporary_backup" >/dev/null
-    mv "$temporary_backup" "$backup_file"
 
-    trap - EXIT
-
-    if ! validate_backup; then
-        log error "created InfluxDB backup did not pass validation"
+    if ! validate_backup_against_source "$temporary_backup"; then
+        log error "created InfluxDB backup does not contain the complete source tree"
         exit 1
     fi
 
+    mv "$temporary_backup" "$backup_file"
     log info "InfluxDB backup created and verified at ${backup_file}"
 fi
 
-touch "$marker_file"
-log info "InfluxDB 2.9 upgrade preflight marker created after verified backup"
+backup_checksum="$(sha256sum "$backup_file" | awk '{print $1}')"
+write_marker legacy-backup "$backup_checksum"
+log info "InfluxDB 2.9 migration marker created with verified backup checksum"

--- a/scrutiny_fa/scrutiny-ha-influxdb-preflight
+++ b/scrutiny_fa/scrutiny-ha-influxdb-preflight
@@ -10,6 +10,7 @@ marker_tmp="${marker_file}.tmp"
 backup_file="${backup_dir}/influxdb-pre-2.9.tar.gz"
 temporary_backup="${backup_file}.tmp"
 archive_root="$(basename "$data_dir")"
+validation_method="content-sha256-v1"
 source_manifest=""
 archive_manifest=""
 
@@ -46,8 +47,22 @@ validate_archive() {
     tar -tzf "$archive" >/dev/null 2>&1
 }
 
+reset_manifests() {
+    rm -f "$source_manifest" "$archive_manifest"
+    source_manifest=""
+    archive_manifest=""
+}
+
 validate_backup_against_source() {
     local archive="$1"
+    local relative_path
+    local source_path
+    local archive_member
+    local listing
+    local source_checksum
+    local archive_checksum
+    local source_target
+    local archive_target
 
     validate_archive "$archive" || return 1
     source_manifest="$(mktemp)"
@@ -63,15 +78,52 @@ validate_backup_against_source() {
         LC_ALL=C sort > "$archive_manifest"
 
     if ! cmp -s "$source_manifest" "$archive_manifest"; then
-        rm -f "$source_manifest" "$archive_manifest"
-        source_manifest=""
-        archive_manifest=""
+        reset_manifests
         return 1
     fi
 
-    rm -f "$source_manifest" "$archive_manifest"
-    source_manifest=""
-    archive_manifest=""
+    while IFS= read -r relative_path; do
+        source_path="${data_dir}/${relative_path}"
+        archive_member="${archive_root}/${relative_path}"
+        listing="$(tar -tvzf "$archive" -- "$archive_member" 2>/dev/null)" || {
+            reset_manifests
+            return 1
+        }
+
+        if [[ -L "$source_path" ]]; then
+            [[ "${listing:0:1}" == "l" ]] || {
+                reset_manifests
+                return 1
+            }
+            source_target="$(readlink "$source_path")"
+            archive_target="${listing##* -> }"
+            [[ "$source_target" == "$archive_target" ]] || {
+                reset_manifests
+                return 1
+            }
+        elif [[ -f "$source_path" ]]; then
+            [[ "${listing:0:1}" == "-" || "${listing:0:1}" == "h" ]] || {
+                reset_manifests
+                return 1
+            }
+            source_checksum="$(sha256sum "$source_path" | awk '{print $1}')"
+            archive_checksum="$(tar -xOzf "$archive" -- "$archive_member" | sha256sum | awk '{print $1}')"
+            [[ "$source_checksum" == "$archive_checksum" ]] || {
+                reset_manifests
+                return 1
+            }
+        elif [[ -d "$source_path" ]]; then
+            [[ "${listing:0:1}" == "d" ]] || {
+                reset_manifests
+                return 1
+            }
+        else
+            reset_manifests
+            return 1
+        fi
+    done < "$source_manifest"
+
+    reset_manifests
 }
 
 marker_value() {
@@ -82,26 +134,42 @@ marker_value() {
 write_marker() {
     local state="$1"
     local checksum="${2:-}"
+    local validation="${3:-}"
 
     {
         printf 'state=%s\n' "$state"
-        if [[ -n "$checksum" ]]; then
-            printf 'backup_sha256=%s\n' "$checksum"
-        fi
+        if [[ -n "$validation" ]]; then printf 'validation=%s\n' "$validation"; fi
+        if [[ -n "$checksum" ]]; then printf 'backup_sha256=%s\n' "$checksum"; fi
     } > "$marker_tmp"
     mv "$marker_tmp" "$marker_file"
 }
 
 validate_existing_marker() {
-    local state expected_checksum actual_checksum
+    local state
+    local validation
+    local expected_checksum
+    local actual_checksum
 
     state="$(marker_value state)"
+    validation="$(marker_value validation)"
+
     case "$state" in
         no-legacy-data)
-            log info "verified no-legacy-data migration marker"
+            if [[ -n "$validation" && "$validation" != "no-data-v1" ]]; then
+                log error "no-data migration marker uses an unknown validation method"
+                return 1
+            fi
+            if [[ -z "$validation" ]]; then
+                write_marker no-legacy-data "" no-data-v1
+                log warning "upgraded no-data migration marker with explicit validation state"
+            fi
             return 0
             ;;
         legacy-backup)
+            if [[ "$validation" != "$validation_method" ]]; then
+                log error "legacy backup marker lacks content-level validation proof"
+                return 1
+            fi
             expected_checksum="$(marker_value backup_sha256)"
             if [[ -z "$expected_checksum" ]] || ! validate_archive "$backup_file"; then
                 log error "legacy backup marker exists but its archive cannot be verified"
@@ -112,18 +180,11 @@ validate_existing_marker() {
                 log error "legacy backup checksum does not match the migration marker"
                 return 1
             fi
-            log info "verified legacy InfluxDB backup and migration marker"
             return 0
             ;;
         *)
-            if ! validate_archive "$backup_file"; then
-                log error "legacy migration marker exists but no verified backup archive is available"
-                return 1
-            fi
-            actual_checksum="$(sha256sum "$backup_file" | awk '{print $1}')"
-            write_marker legacy-backup "$actual_checksum"
-            log warning "upgraded legacy migration marker with the existing backup checksum"
-            return 0
+            log error "legacy migration marker lacks content-level validation proof"
+            return 1
             ;;
     esac
 }
@@ -131,40 +192,37 @@ validate_existing_marker() {
 mkdir -p "$data_dir"
 
 if [[ -f "$marker_file" ]]; then
-    if validate_existing_marker; then
-        exit 0
-    fi
+    if validate_existing_marker; then exit 0; fi
     exit 1
 fi
 
 if ! has_existing_data; then
-    write_marker no-legacy-data
-    log info "no existing InfluxDB data detected; recorded no-legacy-data migration state"
+    write_marker no-legacy-data "" no-data-v1
+    log info "no existing InfluxDB data detected; recorded no-data migration state"
     exit 0
 fi
 
 mkdir -p "$backup_dir"
 
 if [[ -e "$backup_file" ]] && validate_backup_against_source "$backup_file"; then
-    log info "using existing complete InfluxDB backup at ${backup_file}"
+    log info "using existing content-verified InfluxDB backup at ${backup_file}"
 else
     if [[ -e "$backup_file" ]]; then
-        log warning "existing InfluxDB backup is incomplete or invalid and will be replaced"
-        rm -f "$backup_file"
+        log warning "existing InfluxDB backup is stale, incomplete, or invalid and will be atomically replaced"
     fi
 
-    log warning "existing InfluxDB data detected; creating offline backup at ${backup_file}"
+    log warning "creating offline InfluxDB backup at ${backup_file}"
     tar -C "$(dirname "$data_dir")" -czf "$temporary_backup" "$archive_root"
 
     if ! validate_backup_against_source "$temporary_backup"; then
-        log error "created InfluxDB backup does not contain the complete source tree"
+        log error "created InfluxDB backup failed content-level validation"
         exit 1
     fi
 
-    mv "$temporary_backup" "$backup_file"
-    log info "InfluxDB backup created and verified at ${backup_file}"
+    mv -f "$temporary_backup" "$backup_file"
+    log info "InfluxDB backup created and content-verified at ${backup_file}"
 fi
 
 backup_checksum="$(sha256sum "$backup_file" | awk '{print $1}')"
-write_marker legacy-backup "$backup_checksum"
-log info "InfluxDB 2.9 migration marker created with verified backup checksum"
+write_marker legacy-backup "$backup_checksum" "$validation_method"
+log info "InfluxDB 2.9 migration marker created with content-validation method and backup checksum"


### PR DESCRIPTION
## Summary

- restore upstream s6-overlay `/init` as PID 1 for both `scrutiny` and `scrutiny_fa`
- stop rewriting and manually launching `/etc/services.d` scripts, so upstream `s6-svwait` and `s6-svc` calls operate against a real supervision tree
- automatically create and validate an offline backup of existing persistent InfluxDB data before allowing the upstream 2.9 migration preflight to continue
- keep standard and Full Access backups separate under `/share/scrutiny` and `/share/scrutiny_fa`
- replace the Full Access add-on's cross-directory `rootfs` build dependency with a materialized, self-contained overlay
- add a build-time migration test that verifies archive contents, marker creation, and idempotency

## Root cause

The previous fix removed only the SMART collector's `s6-svwait` call. The Home Assistant wrapper was still replacing `/init` and running every upstream service script directly. Scrutiny 1.67 contains additional optional collector scripts that depend on the s6 supervision tree; rewriting their shebangs through the wrapper also caused unset optional environment variables to fail under nounset behavior.

Separately, Scrutiny 1.67 upgrades bundled InfluxDB from 2.2 to 2.9. Upstream deliberately refuses to start against existing data until an offline backup has been confirmed. The add-on now creates that backup before services start and only writes upstream's preflight marker after the archive passes gzip, tar, and expected-content validation.

## Validation

Local migration-helper tests:

- `bash -n`
- representative InfluxDB tree containing Bolt metadata and engine data
- gzip/tar validation and required-member checks
- marker creation only after successful validation
- idempotent second execution without rewriting the archive
- empty-data behavior without a spurious backup or marker
- replacement of an invalid pre-existing backup

GitHub Actions:

- `scrutiny`: add-on lint passed; image builds passed on aarch64 and amd64 (run 29654415061)
- `scrutiny_fa`: changelog check, add-on lint, and image builds passed on aarch64 and amd64 (run 29654942808)
- super-linter passed on the final commit (run 29654942807)

Both image builds execute the representative migration and idempotency test during Docker build.

Closes #2879

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated, verified offline InfluxDB backup preflight with idempotent migration markers.
  * Extended update scheduling so “Custom” supports day-based intervals.
  * Improved startup wiring for services (including entrypoint/init changes) and collector mode behavior.
  * Added/expanded NGINX ingress runtime configuration (SSL templating and proxy routing).

* **Bug Fixes**
  * Fail-closed handling for corrupt or mismatched offline backups (backup is not reused).
  * Safer collector configuration copying and more robust service stop/cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->