### PR TITLE
fix(ci): drop track_progress where the event has no issue/PR context

### DIFF
--- a/.github/workflows/daily_ai_fix.yaml
+++ b/.github/workflows/daily_ai_fix.yaml
@@ -133,9 +133,11 @@ jobs:
           # workflow_dispatch by anyone else would 401. AI_PR_TOKEN, not
           # GITHUB_TOKEN, so a PR Claude opens triggers CI.
           github_token: ${{ secrets.AI_PR_TOKEN }}
-          # One sticky, auto-updating status comment per run instead of the
-          # model narrating its own progress in scattered comments.
-          track_progress: true
+          # No track_progress here. It needs an issue or PR to hang its sticky
+          # comment on, and the action hard-fails validation without one; this
+          # workflow only ever runs on schedule/workflow_dispatch. Per-issue
+          # progress still gets reported — issue-fix.md has Claude comment on
+          # each issue directly via gh.
           prompt: |
             The batch of issues to work through is /tmp/ai-fix/batch.json.
             Follow .github/prompts/issue-fix.md exactly. Do not deviate from

--- a/.github/workflows/on_issue_approved.yaml
+++ b/.github/workflows/on_issue_approved.yaml
@@ -142,7 +142,10 @@ jobs:
           # github.actor lacks write access. AI_PR_TOKEN, not GITHUB_TOKEN, so
           # a PR Claude opens triggers CI.
           github_token: ${{ secrets.AI_PR_TOKEN }}
-          track_progress: true
+          # Only the `issues` path has a comment thread to track progress in.
+          # On workflow_dispatch there is none, and passing true there fails
+          # the action's input validation outright.
+          track_progress: ${{ github.event_name == 'issues' }}
           prompt: |
             The approved plan is /tmp/ai-exec/plan.md and the issue it belongs
             to is /tmp/ai-exec/issue.json. Follow .github/prompts/issue-execute-plan.md


### PR DESCRIPTION
## What broke

The AI fix sweep has never completed a non-empty batch. [Run 30265277395](https://github.com/alexbelgium/hassio-addons/actions/runs/30265277395/job/89974354049) failed in `Analyse and fix` after ~0.3s, before any analysis happened:

```
##[error]Action failed with error: track_progress is only supported for events:
pull_request, issues, issue_comment, pull_request_review_comment, pull_request_review.
Current event: workflow_dispatch
##[error]Process completed with exit code 1.
```

`track_progress` needs an issue or PR to hang its sticky comment on. `daily_ai_fix.yaml` triggers only on `schedule` and `workflow_dispatch`, neither of which has one, so `claude-code-action` rejects the input during validation.

## Why nobody noticed

The step is gated on `if: steps.batch.outputs.count != '0'`. Runs with an empty batch skip it entirely and report green:

| run | event | `Analyse and fix` |
|---|---|---|
| 30265277395 | workflow_dispatch | **failure** |
| 30236697655 | schedule | skipped |
| 30072643898 | workflow_dispatch | skipped |
| 30011599875 | workflow_dispatch | **failure** |

Every green run is a no-op. Every run with issues to work through failed the same way. The 3am cron would fail identically the moment an `ai-triage` issue exists — this is not dispatch-only.

## Changes

- **`daily_ai_fix.yaml`** — remove `track_progress`. No trigger of this workflow can satisfy the constraint, so there is no conditional worth keeping. Per-issue reporting is unaffected: `issue-fix.md` already has Claude comment on each issue via `gh`. Only the run-level sticky comment is lost.
- **`on_issue_approved.yaml`** — same latent failure on its `workflow_dispatch` path, but its `issues` path is valid, so gate on the event rather than dropping it: `track_progress: ${{ github.event_name == 'issues' }}`. The action declares this input's default as the string `"false"`, so the expression result is a shape it already handles.

## Verification

Both files parse. Not runtime-verified — that needs a dispatch with a non-empty `ai-triage` batch, which is worth doing once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated issue and pull request processing by preventing unsupported progress tracking in batch workflows.
  * Progress tracking is now enabled only when a suitable issue conversation is available, preventing failures during manually triggered workflows.
  * Clarified progress reporting behavior for automated fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->