### PR TITLE
filebrowser: fix healthcheck protocol detection with ssl enabled

### DIFF
--- a/filebrowser/CHANGELOG.md
+++ b/filebrowser/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.63.18.5 (26-07-2026)
+- Fixed healthcheck log spam when ssl is enabled (#2881)
 ## 2.63.18.4 (22-07-2026)
 - Minor bugs fixed
 ## 2.63.18.3 (22-07-2026)

--- a/filebrowser/Dockerfile
+++ b/filebrowser/Dockerfile
@@ -134,4 +134,4 @@ HEALTHCHECK \
     --retries=5 \
     --start-period=30s \
     --timeout=25s \
-    CMD if [ "$ssl" = "true" ]; then curl -A "HealthCheck: Docker/1.0" -s -f -k https://127.0.01:${HEALTH_PORT}${HEALTH_URL}; else curl -A "HealthCheck: Docker/1.0" -s -f http://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}/; fi
+    CMD curl -A "HealthCheck: Docker/1.0" -s -f -k "$(cat /run/health_protocol 2>/dev/null || echo http)://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}/" >/dev/null 2>&1 || exit 1

--- a/filebrowser/config.yaml
+++ b/filebrowser/config.yaml
@@ -126,4 +126,4 @@ schema:
 slug: filebrowser
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "2.63.18.4"
+version: "2.63.18.5"

--- a/filebrowser/rootfs/etc/cont-init.d/99-run.sh
+++ b/filebrowser/rootfs/etc/cont-init.d/99-run.sh
@@ -51,6 +51,10 @@ if bashio::config.true 'ssl'; then
     ADDON_PROTOCOL=https
 fi
 
+# Expose the protocol to the docker HEALTHCHECK, which runs outside this
+# shell and therefore cannot read the addon options
+echo -n "${ADDON_PROTOCOL}" > /run/health_protocol
+
 #port=$(bashio::addon.port 80)
 ingress_port=$(bashio::addon.ingress_port)
 ingress_interface=$(bashio::addon.ip_address)


### PR DESCRIPTION
Fixes #2881.

## Problem

The healthcheck added in b081e94 branches on `$ssl`:

```dockerfile
CMD if [ "$ssl" = "true" ]; then curl ... https://... ; else curl ... http://... ; fi
```

**`$ssl` is never present in the container environment.** Supervisor only injects the `environment:` block from `config.yaml` (`FB_BASEURL`, `PGID`, `PUID`) plus `TZ`/`SUPERVISOR_TOKEN`. The `ssl` option lives in `/data/options.json` and is read via `bashio::config.true 'ssl'` inside `cont-init.d/99-run.sh`. `HEALTHCHECK CMD` is spawned by dockerd, so nothing exported from that shell can reach it.

The test is therefore always false, and the healthcheck keeps probing `http://` against the TLS listener every 5s — reproducing exactly the log spam reported in #2881:

```
http: TLS handshake error from 127.0.0.1:XXXXX: client sent an HTTP request to an HTTPS server
```

## Fix

Write the already-computed protocol to a runtime file and read it back in the healthcheck — the same pattern the `gitea` addon uses (`gitea/Dockerfile:136`).

`99-run.sh`, right after `ADDON_PROTOCOL` is resolved:

```sh
echo -n "${ADDON_PROTOCOL}" > /run/health_protocol
```

`Dockerfile`:

```dockerfile
CMD curl -A "HealthCheck: Docker/1.0" -s -f -k "$(cat /run/health_protocol 2>/dev/null || echo http)://127.0.0.1:${HEALTH_PORT}${HEALTH_URL}/" >/dev/null 2>&1 || exit 1
```

The `|| echo http` fallback covers the window before `99-run.sh` runs, which `--start-period=30s` already tolerates.

## Also

- Corrects `127.0.01` → `127.0.0.1` (missing octet). It happened to resolve via `inet_aton`'s 3-part shorthand, so it was not breaking anything, but every other addon in the repo uses the full form.
- Uses `>/dev/null 2>&1` rather than gitea's `&>`, since `/bin/sh` is busybox ash on this Alpine base.

Version bumped to `2.63.18.5`, changelog updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed container health checks when SSL is enabled by automatically using the correct HTTP or HTTPS protocol.
  * Reduced healthcheck log spam and improved failure detection.

* **Chores**
  * Updated Filebrowser to version 2.63.18.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->