### PR TITLE
Fix Bazarr base_url sed clobbering Radarr/Sonarr's own base_url

### DIFF
--- a/bazarr/CHANGELOG.md
+++ b/bazarr/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 1.6.0.2 (2026-07-27)
+
+- Fix base_url sed patterns rewriting *every* `base_url` key in Bazarr's config.yaml (radarr.base_url, sonarr.base_url, and any other configured integration), instead of only Bazarr's own under `general:`. This silently broke the Radarr/Sonarr connections inside Bazarr on every addon restart when ingress was enabled
+
 ## 1.6.0.1 (2026-07-27)
 
 - Fix ingress: nginx rewrote Bazarr's redirects into an absolute `http://<host>:8099/...` URL, which the browser blocked as mixed content when Home Assistant is served over HTTPS. Redirects now stay relative and point at the ingress path

--- a/bazarr/config.yaml
+++ b/bazarr/config.yaml
@@ -112,4 +112,4 @@ schema:
 slug: bazarr_nas
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/bazarr
-version: "1.6.0.1"
+version: "1.6.0.2"

--- a/bazarr/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/bazarr/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -35,16 +35,20 @@ if [ -f "$CONFIG_LOCATION" ]; then
         ingress_noauth)
             bashio::log.green "Ingress is enabled, authentication is disabled"
             bashio::log.yellow "WARNING : Make sure that the port is not exposed externally by your router to avoid a security risk !"
-            # Set base_url (must start with / for Flask blueprint registration)
-            sed -i "s|  base_url:.*|  base_url: /$slug|" "$CONFIG_LOCATION"
+            # Set base_url (must start with / for Flask blueprint registration).
+            # Scoped to the general: block only -- config.yaml also carries a
+            # base_url under each configured *arr integration (radarr.base_url,
+            # sonarr.base_url, ...) and those must not be touched.
+            sed -i "/^general:/,/^[^ ]/{ s|  base_url:.*|  base_url: /$slug|; }" "$CONFIG_LOCATION"
             # Disable auth
             sed -i '/^auth:/,/^[^ ]/{ s/  type:.*/  type: null/ }' "$CONFIG_LOCATION"
             ;;
         # Ingress mode, with authentication
         ingress_auth)
             bashio::log.green "Ingress is enabled, and external authentication is enabled"
-            # Set base_url (must start with / for Flask blueprint registration)
-            sed -i "s|  base_url:.*|  base_url: /$slug|" "$CONFIG_LOCATION"
+            # Set base_url (must start with / for Flask blueprint registration).
+            # Scoped to the general: block only -- see note above.
+            sed -i "/^general:/,/^[^ ]/{ s|  base_url:.*|  base_url: /$slug|; }" "$CONFIG_LOCATION"
             # Enable Bazarr auth when leaving ingress_noauth
             sed -i '/^auth:/,/^[^ ]/{ s/  type:.*/  type: form/ }' "$CONFIG_LOCATION"
             ;;
@@ -52,7 +56,8 @@ if [ -f "$CONFIG_LOCATION" ]; then
         noingress_auth)
             bashio::log.green "Disabling ingress and enabling authentication"
             bashio::log.yellow "WARNING : Ingress is disabled so the app won't be available from HA itself !"
-            sed -i "s/  base_url:.*/  base_url: ''/" "$CONFIG_LOCATION"
+            # Scoped to the general: block only -- see note above.
+            sed -i "/^general:/,/^[^ ]/{ s/  base_url:.*/  base_url: ''/; }" "$CONFIG_LOCATION"
             # Enable Bazarr auth when leaving ingress_noauth
             sed -i '/^auth:/,/^[^ ]/{ s/  type:.*/  type: form/ }' "$CONFIG_LOCATION"
             ;;

--- a/bazarr/rootfs/etc/services.d/nginx/run
+++ b/bazarr/rootfs/etc/services.d/nginx/run
@@ -17,8 +17,11 @@ if [ -f "$CONFIG_LOCATION" ]; then
         if ! bashio::config.has_value "connection_mode" || [ "$(bashio::config 'connection_mode')" != "noingress_auth" ]; then
             if ! grep -q "base_url: /$slug" "$CONFIG_LOCATION"; then
                 bashio::log.warning "BaseUrl not set properly, restarting"
