### PR TITLE
fix(templates): stop corrupting option values in shell_quote / dotenv_quote

### DIFF
--- a/.templates/00-global_var.sh
+++ b/.templates/00-global_var.sh
@@ -4,6 +4,128 @@
 set -e
 
 ################################################################################
+# Block markers, temp helper, quoting and export-block builders
+#
+# Everything here is free of side effects and defined before the Supervisor
+# guard, so that the self-test below can exercise the whole value path outside a
+# container, where bashio is not available.
+################################################################################
+BLOCK_BEGIN="# --- BEGIN ADDON ENV (generated) ---"
+BLOCK_END="# --- END ADDON ENV (generated) ---"
+
+mktemp_safe() {
+    local tmpdir="${TMPDIR:-/tmp}"
+    mkdir -p "$tmpdir"
+    mktemp "$tmpdir/tmp.XXXXXXXXXX"
+}
+
+dotenv_quote() {
+    # For /.env and /etc/environment: double quotes + minimal escaping
+    local v="$1"
+    v="${v//\\/\\\\}"
+    v="${v//\"/\\\"}"
+    v="${v//$'\n'/\\n}"
+    v="${v//$'\r'/\\r}"
+    printf '"%s"' "$v"
+}
+
+shell_quote() {
+    # Single-quote for safe injection into shell code.
+    #
+    # Inside single quotes every character is literal, so the only thing a value
+    # needs escaping for is the quote character itself: close the quote, emit an
+    # escaped quote, reopen it. Backslashes must be left untouched.
+    #
+    # This used to double every backslash and to replace ' with '"'"' followed by
+    # a stray space. The stray space corrupted every value containing a quote
+    # (O'Brien pass arrived as O' Brien pass); the doubling was undone further
+    # down the path by the "awk -v" in append_export, so backslashes survived by
+    # accident. Both halves are fixed together -- see the note in append_export.
+    local s="$1"
+    printf "'%s'" "${s//\'/\'\\\'\'}"
+}
+
+append_export() {
+    # Plain append, deliberately not awk: "awk -v q=$value" runs the value
+    # through awk's escape processing, which turns \t into a tab, \b into a
+    # backspace and \\ into a single backslash. That used to be cancelled out by
+    # shell_quote doubling every backslash, so the two bugs hid each other --
+    # fixing only one of them corrupts the value.
+    printf 'export %s=%s\n' "$1" "$(shell_quote "$2")" >> "$EXPORT_BODY"
+}
+
+compose_export_block() {
+    {
+        echo "$BLOCK_BEGIN"
+        echo "# Generated from $JSONSOURCE"
+        cat "$EXPORT_BODY"
+        echo "$BLOCK_END"
+    } > "$EXPORT_BLOCK"
+}
+
+################################################################################
+# Self-test: bash .templates/00-global_var.sh --self-test
+#
+# Builds a real export block and sources it, which is exactly what happens once
+# the block is injected at the top of a service run script, then checks that
+# every value came back byte for byte. Testing the whole path matters: the two
+# defects this guards against (shell_quote doubling backslashes and append_export
+# passing values through "awk -v") cancelled each other out, so a test of either
+# helper alone reported success while the pair was wrong.
+#
+# Runs before the Supervisor guard and exits, so it never affects startup.
+################################################################################
+if [[ "${1:-}" == "--self-test" ]]; then
+    # Literal test data: the single quotes and metacharacters are the point.
+    # shellcheck disable=SC2016
+    self_test_values=(
+        'plain.host'
+        'next\.duckdns\.org'   # regex, dots escaped once
+        'next\\.duckdns\\.org' # regex, dots escaped twice by the user
+        'C:\Users\bob\share'   # windows path, \U and \b are awk escapes
+        '\\server\share'       # UNC path
+        'col\tsep'             # \t is an awk escape
+        "O'Brien pass"         # embedded quote
+        "it's a 'quoted' word" # several embedded quotes
+        "'leading"
+        "trailing'"
+        'a$b`c"d' # shell metacharacters
+        '*.example.com|^foo\d+$'
+        $'sp ace\ttab'
+        ''
+    )
+
+    JSONSOURCE="self-test"
+    EXPORT_BODY="$(mktemp_safe)"
+    EXPORT_BLOCK="$(mktemp_safe)"
+    trap 'rm -f "$EXPORT_BODY" "$EXPORT_BLOCK"' EXIT
+
+    for self_test_i in "${!self_test_values[@]}"; do
+        append_export "SELFTEST_${self_test_i}" "${self_test_values[$self_test_i]}"
+    done
+    compose_export_block
+
+    # Source the generated block the way an injected run script would
+    # shellcheck source=/dev/null
+    . "$EXPORT_BLOCK"
+
+    self_test_rc=0
+    for self_test_i in "${!self_test_values[@]}"; do
+        self_test_name="SELFTEST_${self_test_i}"
+        if [[ "${!self_test_name}" != "${self_test_values[$self_test_i]}" ]]; then
+            printf 'FAIL: <%s> came back as <%s> via %s\n' \
+                "${self_test_values[$self_test_i]}" "${!self_test_name}" \
+                "$(shell_quote "${self_test_values[$self_test_i]}")"
+            self_test_rc=1
+        fi
+    done
+
+    [[ "$self_test_rc" -eq 0 ]] &&
+        echo "export block: ${#self_test_values[@]} values round-tripped unchanged"
+    exit "$self_test_rc"
+fi
+
+################################################################################
 # Guard: only run inside Supervisor-managed add-ons
 ################################################################################
 if ! bashio::supervisor.ping 2>/dev/null; then
