### PR TITLE
Fix Bazarr ingress: keep redirects relative so they aren't blocked as mixed content

### DIFF
--- a/bazarr/CHANGELOG.md
+++ b/bazarr/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+## 1.6.0.1 (2026-07-27)
+
+- Fix ingress: nginx rewrote Bazarr's redirects into an absolute `http://<host>:8099/...` URL, which the browser blocked as mixed content when Home Assistant is served over HTTPS. Redirects now stay relative and point at the ingress path
+- Fix fallback base_url in the nginx service script missing its leading `/`, which crashed Bazarr on startup
+
 ## 1.6.0 (2026-07-08)
 
 - Update to latest version from linuxserver/docker-bazarr (changelog : https://github.com/linuxserver/docker-bazarr/releases)

--- a/bazarr/config.yaml
+++ b/bazarr/config.yaml
@@ -112,4 +112,4 @@ schema:
 slug: bazarr_nas
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/bazarr
-version: "1.6.0"
+version: "1.6.0.1"

--- a/bazarr/rootfs/etc/nginx/servers/ingress.conf
+++ b/bazarr/rootfs/etc/nginx/servers/ingress.conf
@@ -19,6 +19,19 @@ server {
        proxy_set_header Connection $http_connection;
        #auth_basic off;
 
+       # Adjust Location headers in backend redirects
+       # Bazarr is Flask-based and answers /bazarr with a redirect to /bazarr/,
+       # made absolute against the Host nginx sends upstream, so it reads
+       # http://127.0.0.1:6767/bazarr/. proxy_redirect strips that prefix, and
+       # nginx then re-absolutises the result as $scheme://$host:$server_port/...
+       # i.e. http://<ha_host>:8099/bazarr/ -- blocked by the browser as mixed
+       # content inside the ingress iframe. absolute_redirect off keeps it
+       # relative; the proxy_redirect rules re-prefix it with the ingress entry
+       # (the second rule also covers a redirect that was relative already).
+       absolute_redirect off; # Do not add port to redirect
+       proxy_redirect http://127.0.0.1:6767/ %%ingress_entry%%/;
+       proxy_redirect / %%ingress_entry%%/;
+
        # Correct base_url
        proxy_set_header Accept-Encoding "";
        sub_filter_once off;

--- a/bazarr/rootfs/etc/services.d/nginx/run
+++ b/bazarr/rootfs/etc/services.d/nginx/run
@@ -15,7 +15,7 @@ bashio::net.wait_for "$port" localhost 900
 if [ -f "$CONFIG_LOCATION" ]; then
     if ! bashio::config.true "ingress_disabled"; then
         if ! bashio::config.has_value "connection_mode" || [ "$(bashio::config 'connection_mode')" != "noingress_auth" ]; then
-            if ! grep -q "base_url.*$slug" "$CONFIG_LOCATION"; then
+            if ! grep -q "base_url: /$slug" "$CONFIG_LOCATION"; then
                 bashio::log.warning "BaseUrl not set properly, restarting"
                 # Must start with / for Flask blueprint registration
                 sed -i "s|  base_url:.*|  base_url: /$slug|" "$CONFIG_LOCATION"

--- a/bazarr/rootfs/etc/services.d/nginx/run
+++ b/bazarr/rootfs/etc/services.d/nginx/run
@@ -17,7 +17,8 @@ if [ -f "$CONFIG_LOCATION" ]; then
         if ! bashio::config.has_value "connection_mode" || [ "$(bashio::config 'connection_mode')" != "noingress_auth" ]; then
             if ! grep -q "base_url.*$slug" "$CONFIG_LOCATION"; then
                 bashio::log.warning "BaseUrl not set properly, restarting"
-                sed -i "s/  base_url:.*/  base_url: $slug/" "$CONFIG_LOCATION"
+                # Must start with / for Flask blueprint registration
+                sed -i "s|  base_url:.*|  base_url: /$slug|" "$CONFIG_LOCATION"
                 bashio::addon.restart
             fi
         fi


### PR DESCRIPTION
## Problem

Opening the Bazarr panel on an HTTPS Home Assistant fails with:

```
Mixed Content: The page at 'https://<ha_host>/app/xxxxxxxx_bazarr_nas' was loaded over HTTPS,
but requested an insecure frame 'http://<ha_host>:8099/bazarr/'. This request has been blocked;
the content must be served over HTTPS
```

## Cause

`ingress_entry: bazarr` makes HA load the iframe at `/api/hassio_ingress/<token>/bazarr` — no
trailing slash. Bazarr is Flask-based, its blueprint is registered at `base_url: /bazarr`, so
Werkzeug answers that with a redirect to `/bazarr/`, made absolute against the `Host` nginx sends
upstream: `http://127.0.0.1:6767/bazarr/`.

`proxy_redirect`'s implicit `default` rule strips that prefix, which makes nginx adopt the
`Location` as its own. The header filter then re-absolutises it as `$scheme://$host:$server_port/…`:

- `$host` is the browser's host, forwarded verbatim by the Supervisor
- `$server_port` is the ingress port — `8099`, the Supervisor default, since `config.yaml`
  declares `ingress: true` without an `ingress_port`

The result is a plain-`http` URL on a port the browser refuses to frame from an `https` page.

The byte-identical configs in `sonarr/`, `radarr/`, `prowlarr/` and `readarr/` are unaffected —
those are .NET apps that don't emit this redirect — so this PR touches Bazarr only.

## Fix

`absolute_redirect off` keeps the `Location` relative; the `proxy_redirect` rules re-prefix it with
the ingress entry so it resolves under `/api/hassio_ingress/<token>/`. Same pattern already used by
`scrutiny`, `transmission` and `mealie` in this repo.

Also fixes the fallback `base_url` in `services.d/nginx/run`, which wrote it without the leading
`/` and so reintroduced the startup crash fixed in 1.5.6-4.

## Verification

Run against a local nginx with a stand-in backend, comparing the config before and after:

| upstream `Location` | before | after |
|---|---|---|
| `http://127.0.0.1:6767/bazarr/` | `http://<host>:<ingress_port>/bazarr/` ❌ | `/api/hassio_ingress/<token>/bazarr/` ✅ |
| `/bazarr/` | `/bazarr/` (wrong path) | `/api/hassio_ingress/<token>/bazarr/` ✅ |
| `https://www.opensubtitles.com/login` | unchanged | unchanged ✅ |

The pre-fix config reproduces the reported URL exactly. `nginx -t` passes and `shellcheck` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted Bazarr redirect handling to stay relative when used behind Home Assistant over HTTPS, preventing mixed-content issues.
  * Corrected ingress redirect prefixing so redirects work properly within embedded views.
  * Fixed an add-on startup issue related to an incorrectly formatted base URL.
* **Chores**
  * Updated the add-on version to **1.6.0.1**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->