-                # Must start with / for Flask blueprint registration
-                sed -i "s|  base_url:.*|  base_url: /$slug|" "$CONFIG_LOCATION"
+                # Must start with / for Flask blueprint registration. Scoped to
+                # the general: block only -- config.yaml also carries a base_url
+                # under each configured *arr integration (radarr.base_url,
+                # sonarr.base_url, ...) and those must not be touched.
+                sed -i "/^general:/,/^[^ ]/{ s|  base_url:.*|  base_url: /$slug|; }" "$CONFIG_LOCATION"
                 bashio::addon.restart
             fi
         fi

--- a/bazarr/rootfs/etc/services.d/nginx/run
+++ b/bazarr/rootfs/etc/services.d/nginx/run
@@ -15,7 +15,7 @@ bashio::net.wait_for "$port" localhost 900
 if [ -f "$CONFIG_LOCATION" ]; then
     if ! bashio::config.true "ingress_disabled"; then
         if ! bashio::config.has_value "connection_mode" || [ "$(bashio::config 'connection_mode')" != "noingress_auth" ]; then
-            if ! grep -q "base_url: /$slug" "$CONFIG_LOCATION"; then
+            if ! sed -n "/^general:/,/^[^ ]/ { /^  base_url: \/$slug$/p; }" "$CONFIG_LOCATION" | grep -q .; then
                 bashio::log.warning "BaseUrl not set properly, restarting"
                 # Must start with / for Flask blueprint registration. Scoped to
                 # the general: block only -- config.yaml also carries a base_url


### PR DESCRIPTION
## Problem

Bazarr's `config.yaml` carries a `base_url` under `general:` (Bazarr's own ingress path) **and** a separate `base_url` under each configured *arr integration:

```yaml
general:
  base_url: /bazarr
radarr:
  base_url: /radarr
sonarr:
  base_url: /sonarr
subsarr:
  base_url: /bazarr
```

Every `base_url` sed in this addon is unscoped:

```bash
sed -i "s|  base_url:.*|  base_url: /$slug|" "$CONFIG_LOCATION"
```

`sed` applies `s///` to every matching line in the file, and `  base_url:.*` matches **any** 2-space-indented `base_url:` line regardless of which top-level section it's under. Since `general.base_url`, `radarr.base_url`, `sonarr.base_url`, etc. all sit at that same indent, this rewrites *all* of them to Bazarr's own value — on every container start (`32-nginx_ingress.sh`), and again in the `run` script's fallback. That silently breaks Bazarr's configured connections to Radarr and Sonarr each time the addon restarts with ingress enabled.

Reproduced against a representative config:

```
before:  general=/bazarr  radarr=/radarr  sonarr=/sonarr
after:   general=/bazarr  radarr=/bazarr  sonarr=/bazarr   <- clobbered
```

## Fix

Scope each `base_url` sed to the `general:` block only, reusing the range idiom this same file already uses to scope the `auth:` block's `type:` substitution:

```bash
sed -i "/^general:/,/^[^ ]/{ s|  base_url:.*|  base_url: /$slug|; }" "$CONFIG_LOCATION"
```

Applied to all four call sites: the three `connection_mode` branches in `32-nginx_ingress.sh`, and the fallback in `services.d/nginx/run`.

## Verification

Ran the exact sed lines now in the repo against a representative `config.yaml` (general/radarr/sonarr/subsarr sections, including `general:`'s list-style provider entries) for all three `connection_mode` branches plus the `run` fallback:

| section | before | after (every branch) |
|---|---|---|
| `general.base_url` | `/bazarr` | `/bazarr` (or `''` for `noingress_auth`) ✅ |
| `radarr.base_url` | `/radarr` | `/radarr` — untouched ✅ |
| `sonarr.base_url` | `/sonarr` | `/sonarr` — untouched ✅ |
| `subsarr.base_url` | `/bazarr` | `/bazarr` — untouched ✅ |

`shellcheck` is clean on both modified scripts.

Follow-up to #2910 (already merged), which fixed the mixed-content redirect issue and added the leading `/` this PR builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `base_url` rewriting so it only updates Bazarr’s `general` section when switching connection modes.
  * Prevented accidental changes to Radarr/Sonarr connection `base_url` settings on restarts.
  * Improved base URL and authentication behavior across ingress/no-ingress modes.

* **Chores**
  * Updated the add-on version to **1.6.0.2**.
  * Added a changelog entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->