### PR TITLE
Fix Linkwarden 2.15.1 startup

### DIFF
--- a/linkwarden/CHANGELOG.md
+++ b/linkwarden/CHANGELOG.md
@@ -1,4 +1,8 @@
- 
+## 2.15.1.2 (2026-07-22)
+- **Potential breaking change:** Create a full Home Assistant backup before upgrading. This release changes the Linkwarden application startup and database migration invocation.
+- Fix startup after Linkwarden 2.15 changed its production container layout.
+- Replace the legacy Yarn-based startup with direct Prisma, web, and worker runtime commands.
+
 ## 2.15.1 (2026-07-22)
 - Update to latest version from linkwarden/linkwarden (changelog : https://github.com/linkwarden/linkwarden/releases)
 

--- a/linkwarden/config.yaml
+++ b/linkwarden/config.yaml
@@ -45,5 +45,5 @@ schema:
   STORAGE_FOLDER: str?
 slug: linkwarden
 url: https://github.com/alexbelgium/hassio-addons/tree/master/linkwarden
-version: "2.15.1"
+version: "2.15.1.2"
 webui: "[PROTO:ssl]://[HOST]:[PORT:3000]"

--- a/linkwarden/rootfs/etc/cont-init.d/99-run.sh
+++ b/linkwarden/rootfs/etc/cont-init.d/99-run.sh
@@ -92,4 +92,4 @@ prisma migrate deploy --schema="/data_linkwarden/packages/prisma/schema.prisma"
 
 exec concurrently -k -n web,worker \
     "cd /data_linkwarden/apps/web && exec next start" \
-    "cd /data_linkwarden/apps/worker && exec tsx index.ts"
+    "cd /data_linkwarden/apps/worker && exec tsx worker.ts"

--- a/linkwarden/rootfs/etc/cont-init.d/99-run.sh
+++ b/linkwarden/rootfs/etc/cont-init.d/99-run.sh
@@ -86,4 +86,10 @@ fi
 ########################
 
 bashio::log.info "Starting app..."
-yarn prisma:deploy && yarn concurrently:start
+export PATH="/data_linkwarden/node_modules/.bin:${PATH}"
+
+prisma migrate deploy --schema="/data_linkwarden/packages/prisma/schema.prisma"
+
+exec concurrently -k -n web,worker \
+    "cd /data_linkwarden/apps/web && exec next start" \
+    "cd /data_linkwarden/apps/worker && exec tsx index.ts"


### PR DESCRIPTION
## Summary

- replace the obsolete Yarn-based startup command with direct runtime binaries compatible with Linkwarden 2.15.1
- run Prisma migrations against the explicit schema path before starting the web and worker processes
- start `worker.ts` directly so fatal worker failures propagate to `concurrently` and Home Assistant
- bump the add-on version to `2.15.1.2`
- document this as a potential breaking change and instruct users to create a full Home Assistant backup before upgrading

## Root cause

Linkwarden 2.15 moved to a multi-stage image. Corepack is enabled in the build stage, but the final runtime stage does not expose Yarn 4. The add-on overrides the upstream runtime command with `yarn prisma:deploy && yarn concurrently:start`, which invokes the legacy global Yarn 1.22.22 and exits because `package.json` requires Yarn 4.12.0.

## Validation

- `bash -n` passes for `99-run.sh`
- branch is based on the current `master` and changes only the Linkwarden startup script, changelog, and version
- runtime commands match the Linkwarden 2.15.1 production container, including direct execution of `worker.ts`
- the actionable review comment about avoiding the `index.ts` respawn wrapper was implemented and resolved
- Super-Linter, Home Assistant add-on lint, and changelog checks pass
- the add-on build check was retried and fails before executing the add-on Dockerfile because the repository workflow reads `build.yaml` with `jq`, passes an empty `BUILD_FROM`, and BuildKit rejects `FROM ${BUILD_FROM}`; this is an existing CI workflow false negative rather than a failure caused by this patch

A complete runtime smoke test still requires building the add-on with the resolved `BUILD_FROM` for both `amd64` and `aarch64`.

Closes #2891

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed add-on startup compatibility with Linkwarden 2.15’s updated production container layout.
  * Improved database migration handling during startup.
  * Ensured the web interface and background processing start reliably together.

* **Chores**
  * Updated the add-on to version 2.15.1.2.

* **Documentation**
  * Added upgrade guidance recommending a full Home Assistant backup before updating due to a potential breaking change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->