@@ -29,15 +151,6 @@ command -v jq >/dev/null || bashio::exit.nok "jq is required"
 
 mkdir -p /etc
 touch "$ETC_ENV_FILE"
-
-################################################################################
-# Temp helper
-################################################################################
-mktemp_safe() {
-    local tmpdir="${TMPDIR:-/tmp}"
-    mkdir -p "$tmpdir"
-    mktemp "$tmpdir/tmp.XXXXXXXXXX"
-}
 
 ################################################################################
 # Secrets support
@@ -69,53 +182,12 @@ resolve_secret() {
 }
 
 ################################################################################
-# Quoting
-################################################################################
-dotenv_quote() {
-    # For /.env and /etc/environment: double quotes + minimal escaping
-    local v="$1"
-    v="${v//\\/\\\\}"
-    v="${v//\"/\\\"}"
-    v="${v//$'\n'/\\n}"
-    v="${v//$'\r'/\\r}"
-    printf '"%s"' "$v"
-}
-
-shell_quote() {
-    # Single-quote for safe injection in shell code
-    local s="$1"
-    s="${s//\\/\\\\}"
-    s="${s//\'/\'\"\'\"\' }"
-    s="${s% }"
-    printf "'%s'" "$s"
-}
-
-################################################################################
 # S6 + script injection block
 ################################################################################
-BLOCK_BEGIN="# --- BEGIN ADDON ENV (generated) ---"
-BLOCK_END="# --- END ADDON ENV (generated) ---"
-
 EXPORT_BLOCK="$(mktemp_safe)"
+EXPORT_BODY="$(mktemp_safe)"
 KV_FILE="$(mktemp_safe)"
