### PR TITLE
fix(birdnet-go-dev): rebuild without broken PR 36

### DIFF
--- a/birdnet-go-dev/config.yaml
+++ b/birdnet-go-dev/config.yaml
@@ -127,5 +127,5 @@ slug: birdnet-go-dev
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "source-20260717"
+version: "source-20260729.1"
 video: true


### PR DESCRIPTION
## Summary
- retrigger the `birdnet-go-dev` source build as `source-20260729.1`
- PR `alexbelgium/birdnet-go#36` was temporarily converted to draft because it introduces invalid `skippedFields` references in `internal/api/v2/settings.go`
- the dynamic merge script will therefore build the remaining eight ready PRs without the compile-breaking branch

## Root cause
The failed amd64 build in Actions run `30451896787` stopped with:

```text
internal/api/v2/settings.go:1144:30: undefined: skippedFields
internal/api/v2/settings.go:1149:30: undefined: skippedFields
internal/api/v2/settings.go:1178:29: undefined: skippedFields
```

The source PR has been annotated with the required focused repair before it can be marked ready again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the add-on to the latest available source version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->