### PR TITLE
feat: manual tier-1 triage of a single issue number

### DIFF
--- a/.github/workflows/on_issues_ai_triage.yaml
+++ b/.github/workflows/on_issues_ai_triage.yaml
@@ -13,6 +13,11 @@ name: AI issue triage
 on:
   issues:
     types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: "Issue number to (re-)triage manually"
+        required: true
 
 permissions:
   contents: read
@@ -20,7 +25,7 @@ permissions:
   id-token: write  # claude-code-action fetches a GitHub OIDC token to auth the OAuth flow
 
 concurrency:
-  group: ai-triage-${{ github.event.issue.number }}
+  group: ai-triage-${{ github.event.issue.number || inputs.issue }}
   cancel-in-progress: false
 
 env:
@@ -28,9 +33,13 @@ env:
 
 jobs:
   classify:
+    # Manual dispatch is a deliberate override: skip the auto-trigger guards
+    # (don't self-triage the maintainer's own issues; honour the no-ai
+    # opt-out) that only make sense for the fire-on-every-open path.
     if: >-
-      github.event.issue.user.login != 'alexbelgium' &&
-      !contains(github.event.issue.labels.*.name, 'no-ai')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.user.login != 'alexbelgium' &&
+       !contains(github.event.issue.labels.*.name, 'no-ai'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: CR_PAT
@@ -41,7 +50,10 @@ jobs:
       # Both workflows fire on the same issues.opened event and race. The
       # submitter ping completes in 6-11s of job time across recent runs; 60s
       # leaves a generous margin for runner-queue skew between the two jobs.
+      # A manual dispatch runs against an existing issue whose ping (if any)
+      # landed long ago, so there is nothing to wait for.
       - name: Wait for ping_submitter
+        if: github.event_name == 'issues'
         run: sleep 60
 
       - name: Checkout tooling
@@ -57,7 +69,7 @@ jobs:
       - name: Build context bundle
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue }}
           REPO: ${{ github.repository }}
         run: bash .github/scripts/ai_triage_context.sh
 
@@ -83,7 +95,7 @@ jobs:
       - name: Apply verdict
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE: ${{ github.event.issue.number }}
+          ISSUE: ${{ github.event.issue.number || inputs.issue }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to **AI issue triage** (tier 1) so you can triage one specific existing issue on demand — Actions → *AI issue triage* → **Run workflow** → enter the issue number. Until now tier 1 only fired automatically on `issues.opened`.

### What changed (one file, `on_issues_ai_triage.yaml`)
- New `workflow_dispatch` input `issue` (required).
- Every issue-number reference now resolves as `github.event.issue.number || inputs.issue` — from the event on the auto path, from the input on manual dispatch (concurrency group, `ISSUE_NUMBER`, `ISSUE`).
- The auto-trigger guards (don't self-triage the maintainer's own issues; honour `no-ai`) are **bypassed on manual dispatch** — an explicit run is a deliberate override.
- The 60s `ping_submitter` wait is **skipped on manual dispatch** — no race to lose on an issue whose ping already landed.

### Safety
The input flows only through `env:` vars and expression contexts, never inline into a `run:` block, so there's no shell-injection surface; a non-numeric value just makes `gh issue view` fail cleanly. `actionlint` passes.

### Note
Re-triaging an already-classified issue will re-apply labels and may post a fresh triage comment — that's inherent to re-running triage on demand, not deduped here (kept the change minimal). Say the word if you'd rather it skip issues already carrying `ai:classified`.

> Stacked on `fix/ai-triage-live-readiness` (#2899) since it builds on that branch's live-ready tier-1 code (DRY_RUN removed, `id-token: write` added). GitHub will retarget this to `master` automatically once #2899 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