-trap 'rm -f "$EXPORT_BLOCK" "$KV_FILE"' EXIT
-
-{
-    echo "$BLOCK_BEGIN"
-    echo "# Generated from $JSONSOURCE"
-    echo "$BLOCK_END"
-} > "$EXPORT_BLOCK"
-
-append_export() {
-    local k="$1" v="$2" q
-    q="$(shell_quote "$v")"
-
-    awk -v k="$k" -v q="$q" -v e="$BLOCK_END" '
-        $0==e { print "export " k "=" q }
-        { print }
-    ' "$EXPORT_BLOCK" > "$EXPORT_BLOCK.tmp"
-    mv "$EXPORT_BLOCK.tmp" "$EXPORT_BLOCK"
-}
+trap 'rm -f "$EXPORT_BLOCK" "$EXPORT_BODY" "$KV_FILE"' EXIT
 
 inject_block() {
     local f="$1" tmp
@@ -235,6 +307,8 @@ cp "$ENV_FILE" "$ETC_ENV_FILE"
 ################################################################################
 # Inject into scripts and shells (best-effort)
 ################################################################################
+compose_export_block
+
 for f in /etc/services.d/*/run /etc/s6-overlay/s6-rc.d/*/run /etc/cont-init.d/*.sh /entrypoint.sh /etc/bash.bashrc "${GLOBAL_VAR_FILES:-}"; do
     [[ -f "$f" ]] && inject_block "$f"
 done

--- a/.templates/00-global_var.sh
+++ b/.templates/00-global_var.sh
@@ -139,7 +139,7 @@ if [[ "${1:-}" == "--self-test" ]]; then
         printf 'DOTENVTEST_%s=%s\n' \
             "$self_test_i" "$(dotenv_quote "${self_test_values[$self_test_i]}")"
     done > "$self_test_env"
-    if ! bash -n "$self_test_env" 2>/dev/null; then
+    if ! bash -n "$self_test_env"; then
         # An unescaped backtick or quote leaves the file unparseable, which would
         # abort the sourcing shell instead of just yielding a wrong value.
         echo "FAIL (dotenv): generated env file is not valid shell"

--- a/.templates/00-global_var.sh
+++ b/.templates/00-global_var.sh
@@ -20,10 +20,21 @@ mktemp_safe() {
 }
 
 dotenv_quote() {
-    # For /.env and /etc/environment: double quotes + minimal escaping
+    # For /.env and /etc/environment: double quotes + minimal escaping.
+    #
+    # These files are read back by sourcing them from a shell, so every
+    # character that is still special inside double quotes has to be escaped.
+    # $ and ` used to be left alone, which meant a value was expanded instead of
+    # being read literally: a password like pa$$w0rd came back with the shell
+    # PID spliced into it, and a value containing backticks ran as a command.
+    #
+    # Backslash must be doubled first, so that the backslashes added below are
+    # not doubled in turn.
     local v="$1"
     v="${v//\\/\\\\}"
     v="${v//\"/\\\"}"
+    v="${v//\$/\\\$}"
+    v="${v//\`/\\\`}"
     v="${v//$'\n'/\\n}"
     v="${v//$'\r'/\\r}"
     printf '"%s"' "$v"
@@ -98,30 +109,51 @@ if [[ "${1:-}" == "--self-test" ]]; then
     JSONSOURCE="self-test"
     EXPORT_BODY="$(mktemp_safe)"
     EXPORT_BLOCK="$(mktemp_safe)"
-    trap 'rm -f "$EXPORT_BODY" "$EXPORT_BLOCK"' EXIT
+    self_test_env="$(mktemp_safe)"
+    trap 'rm -f "$EXPORT_BODY" "$EXPORT_BLOCK" "$self_test_env"' EXIT
+    self_test_rc=0
 
+    self_test_check() {
+        # $1 name of the variable that was read back, $2 expected value, $3 how
+        local self_test_got="${!1}"
+        [[ "$self_test_got" == "$2" ]] && return 0
+        printf 'FAIL (%s): <%s> came back as <%s>\n' "$3" "$2" "$self_test_got"
+        self_test_rc=1
+    }
+
+    # 1. The export block, sourced the way an injected run script would
     for self_test_i in "${!self_test_values[@]}"; do
         append_export "SELFTEST_${self_test_i}" "${self_test_values[$self_test_i]}"
     done
     compose_export_block
-
-    # Source the generated block the way an injected run script would
     # shellcheck source=/dev/null
     . "$EXPORT_BLOCK"
-
-    self_test_rc=0
     for self_test_i in "${!self_test_values[@]}"; do
-        self_test_name="SELFTEST_${self_test_i}"
-        if [[ "${!self_test_name}" != "${self_test_values[$self_test_i]}" ]]; then
-            printf 'FAIL: <%s> came back as <%s> via %s\n' \
-                "${self_test_values[$self_test_i]}" "${!self_test_name}" \
-                "$(shell_quote "${self_test_values[$self_test_i]}")"
-            self_test_rc=1
-        fi
+        self_test_check "SELFTEST_${self_test_i}" "${self_test_values[$self_test_i]}" "export block"
     done
 
+    # 2. /.env, sourced the way browserless_chrome and wger read it back.
+    # Values holding a newline are out of scope: dotenv_quote writes them as a
+    # literal \n, which a dotenv parser unescapes but a shell does not.
+    for self_test_i in "${!self_test_values[@]}"; do
+        printf 'DOTENVTEST_%s=%s\n' \
+            "$self_test_i" "$(dotenv_quote "${self_test_values[$self_test_i]}")"
+    done > "$self_test_env"
+    if ! bash -n "$self_test_env" 2>/dev/null; then
+        # An unescaped backtick or quote leaves the file unparseable, which would
+        # abort the sourcing shell instead of just yielding a wrong value.
+        echo "FAIL (dotenv): generated env file is not valid shell"
+        self_test_rc=1
+    else
+        # shellcheck source=/dev/null
+        . "$self_test_env"
+        for self_test_i in "${!self_test_values[@]}"; do
+            self_test_check "DOTENVTEST_${self_test_i}" "${self_test_values[$self_test_i]}" "dotenv"
+        done
+    fi
+
     [[ "$self_test_rc" -eq 0 ]] &&
-        echo "export block: ${#self_test_values[@]} values round-tripped unchanged"
+        echo "${#self_test_values[@]} values round-tripped unchanged (export block + dotenv)"
     exit "$self_test_rc"
 fi
 


### PR DESCRIPTION
## Summary

`.templates/00-global_var.sh` converts every add-on option into an environment
variable in three places: an `export KEY='value'` block injected at the top of
service run scripts / cont-init scripts / shells, and `/.env` +
`/etc/environment`. Two independent quoting bugs on those paths corrupted
option values. This is a shared template pulled into **124 add-ons** (115
active + 9 archived) via `ha_automodules.sh`, with no runtime refresh — each
picks up the fix on its next rebuild, not immediately.

### 1. `shell_quote` / `append_export` (commit 85bc9c72)

- `shell_quote` replaced `'` with `'"'"' ` (note the trailing space) instead of
  the POSIX `'\''`, so any value containing a single quote arrived corrupted:
  `O'Brien pass` → `O' Brien pass`. This hits passwords and any option with an
  apostrophe.
- It also doubled every backslash. That looked like the bug reported in #2768
  (Collabora `aliasgroup1`), but tracing the full pipeline showed
  `append_export` piped the quoted value through `awk -v`, which does its own
  escape processing and silently undid the doubling. **The two bugs cancelled
  each other out** — backslash values (regexes, Windows/UNC paths) were
  actually reaching services correctly. Fixing only `shell_quote` would have
  been a regression, so both are fixed together, and `append_export` no longer
  goes through `awk -v`.
- The real, previously-unreported consequence of the doubling: `/.env` and
  `/etc/environment` (via `dotenv_quote`, unaffected by the awk step) really
  do end up with doubled backslashes — likely what was actually observed as
  "four backslashes arriving" in #2768.

### 2. `dotenv_quote` (commit 041356e6)

`/.env` / `/etc/environment` are read back by *sourcing* them from a shell
(`browserless_chrome`'s Dockerfile does `set -a; . /.env`, `wger` and
`fireflyiii_data_importer` also consume them). `dotenv_quote` emits a
double-quoted value but never escaped `$` or `` ` ``, so both were expanded
instead of taken literally:

```
pa$$w0rd    -> pa904869w0rd   (shell PID spliced in)
back`tick`  -> back           (backtick ran as a command)
```

### Self-test

Added `bash .templates/00-global_var.sh --self-test`, which builds a real
export block and a real `/.env`-style file, sources both, and diffs the
values byte-for-byte. It deliberately tests the *whole* path rather than each
helper in isolation — that's exactly what let the shell_quote/awk pair stay
wrong for as long as it did. Verified it fails (with a readable message) if
any one of the three fixes is reverted individually.

## Why not a mass rebuild

Discussed with alexbelgium: no forced version bump across the 124 add-ons.
Only values containing `'`, `$`, or `` ` `` are affected, so the practical
blast radius is the subset of add-ons with credential-style options
(passwords, usernames, SMB/network paths) — those pick the fix up on their
next routine update via the weekly upstream bump.

## Review

Per this repo's convention, changes to `.templates/` are shared across every
add-on — **please don't merge without a look**, @alexbelgium.

## Test plan

- [x] `bash .templates/00-global_var.sh --self-test` passes (14 values,
      export-block path + dotenv path)
- [x] `shellcheck -x .templates/00-global_var.sh` clean
- [x] Mutation-tested: reverting any one of the three fixes individually makes
      the self-test fail with a specific, readable message
- [x] End-to-end sandbox harness (real JSON options → `export_var` →
      `append_export`/`compose_export_block` → `inject_block` → executed
      service `run` script, and separately sourced `/.env`) confirmed
      byte-identical round-trip for regexes, UNC/Windows paths, passwords with
      quotes, and `$`/backtick values
- [ ] `shfmt -i 4 -d` not run locally (binary unavailable, no docker daemon in
      this sandbox) — indentation is consistent 4-space by hand; CI's weekly
      lint job will catch/fix any nit
- [ ] Not tested against a real Supervisor / actual add-on container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable generation so special characters (including `$`, backticks, and newlines) are preserved accurately when injected into shell code and exported in dotenv format.
  * Enhanced generated configuration reliability and validity checks.

* **New Features**
  * Added a `--self-test` mode that builds real injection output and a dotenv file, then verifies that test values round-trip unchanged and that the generated dotenv content is valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->