### PR TITLE
fix(webtop_kde): tolerate init-video/init-selkies-config failures to …

### DIFF
--- a/webtop_kde/CHANGELOG.md
+++ b/webtop_kde/CHANGELOG.md
@@ -1,4 +1,10 @@
  
+## 4.16-r0-ls93.1 (2026-07-28)
+- Fix crash loop on start: make the `init-video` and `init-selkies-config` oneshots
+  tolerant of their best-effort device/permission setup failing in the HA add-on
+  sandbox, so a non-zero exit no longer crash-loops the container and `svc-selkies`
+  (closes #2918)
+ 
 ## 4.16-r0-ls93 (2026-07-21)
 - Update to latest version from linuxserver/docker-webtop (changelog : https://github.com/linuxserver/docker-webtop/releases)
  

--- a/webtop_kde/rootfs/etc/cont-init.d/20-folders.sh
+++ b/webtop_kde/rootfs/etc/cont-init.d/20-folders.sh
@@ -81,3 +81,16 @@ ln -sf /config/.cache /.cache
 bashio::log.info "Setting ownership to $PUID:$PGID"
 chown -R "$PUID":"$PGID" "$LOCATION"
 chmod -R 700 "$LOCATION"
+
+# The Selkies desktop init oneshots do best-effort device/permission setup (mknod
+# /dev/input/*, chmod /tmp/selkies*, /dev/dri perms) that is only partially permitted in the
+# HA add-on sandbox. A non-zero exit from a oneshot fails add-on bringup and crash-loops the
+# container, so make these two tolerant and always report success. Longruns (svc-*) are left
+# untouched so s6 keeps supervising them with their real exit codes.
+for oneshot in init-video init-selkies-config; do
+    run="/etc/s6-overlay/s6-rc.d/$oneshot/run"
+    if [ -f "$run" ] && ! grep -q '^set +e$' "$run"; then
+        sed -i "1a set +e" "$run"
+        printf '\nexit 0\n' >> "$run"
+    fi
+done


### PR DESCRIPTION
…stop crash loop

The Selkies desktop init oneshots do best-effort device/permission setup (mknod /dev/input/*, chmod /tmp/selkies*, /dev/dri perms) that is only partially permitted in the HA add-on sandbox. A non-zero exit from a oneshot crash-loops the container along with svc-selkies. Apply the same tolerant-oneshot fix already used in claude_desktop's 20-folders.sh.

Closes #2918

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented startup crash loops when video or desktop configuration setup encounters device or permission errors.
  * Improved reliability in sandboxed environments by allowing best-effort initialization to complete without repeatedly restarting the desktop service.

* **Documentation**
  * Added a changelog entry documenting the startup crash-loop fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->