### PR TITLE
AI triage: use Opus 5 instead of Opus 4.8

### DIFF
--- a/.github/workflows/daily_ai_fix.yaml
+++ b/.github/workflows/daily_ai_fix.yaml
@@ -1,7 +1,7 @@
 ---
 # Destination: .github/workflows/daily_ai_fix.yaml
 #
-# Tier 2 of the AI triage system. One Opus 4.8 run at xhigh over the whole
+# Tier 2 of the AI triage system. One Opus 5 run at xhigh over the whole
 # batch of `ai-triage` issues, grouped by add-on, so it can spot the cross-issue
 # patterns a per-issue run never sees ("these four reports are all the same base
 # image bump"). Runs daily rather than weekly, so batches (default limit 8) stay
@@ -18,8 +18,8 @@
 #
 # Full tier map:
 #   Tier 1  on_issues_ai_triage.yaml  Sonnet-low  classify on issue open
-#   Tier 2  daily_ai_fix.yaml (this)  Opus-xhigh  daily fix/plan sweep
-#   Tier 3  on_issue_approved.yaml    Opus-high   execute an approved plan
+#   Tier 2  daily_ai_fix.yaml (this)  Opus 5-xhigh  daily fix/plan sweep
+#   Tier 3  on_issue_approved.yaml    Opus 5-high   execute an approved plan
 #   @claude on_claude_mention.yml     Sonnet-low  maintainer-only interactive
 #   PR      on_pr_coderabbit.yml      Sonnet-low  one-shot CodeRabbit follow-up
 # Kill switch: set repo variable AI_DISABLED=true to pause every AI workflow.
@@ -137,7 +137,7 @@ jobs:
             Follow .github/prompts/issue-fix.md exactly. Do not deviate from
             the path restrictions in that file under any circumstances.
           claude_args: |
-            --model claude-opus-4-8
+            --model claude-opus-5
             --effort xhigh
             --max-turns 300
             --allowedTools "Read,Write,Edit,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(shellcheck:*),Bash(yamllint:*),Bash(docker build:*)"

--- a/.github/workflows/on_issue_approved.yaml
+++ b/.github/workflows/on_issue_approved.yaml
@@ -146,7 +146,7 @@ jobs:
             exactly. Do not deviate from the path restrictions under any
             circumstances.
           claude_args: |
-            --model claude-opus-4-8
+            --model claude-opus-5
             --effort high
             --max-turns 200
             --allowedTools "Read,Write,Edit,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(shellcheck:*),Bash(yamllint:*),Bash(docker build:*)"

--- a/.github/workflows/on_issues_ai_triage.yaml
+++ b/.github/workflows/on_issues_ai_triage.yaml
@@ -13,8 +13,8 @@
 #
 # Full tier map:
 #   Tier 1  on_issues_ai_triage.yaml (this)  Sonnet-low  classify on issue open
-#   Tier 2  daily_ai_fix.yaml                Opus-xhigh  daily fix/plan sweep
-#   Tier 3  on_issue_approved.yaml           Opus-high   execute an approved plan
+#   Tier 2  daily_ai_fix.yaml                Opus 5-xhigh  daily fix/plan sweep
+#   Tier 3  on_issue_approved.yaml           Opus 5-high   execute an approved plan
 #   @claude on_claude_mention.yml            Sonnet-low  maintainer-only interactive
 #   PR      on_pr_coderabbit.yml             Sonnet-low  one-shot CodeRabbit follow-up
 # Kill switch: set repo variable AI_DISABLED=true to pause every AI workflow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,8 +149,8 @@ in `.github/scripts/`.
 | Workflow | Model | Trigger | Role |
 |---|---|---|---|
 | `on_issues_ai_triage.yaml` | Sonnet-low | issue opened (+ author reply, daily catch-up) | Tier 1: classify, dedupe, answer, ask for info; label `ai-triage` for real add-on bugs |
-| `daily_ai_fix.yaml` | Opus-xhigh | daily 03:00 | Tier 2: diagnose the `ai-triage` batch; small+confident → ready PR (`ai:fixed`); else write a plan (`ai:plan-pending`) |
-| `on_issue_approved.yaml` | Opus-high | maintainer adds `ai:approved` | Tier 3: execute the approved plan → ready PR |
+| `daily_ai_fix.yaml` | Opus 5-xhigh | daily 03:00 | Tier 2: diagnose the `ai-triage` batch; small+confident → ready PR (`ai:fixed`); else write a plan (`ai:plan-pending`) |
+| `on_issue_approved.yaml` | Opus 5-high | maintainer adds `ai:approved` | Tier 3: execute the approved plan → ready PR |
 | `on_claude_mention.yml` | Sonnet-low | `@claude` by @alexbelgium | Manual interactive override on any issue/PR |
 | `on_pr_coderabbit.yml` | Sonnet-low | CodeRabbit reviews an `ai-fix/*` PR | Once: fix or reply to review comments |
 


### PR DESCRIPTION
Anthropic released Claude Opus 5 on 2026-07-24 — same price as Opus 4.8, and both effort levels already in use here (`xhigh` in the tier-2 sweep, `high` in the tier-3 executor) remain supported on it.

## Change
Swap `--model claude-opus-4-8` → `--model claude-opus-5` in the two Opus steps:
- `daily_ai_fix.yaml` (Tier 2 fix sweep)
- `on_issue_approved.yaml` (Tier 3 approved-plan executor)

Sonnet-low tiers (Tier 1 classify, `@claude` interactive, CodeRabbit follow-up) are untouched — no reason to change those.

Also updated the doc comments/`CLAUDE.md` tier-map references from "Opus 4.8"/"Opus-xhigh" to "Opus 5"/"Opus 5-xhigh" so they stay accurate.

## Not changed
Auto-merge for AI-authored PRs was discussed and explicitly declined — ready PRs still require your manual merge click, same as today.

## Verification
- `actionlint` passes on all three touched workflow files.
- No behavior change beyond the model string; `--effort xhigh`/`high` confirmed supported on Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated AI workflow configurations to use the Opus 5 model.
  * Updated workflow labels and documentation to reflect the revised model names.
  * Existing automation behavior and execution settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->