### PR TITLE
fix(ci): pass github_token to claude-code-action so AI workflows can auth

### DIFF
--- a/.github/workflows/daily_ai_fix.yaml
+++ b/.github/workflows/daily_ai_fix.yaml
@@ -50,7 +50,6 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  id-token: write  # unused while github_token is set below; kept as the fallback auth path
 
 concurrency:
   group: ai-fix-sweep

--- a/.github/workflows/daily_ai_fix.yaml
+++ b/.github/workflows/daily_ai_fix.yaml
@@ -50,7 +50,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  id-token: write  # claude-code-action fetches a GitHub OIDC token to auth the OAuth flow
+  id-token: write  # unused while github_token is set below; kept as the fallback auth path
 
 concurrency:
   group: ai-fix-sweep
@@ -129,6 +129,11 @@ jobs:
         uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Skip the OIDC -> Claude App token exchange. The scheduled path
+          # happens to pass it (github.actor is the maintainer), but
+          # workflow_dispatch by anyone else would 401. AI_PR_TOKEN, not
+          # GITHUB_TOKEN, so a PR Claude opens triggers CI.
+          github_token: ${{ secrets.AI_PR_TOKEN }}
           # One sticky, auto-updating status comment per run instead of the
           # model narrating its own progress in scattered comments.
           track_progress: true

--- a/.github/workflows/on_issue_approved.yaml
+++ b/.github/workflows/on_issue_approved.yaml
@@ -32,7 +32,6 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  id-token: write  # unused while github_token is set below; kept as the fallback auth path
 
 concurrency:
   group: ai-approve-${{ github.event.issue.number || inputs.issue }}

--- a/.github/workflows/on_issue_approved.yaml
+++ b/.github/workflows/on_issue_approved.yaml
@@ -32,7 +32,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  id-token: write  # claude-code-action fetches a GitHub OIDC token to auth the OAuth flow
+  id-token: write  # unused while github_token is set below; kept as the fallback auth path
 
 concurrency:
   group: ai-approve-${{ github.event.issue.number || inputs.issue }}
@@ -139,6 +139,10 @@ jobs:
         uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Skip the OIDC -> Claude App token exchange, which 401s whenever
+          # github.actor lacks write access. AI_PR_TOKEN, not GITHUB_TOKEN, so
+          # a PR Claude opens triggers CI.
+          github_token: ${{ secrets.AI_PR_TOKEN }}
           track_progress: true
           prompt: |
             The approved plan is /tmp/ai-exec/plan.md and the issue it belongs

--- a/.github/workflows/on_issues_ai_triage.yaml
+++ b/.github/workflows/on_issues_ai_triage.yaml
@@ -41,7 +41,6 @@ on:
 permissions:
   contents: read
   issues: write
-  id-token: write  # unused while github_token is set below; kept as the fallback auth path
 
 concurrency:
   group: ai-triage-${{ github.event.issue.number || inputs.issue || github.run_id }}

--- a/.github/workflows/on_issues_ai_triage.yaml
+++ b/.github/workflows/on_issues_ai_triage.yaml
@@ -41,7 +41,7 @@ on:
 permissions:
   contents: read
   issues: write
-  id-token: write  # claude-code-action fetches a GitHub OIDC token to auth the OAuth flow
+  id-token: write  # unused while github_token is set below; kept as the fallback auth path
 
 concurrency:
   group: ai-triage-${{ github.event.issue.number || inputs.issue || github.run_id }}
@@ -148,6 +148,12 @@ jobs:
         uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Without this the action falls back to the OIDC -> Claude App token
+          # exchange, which 401s ("User does not have write access on this
+          # repository") whenever github.actor is the outside reporter who
+          # opened the issue or replied to a needs-info request. Same token the
+          # step already exports as GH_TOKEN; classify only reads.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           show_full_output: true
           prompt: |
             Read /tmp/ai-triage/context.md, then follow the instructions in

--- a/.github/workflows/on_pr_coderabbit.yml
+++ b/.github/workflows/on_pr_coderabbit.yml
@@ -25,7 +25,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  id-token: write  # claude-code-action fetches a GitHub OIDC token to auth the OAuth flow
+  id-token: write  # unused while github_token is set below; kept as the fallback auth path
 
 concurrency:
   group: ai-coderabbit-${{ github.event.pull_request.number }}
