### PR TITLE
claude_desktop: fix Codex install failing on every boot

### DIFF
--- a/claude_desktop/CHANGELOG.md
+++ b/claude_desktop/CHANGELOG.md
@@ -1,4 +1,8 @@
  
+## 1.36.1 (27-07-2026)
+
+- Fix the Codex CLI install failing on every boot with `Verified Codex <version> installation failed; Codex is unavailable this boot`, leaving `install_codex_cli` permanently non-functional. The download, its SHA-256 verification, and the extraction all succeeded; the chain broke at the final step, which validates the candidate binary by running `--version` as the `abc` runtime user. `mktemp -d` creates its directory `0700 root:root`, and `abc` cannot traverse a root-only directory, so executing the staged binary failed with `unable to exec: Permission denied` (exit 126) before it could be moved into place. Reproduced and fixed by making the staging directory traversable (`chmod 0755`) immediately after `mktemp`; verified on a live add-on container, where the same probe goes from exit 126 to success once the mode is widened. Nothing secret is staged there — the public release archive and the extracted binary, both world-readable upstream artifacts — and the existing `cleanup()` trap still removes the directory on exit. The validation deliberately keeps running as `abc` rather than root, so the binary is exercised as the identity that will actually run it.
+
 ## 1.36 (27-07-2026)
 
 - Add optional OpenAI Codex CLI support, so a Claude session in this add-on can delegate work to ChatGPT Codex. Three parts: an `install_codex_cli` switch, a browserless way to activate a ChatGPT subscription on it, and an MCP registration that makes Codex callable as a tool from Claude.

--- a/claude_desktop/config.yaml
+++ b/claude_desktop/config.yaml
@@ -122,5 +122,5 @@ slug: claude_desktop
 tmpfs: true
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "1.36"
+version: "1.36.1"
 video: true

--- a/claude_desktop/rootfs/etc/cont-init.d/81-codex_cli.sh
+++ b/claude_desktop/rootfs/etc/cont-init.d/81-codex_cli.sh
@@ -60,6 +60,13 @@ fi
 # follows upstream updates without pinning a version, while downloading the large asset only when
 # the installed version changes. A metadata outage never replaces or removes a working binary.
 codex_tmp="$(mktemp -d -p "$CODEX_ROOT")"
+# mktemp always creates 0700 root:root here, but the candidate binary is validated by running it
+# as the abc runtime user, which cannot traverse a root-only directory — that made every install
+# fail at the --version step with "unable to exec: Permission denied" (exit 126) and report
+# "Codex is unavailable this boot". Make the staging directory traversable. Nothing secret is
+# staged here: it holds the public release archive and the extracted binary, both of which are
+# world-readable upstream artifacts, and cleanup() removes the directory on exit.
+chmod 0755 "$codex_tmp"
 cleanup() {
     rm -rf "$codex_tmp"
 }


### PR DESCRIPTION
Follow-up to #2911. As merged, `install_codex_cli` is non-functional: every boot logs

```
WARNING: Verified Codex 0.145.0 installation failed; Codex is unavailable this boot
```

and no binary is ever installed. This is deterministic, not intermittent.

## Root cause

The install is a single `&&`-chain. Everything up to the last step succeeds — `curl`, `sha256sum -c` against the GitHub-published digest, `tar -xzf`, the `-f` check, `chmod 0755` on the extracted file. It breaks here:

```bash
&& run_as_runtime_user "$extracted" --version > /dev/null 2>&1 \
```

`mktemp -d` creates its directory `0700 root:root`, and `abc` cannot traverse a root-only directory, so executing the staged binary as `abc` fails with `unable to exec: Permission denied` (exit 126) before it can be moved into place. Because the whole thing is one `&&`-list, this surfaced only as the generic failure warning, with no indication of which step failed.

The validation was moved from root to `abc` late in #2911 (`3a9882a`, addressing the runtime-home review thread). That change is correct in intent — the binary should be exercised as the identity that will actually run it — but the staging directory was never made reachable by that identity.

## Fix

One line, immediately after `mktemp`:

```bash
codex_tmp="$(mktemp -d -p "$CODEX_ROOT")"
chmod 0755 "$codex_tmp"
```

Nothing secret is staged there: the public release archive and the extracted binary, both world-readable upstream artifacts. The existing `cleanup()` trap still removes the directory on exit. The validation deliberately keeps running as `abc`.

## Verification

Reproduced and verified on a live add-on container.

Isolated probe — a `0755` binary inside a `mktemp -d` directory, executed via `s6-setuidgid abc`:

```
drwx------ root root   ->  s6-applyuidgid: fatal: unable to exec ...: Permission denied  (rc 126)
drwxr-xr-x root root   ->  OK
```

Full installer with the fix applied, run under real boot conditions:

```
/data/codex/bin/codex-real   296.3M   (codex-cli 0.145.0)
/data/codex/bin/.version     0.145.0
/usr/local/bin/codex         -> wrapper, `codex --version` OK as abc
managed ~/.codex/config.toml written, mode 0600
staging leftovers: none
```

The previously failing step — running the binary as `abc` — now returns `codex-cli 0.145.0`.

`shellcheck` clean; `yamllint` reports no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Codex CLI installation failing during startup due to permission restrictions in its temporary staging directory.
  - Codex CLI validation and installation can now complete successfully during boot.

- **Release**
  - Updated the add-on version to 1.36.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->