### PR TITLE
elasticsearch: build FROM docker.elastic.co (fix aarch64 mirror-lag build failure)

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -15,7 +15,11 @@
 #################
 
 ARG BUILD_UPSTREAM="8.19.19"
-FROM elasticsearch:$BUILD_UPSTREAM
+# Pull from Elastic's own registry (multi-arch, published atomically with the
+# GitHub release the updater tracks) rather than the Docker Hub "library"
+# mirror, whose arm64/aarch64 tag lags hours behind and breaks the aarch64
+# build right after an update (e.g. elasticsearch:8.19.19 arm64 missing).
+FROM docker.elastic.co/elasticsearch/elasticsearch:$BUILD_UPSTREAM
 
 # The base image ends as USER 1000:0 with a root-owned, read-only (0555)
 # entrypoint; switch back to root for the remaining build steps (entrypoint


### PR DESCRIPTION
## Problem

The **Builder** run [*Updater bot : elasticsearch updated to 8.19.19*](https://github.com/alexbelgium/hassio-addons/actions/runs/29838844506) failed both arch builds:

```
ERROR: failed to build: failed to solve: elasticsearch:8.19.19:
failed to resolve source metadata for docker.io/library/elasticsearch:8.19.19: not found
```

This is an upstream **mirror-lag race**, not a bad version:

- `updater.json` tracks **GitHub tags** of `elastic/elasticsearch` (filter `v8.19`) and bumps the moment `v8.19.19` is tagged.
- The Dockerfile built `FROM elasticsearch:$BUILD_UPSTREAM` — the Docker Hub **`library/elasticsearch`** mirror, which lags the release. At build time the tag wasn't there at all.
- Even now, `docker.io/library/elasticsearch:8.19.19` has **only `linux/amd64`** — `arm64/aarch64` is still missing — so a plain re-run would keep failing the `aarch64` job.
- Elastic's own registry **`docker.elastic.co/elasticsearch/elasticsearch:8.19.19` already has both `amd64` and `arm64`** (published atomically with the GitHub tag).

## Fix

```diff
 ARG BUILD_UPSTREAM="8.19.19"
-FROM elasticsearch:$BUILD_UPSTREAM
+FROM docker.elastic.co/elasticsearch/elasticsearch:$BUILD_UPSTREAM
```

Pulling from Elastic's own registry — which the updater's version source (the GitHub release) is already aligned with — fixes this build **and prevents it recurring on every release**, since the Docker Hub `library` mirror will always lag.

## Safety / compatibility

- **Same image content.** Compared both registries' image configs on a version both carry (8.19.18): identical `User=1000:0`, `Entrypoint=[/bin/tini, --, /usr/local/bin/docker-entrypoint.sh]`, `Cmd=[eswrapper]`. The Dockerfile's entrypoint patch (`sed ... addon-init.sh`) and root→uid1000 handling are unaffected.
- **Both arches present now** for 8.19.19 on `docker.elastic.co` → green build.
- **Updater unaffected.** `addons_updater` does a blanket `sed s/<current>/<latest>/g` over the Dockerfile; the version substring in `ARG BUILD_UPSTREAM` is untouched, so future bumps keep working. Registry is anonymous-pullable (no auth/rate-limit concerns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Elasticsearch container image source to Elastic’s official registry.
  * Improved compatibility with newer upstream releases and ARM-based environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->