@@ -83,6 +83,11 @@ jobs:
         uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Skip the OIDC -> Claude App token exchange, which 401s whenever
+          # github.actor lacks write access — here github.actor is
+          # coderabbitai[bot], the review submitter. AI_PR_TOKEN, not
+          # GITHUB_TOKEN, so the pushed fixes re-trigger CI on the PR.
+          github_token: ${{ secrets.AI_PR_TOKEN }}
           prompt: |
             CodeRabbit has reviewed pull request #${{ github.event.pull_request.number }}
             on ${{ github.repository }}. You are on that PR's branch. Follow

--- a/.github/workflows/on_pr_coderabbit.yml
+++ b/.github/workflows/on_pr_coderabbit.yml
@@ -25,7 +25,6 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  id-token: write  # unused while github_token is set below; kept as the fallback auth path
 
 concurrency:
   group: ai-coderabbit-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Problem

[Run 30226365228](https://github.com/alexbelgium/hassio-addons/actions/runs/30226365228/job/89857101280) reported success but did nothing. The `Classify` step is `continue-on-error: true`, so the 401 inside it was swallowed and the job went green:

```
Auto-detected mode: agent for event: issues
Requesting OIDC token...
OIDC token successfully obtained
Exchanging OIDC token for app token...
App token exchange failed: 401 Unauthorized - User does not have write access on this repository
[x3 attempts]
##[error]Action failed with error: User does not have write access on this repository
```

followed by `::warning::no usable verdict produced, leaving issue untouched`. That is why triage looked idle rather than failing.

## Cause

Every `claude-code-action` step except the one in `on_claude_mention.yml` left the **`github_token` input** unset. These workflows do set `GH_TOKEN` as a *step env* — that is what the CLI's `gh` calls use, but it is not the action input.

With the input unset the action falls back to the OIDC → Claude App token exchange, and that exchange validates that **`github.actor` has write access on the repository**. On an `issues.opened` event `github.actor` is the outside reporter who filed the issue, so it can never pass.

Confirmed against the pinned SHA `44423bd`:

- `action.yml:287` — `OVERRIDE_GITHUB_TOKEN: ${{ inputs.github_token }}`
- `src/github/token.ts` — `setupGitHubToken()` returns `OVERRIDE_GITHUB_TOKEN` immediately when set, before ever requesting an OIDC token.

So supplying the input short-circuits the exchange. `on_claude_mention.yml` already relied on exactly this.

## Fix

| Workflow | Token | Why |
|---|---|---|
| `on_issues_ai_triage.yaml` | `GITHUB_TOKEN` | Classify is read-only (`--allowedTools` is limited to `Read,Write,Glob,Grep,Bash(gh issue list:*),Bash(gh search issues:*)`); least privilege, and matches the `GH_TOKEN` the step already exports |
| `on_issue_approved.yaml` | `AI_PR_TOKEN` | Opens PRs — needs a PAT so the PR triggers CI |
| `on_pr_coderabbit.yml` | `AI_PR_TOKEN` | Pushes to PR branches |
| `daily_ai_fix.yaml` | `AI_PR_TOKEN` | Opens PRs |

Both secrets already exist in the `CR_PAT` environment, which all four jobs declare.

Also corrected the stale `id-token: write` comments — the permission is kept as the fallback auth path, but it is no longer the active one.

## Blast radius beyond the reported failure

- `on_pr_coderabbit.yml` was almost certainly broken the same way — `github.actor` there is `coderabbitai[bot]`. Every recent run was `skipped`, so it had not been exercised.
- `daily_ai_fix.yaml` passed only incidentally: it is `schedule`-triggered, so the actor is the maintainer. A `workflow_dispatch` by anyone else would have hit the same 401.

## Verification

All four files pass `yaml.safe_load`. Note that `issues`-event workflows only run from the default branch, so triage stays broken until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of automated issue triage, approved-plan execution, and pull request follow-ups by aligning authentication behavior and avoiding authorization-related failures.
  * Ensured automated fixes re-trigger the appropriate CI checks after workflow-driven updates.
* **Chores**
  * Updated workflow notes and permissions guidance to clarify when token-based authentication is used versus fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->