### PR TITLE
fix(portainer): disable nginx gzip re-compression on ingress (#2766)

### DIFF
--- a/portainer/CHANGELOG.md
+++ b/portainer/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## 2.43.0.1 (2026-07-24)
+- Ingress: disable nginx gzip re-compression of proxied responses so Home Assistant relays them via the buffered path (addresses 502 Bad Gateway via ingress, #2766)
+
 ## 2.43.0 (2026-06-27)
 - Update to latest version from portainer/portainer (changelog : https://github.com/portainer/portainer/releases)
 

--- a/portainer/config.yaml
+++ b/portainer/config.yaml
@@ -42,4 +42,4 @@ schema:
 slug: portainer
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "2.43.0"
+version: "2.43.0.1"

--- a/portainer/rootfs/etc/cont-init.d/30-nginx.sh
+++ b/portainer/rootfs/etc/cont-init.d/30-nginx.sh
@@ -16,8 +16,8 @@ if bashio::config.true 'ssl'; then
     sed -i "s|9000|9443|g" /etc/nginx/includes/upstream.conf
     sed -i "s|9000|9443|g" /etc/services.d/nginx/run
     sed -i "s|9099 default_server|9099 ssl|g" /etc/nginx/templates/ingress.gtpl
-    sed -i '7 i ssl_certificate /ssl/{{ .certfile }};' /etc/nginx/templates/ingress.gtpl
-    sed -i '7 i ssl_certificate_key /ssl/{{ .keyfile }};' /etc/nginx/templates/ingress.gtpl
+    sed -i '8 i ssl_certificate /ssl/{{ .certfile }};' /etc/nginx/templates/ingress.gtpl
+    sed -i '8 i ssl_certificate_key /ssl/{{ .keyfile }};' /etc/nginx/templates/ingress.gtpl
     bashio::log.info "Ssl enabled, please use https for connection"
 else
     sed -i '/connection_upgrade/a\proxy_set_header Origin "";' /etc/nginx/templates/ingress.gtpl

--- a/portainer/rootfs/etc/nginx/templates/ingress.gtpl
+++ b/portainer/rootfs/etc/nginx/templates/ingress.gtpl
@@ -4,6 +4,7 @@ server {
   include /etc/nginx/includes/server_params.conf;
   include /etc/nginx/includes/proxy_params.conf;
   client_max_body_size 0;
+  gzip off;
 
   proxy_hide_header X-Frame-Options;
   proxy_hide_header Content-Security-Policy;


### PR DESCRIPTION
## Summary
- Ingress responses were re-gzipped by nginx (default `gzip_types` includes `text/html`), which drops `Content-Length` and forces a chunked/streamed response back through Supervisor and Core's ingress proxy.
- That pushes both relays out of their buffered fast path (small, fixed-length responses read fully then returned) into the streaming path, where an aiohttp-side error surfaces to the browser as a `502 Bad Gateway` — even though the addon's own nginx access log shows a clean `200` for the same request.
- Adds `gzip off;` to the ingress server block so responses stay identity-encoded with an intact `Content-Length`, keeping the relay on its more robust buffered path.
- Bumps addon version to `2.43.0.1` and updates `30-nginx.sh`'s line-numbered `sed` inserts (used when `ssl: true`) to account for the new line.

## Context
Addresses #2766 (`502 Bad Gateway` accessing Portainer via Ingress while direct `:9000` access works fine). Root cause analysis: the 502 body/headers match HA Core/Supervisor's own `aiohttp.web.HTTPBadGateway` default response, and the addon's nginx logs show the corresponding requests succeeding — so the failure happens while Core/Supervisor relay the addon's response back to the browser, most likely triggered by an environment/version skew on the reporter's stack (Core 2025.11.3 with Supervisor 2026.05.1) hitting an edge case in the streaming relay path. This change removes the streaming trigger addon-side regardless of which specific relay quirk fires.

## Test plan
- [x] Rendered `ingress.gtpl` through the exact `sed` sequence in `30-nginx.sh` for both `ssl: false` and `ssl: true`, then validated with `nginx -t` (including real SSL cert loading for the `ssl: true` case) — both configs are syntactically valid and `gzip off;` correctly overrides the global `gzip on;`.
- [ ] Reporter confirms ingress access works after this ships in a build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed 502 Bad Gateway errors when accessing Home Assistant through an ingress.
  * Disabled NGINX gzip compression for proxied responses to improve relay compatibility.

* **Release**
  * Updated the add-on version to 2.43.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->