### PR TITLE
fix: give every addon a version Home Assistant can order

### DIFF
--- a/birdnet-go-dev/CHANGELOG.md
+++ b/birdnet-go-dev/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 20260729.1 (2026-08-01)
+
+- Version renamed from `source-20260729.1`, which Home Assistant could not order and therefore could not reliably offer as an update: every number of the previous version is kept, as a section of its own. The addon itself and the upstream version it tracks are unchanged
+
 ## source-20260729.1 (29-07-2026)
 - Minor bugs fixed
 ## source-20260717 (17-07-2026)

--- a/birdnet-go-dev/config.yaml
+++ b/birdnet-go-dev/config.yaml
@@ -127,5 +127,5 @@ slug: birdnet-go-dev
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "source-20260729.1"
+version: "20260729.1"
 video: true

--- a/browser_chromium/CHANGELOG.md
+++ b/browser_chromium/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2026.08.01 (2026-08-01)
+
+- Version renamed from `version-bf9e0b4f`, which Home Assistant could not order and therefore could not reliably offer as an update: the previous version held no number that could order it, so the date of this change is used. The addon itself and the upstream version it tracks are unchanged
+
  
 ## version-bf9e0b4f (2026-07-25)
 - Update to latest version from linuxserver/docker-chromium (changelog : https://github.com/linuxserver/docker-chromium/releases)

--- a/browser_chromium/config.yaml
+++ b/browser_chromium/config.yaml
@@ -71,5 +71,5 @@ slug: chromium
 tmpfs: true
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "version-bf9e0b4f"
+version: "2026.08.01"
 video: true

--- a/epicgamesfree/CHANGELOG.md
+++ b/epicgamesfree/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2026.07.27 (2026-08-01)
+
+- Version renamed from `debian-2026-07-27`, which Home Assistant could not order and therefore could not reliably offer as an update: every number of the previous version is kept, as a section of its own. The addon itself and the upstream version it tracks are unchanged
+
  
 ## debian-2026-07-27 (2026-07-27)
 - Update to latest version from charlocharlie/epicgames-freegames

--- a/epicgamesfree/config.yaml
+++ b/epicgamesfree/config.yaml
@@ -88,5 +88,5 @@ schema:
 slug: epicgamesfree
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "debian-2026-07-27"
+version: "2026.07.27"
 webui: "[PROTO:ssl]://[HOST]:[PORT:3000]"

--- a/lidarr/CHANGELOG.md
+++ b/lidarr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0.4875.1 (2026-08-01)
+
+- Version renamed from `3.1.0.4875-1`, which Home Assistant could not order and therefore could not reliably offer as an update: every number of the previous version is kept, as a section of its own. The addon itself and the upstream version it tracks are unchanged
+
 
 ## 3.1.0.4875-1 (2026-01-08)
 - ⚠ MAJOR CHANGE : switch to the new config logic from homeassistant. Your configuration files will have migrated from /config/addons_config/lidarr to a folder only accessible from my Filebrowser addon called /addon_configs/xxx-lidarr_nas. This avoids the addon to mess with your homeassistant configuration folder, and allows to backup the options. Migration of data should be automatic. Please be sure to update all your links however ! For more information, see here : https://developers.home-assistant.io/blog/2023/11/06/public-addon-config/

--- a/lidarr/config.yaml
+++ b/lidarr/config.yaml
@@ -102,5 +102,5 @@ schema:
 slug: lidarr_nas
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/blob/master/lidarr/README.md
-version: "3.1.0.4875-1"
+version: "3.1.0.4875.1"
 webui: "[PROTO:ssl]://[HOST]:[PORT:8686]"

--- a/monica/CHANGELOG.md
+++ b/monica/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.0.5.3 (2026-08-01)
+
+- Version renamed from `5.0.0b5-3`, which Home Assistant could not order and therefore could not reliably offer as an update: every number of the previous version is kept, as a section of its own. The addon itself and the upstream version it tracks are unchanged
+
 ## 5.0.0b5-3 (2026-05-10)
 - Fix MariaDB connection on HAOS >=17.3 by forcing IPv4 host resolution (#2688)
 

--- a/monica/config.yaml
+++ b/monica/config.yaml
@@ -108,5 +108,5 @@ services:
   - mysql:want
 slug: monica
 url: https://github.com/alexbelgium/hassio-addons/tree/master/monica
-version: "5.0.0b5-3"
+version: "5.0.0.5.3"
 webui: "[PROTO:ssl]://[HOST]:[PORT:80]"

--- a/nzbget/CHANGELOG.md
+++ b/nzbget/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v26.2.256 (2026-08-01)
+
+- Version renamed from `v26.2-ls256`, which Home Assistant could not order and therefore could not reliably offer as an update: every number of the previous version is kept, as a section of its own. The addon itself and the upstream version it tracks are unchanged
+
  
 ## v26.2-ls256 (2026-08-01)
 - Update to latest version from linuxserver/docker-nzbget (changelog : https://github.com/linuxserver/docker-nzbget/releases)

--- a/nzbget/config.yaml
+++ b/nzbget/config.yaml
@@ -104,4 +104,4 @@ schema:
 slug: nzbget
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "v26.2-ls256"
+version: "v26.2.256"

--- a/organizr/CHANGELOG.md
+++ b/organizr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.7 (2026-08-01)
+
+- Version renamed from `v2-7`, which Home Assistant could not order and therefore could not reliably offer as an update: every number of the previous version is kept, as a section of its own. The addon itself and the upstream version it tracks are unchanged
+
 ## v2-7 (13-01-2026)
 - Minor bugs fixed
 ## v2-6 (13-01-2026)

--- a/organizr/config.yaml
+++ b/organizr/config.yaml
@@ -88,5 +88,5 @@ schema:
 slug: organizr
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "v2-7"
+version: "v2.7"
 webui: "[PROTO:ssl]://[HOST]:[PORT:80]"

--- a/photoprism/CHANGELOG.md
+++ b/photoprism/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2026.07.28 (2026-08-01)
+
+- Version renamed from `ubuntu-2026-07-28`, which Home Assistant could not order and therefore could not reliably offer as an update: every number of the previous version is kept, as a section of its own. The addon itself and the upstream version it tracks are unchanged
+
  
 ## ubuntu-2026-07-28 (2026-07-28)
 - Update to latest version from photoprism/photoprism

--- a/photoprism/config.yaml
+++ b/photoprism/config.yaml
@@ -131,5 +131,5 @@ services:
 slug: photoprism
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "ubuntu-2026-07-28"
+version: "2026.07.28"
 video: true

--- a/plex/CHANGELOG.md
+++ b/plex/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.43.3.10828.316 (2026-08-01)
+
+- Version renamed from `1.43.3.10828-00f62d37d-ls316`, which Home Assistant could not order and therefore could not reliably offer as an update: every number of the previous version is kept, as a section of its own. The addon itself and the upstream version it tracks are unchanged
+
  
 ## 1.43.3.10828-00f62d37d-ls316 (2026-08-01)
 - Update to latest version from linuxserver/docker-plex (changelog : https://github.com/linuxserver/docker-plex/releases)

--- a/plex/config.yaml
+++ b/plex/config.yaml
@@ -175,6 +175,6 @@ slug: plex_nas
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/plex
 usb: true
-version: "1.43.3.10828-00f62d37d-ls316"
+version: "1.43.3.10828.316"
 video: true
 webui: "[PROTO:ssl]://[HOST]:[PORT:32400]/web"

--- a/portainer_agent/CHANGELOG.md
+++ b/portainer_agent/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2025.12.6 (2026-08-01)
+
+- Version renamed from `2025.12-6`, which Home Assistant could not order and therefore could not reliably offer as an update: every number of the previous version is kept, as a section of its own. The addon itself and the upstream version it tracks are unchanged
+
 ## 2025.12-6 (2025-12-31)
 - Minor bugs fixed
 ## 2025.12-5 (2025-12-31)

--- a/portainer_agent/config.yaml
+++ b/portainer_agent/config.yaml
@@ -41,4 +41,4 @@ schema:
 slug: portainer_agent
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: 2025.12-6
+version: "2025.12.6"

--- a/portainer_be/CHANGELOG.md
+++ b/portainer_be/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2026.08.01 (2026-08-01)
+
+- Version renamed from `sts`, which Home Assistant could not order and therefore could not reliably offer as an update: the previous version held no number that could order it, so the date of this change is used. The addon itself and the upstream version it tracks are unchanged
+
  
 ## sts (2026-08-01)
 - Update to latest version from portainer/portainer-ee

--- a/portainer_be/config.yaml
+++ b/portainer_be/config.yaml
@@ -42,4 +42,4 @@ schema:
 slug: portainer_be
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "sts"
+version: "2026.08.01"

--- a/postgres_15/CHANGELOG.md
+++ b/postgres_15/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 15.7.47 (2026-08-01)
+
+- Version renamed from `15.7-47`, which Home Assistant could not order and therefore could not reliably offer as an update: every number of the previous version is kept, as a section of its own. The addon itself and the upstream version it tracks are unchanged
+
 - The Home Assistant project has deprecated support for the armv7, armhf and i386 architectures. Support wil be fully dropped in the upcoming Home Assistant 2025.12 release
 
 - Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.

--- a/postgres_15/config.yaml
+++ b/postgres_15/config.yaml
@@ -34,4 +34,4 @@ schema:
 slug: postgres
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/postgres
-version: 15.7-47
+version: "15.7.47"

--- a/postgres_17/CHANGELOG.md
+++ b/postgres_17/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 17.4.13 (2026-08-01)
+
+- Version renamed from `17.4-13`, which Home Assistant could not order and therefore could not reliably offer as an update: every number of the previous version is kept, as a section of its own. The addon itself and the upstream version it tracks are unchanged
+
 - Added support for configuring extra environment variables via the `env_vars` add-on option alongside config.yaml. See https://github.com/alexbelgium/hassio-addons/wiki/Add-Environment-variables-to-your-Addon-2 for details.
 
 ## 17.4-13 (2025-08-22)

--- a/postgres_17/config.yaml
+++ b/postgres_17/config.yaml
@@ -35,4 +35,4 @@ slug: postgres_latest
 startup: system
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/postgres
-version: 17.4-13
+version: "17.4.13"

--- a/prowlarr/CHANGELOG.md
+++ b/prowlarr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.1.5509.8 (2026-08-01)
+
+- Version renamed from `nightly-2.6.1.5509-ls8`, which Home Assistant could not order and therefore could not reliably offer as an update: every number of the previous version is kept, as a section of its own. The addon itself and the upstream version it tracks are unchanged
+
  
 ## nightly-2.6.1.5509-ls8 (2026-08-01)
 - Update to latest version from linuxserver/docker-prowlarr (changelog : https://github.com/linuxserver/docker-prowlarr/releases)

--- a/prowlarr/config.yaml
+++ b/prowlarr/config.yaml
@@ -110,4 +110,4 @@ schema:
 slug: prowlarr
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "nightly-2.6.1.5509-ls8"
+version: "2.6.1.5509.8"

--- a/webtop/CHANGELOG.md
+++ b/webtop/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.16.0.95.7 (2026-08-01)
+
+- Version renamed from `4.16-r0-ls95-7`, which Home Assistant could not order and therefore could not reliably offer as an update: every number of the previous version is kept, as a section of its own. The addon itself and the upstream version it tracks are unchanged
+
 ## 4.16-r0-ls95-7 (28-07-2026)
 
 - Fix Selkies dying with a Rust `RuntimeDirNotSet` unwrap panic just after `Data WebSocket Server listening on port 8081`, and the data websocket then being proxied to the wrong port. Upstream relies on s6-rc ordering: `init-selkies-config` publishes `XDG_RUNTIME_DIR` and `CUSTOM_WS_PORT` into the s6 envdir and `svc-selkies` starts afterwards. The add-on entrypoint replaces s6-overlay and starts every `s6-rc.d` run script in parallel with no dependency graph, so Selkies can snapshot the envdir before that oneshot has written to it -- which is why it bound port 8081 (its own default) instead of the 8082 nginx proxies to, and why its Wayland compositor found no runtime directory to bind a socket in. `20-folders.sh` now exports both variables inside each run script, where no start ordering can lose them, and corrects the base image's `$HOME/.XDG` override where that write happens instead of appending a correction after the `exit 0` that the oneshot-tolerance block adds -- which meant the correction never ran on any boot after the first.

--- a/webtop/config.yaml
+++ b/webtop/config.yaml
@@ -138,5 +138,5 @@ slug: webtop-kde
 tmpfs: true
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: 4.16-r0-ls95-7
+version: "4.16.0.95.7"
 video: true

--- a/webtop_kde/CHANGELOG.md
+++ b/webtop_kde/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.16.0.94 (2026-08-01)
+
+- Version renamed from `4.16-r0-ls94`, which Home Assistant could not order and therefore could not reliably offer as an update: every number of the previous version is kept, as a section of its own. The addon itself and the upstream version it tracks are unchanged
+
  
 ## 4.16-r0-ls94 (2026-08-01)
 - Update to latest version from linuxserver/docker-webtop (changelog : https://github.com/linuxserver/docker-webtop/releases)

--- a/webtop_kde/config.yaml
+++ b/webtop_kde/config.yaml
@@ -143,5 +143,5 @@ slug: webtop
 tmpfs: true
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "4.16-r0-ls94"
+version: "4.16.0.94"
 video: true

--- a/wger/CHANGELOG.md
+++ b/wger/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.3 (2026-08-01)
+
+- Version renamed from `2.6-dev-3`, which Home Assistant could not order and therefore could not reliably offer as an update: every number of the previous version is kept, as a section of its own. The addon itself and the upstream version it tracks are unchanged
+
 ## 2.6-dev-3 (2026-06-16)
 - Fix fresh-install startup by making the persistent `/data/static` and `/data/media` directories writable by the `wger` user without recursively changing all of `/data`.
 - Preserve existing persistent data by reusing `/data/database.sqlite` when present, and migrating a legacy `/home/wger/db/database.sqlite` only if no persistent database exists yet.

--- a/wger/config.yaml
+++ b/wger/config.yaml
@@ -23,5 +23,5 @@ schema:
 slug: wger
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "2.6-dev-3"
+version: "2.6.3"
 webui: "[PROTO:ssl]://[HOST]:[PORT:80]"


### PR DESCRIPTION
Companion to #2925, which fixes the updater. This one fixes the add-ons that already carry a broken version.

## Why

`awesomeversion`, the library Home Assistant orders add-on versions with, reports `AwesomeVersionStrategy.UNKNOWN` for 20 of the versions currently in this repo. Home Assistant cannot tell which of two such versions is newer, so:

- update detection falls back to the "cannot compare" branch of `UpdateEntity.state` rather than to real ordering;
- `breaking_versions` and the auto-update crossing checks in the Supervisor are undefined for these add-ons;
- as soon as a scheme becomes *partially* comparable, the update silently stops being offered — `1.2.3` → `1.2.3-2` is the case that started this.

## What changed

Only `version:` in `config.yaml` plus a `CHANGELOG.md` entry. No Dockerfile, no `updater.json`, no build file: every add-on still builds from exactly the upstream tag it built from before.

Each new version keeps **every number the old one carried**, as a section of its own, following the rule the updater in #2925 now applies: `v26.2-ls256` -> `v26.2.256`, `4.16-r0-ls95-7` -> `4.16.0.95.7`, `5.0.0b5-3` -> `5.0.0.5.3`. Nothing that ordered the add-on is lost, and no previously published version is reused. Only the two versions holding no number at all fall back to the date.

| add-on | before | after |
|---|---|---|
| nzbget | `v26.2-ls256` | `v26.2.256` |
| webtop | `4.16-r0-ls95-7` | `4.16.0.95.7` |
| webtop_kde | `4.16-r0-ls94` | `4.16.0.94` |
| plex | `1.43.3.10828-00f62d37d-ls316` | `1.43.3.10828.316` |
| prowlarr | `nightly-2.6.1.5509-ls8` | `2.6.1.5509.8` |
| monica | `5.0.0b5-3` | `5.0.0.5.3` |
| lidarr | `3.1.0.4875-1` | `3.1.0.4875.1` |
| postgres_15 | `15.7-47` | `15.7.47` |
| postgres_17 | `17.4-13` | `17.4.13` |
| portainer_agent | `2025.12-6` | `2025.12.6` |
| organizr | `v2-7` | `v2.7` |
| wger | `2.6-dev-3` | `2.6.3` |
| photoprism | `ubuntu-2026-07-28` | `2026.07.28` |
| epicgamesfree | `debian-2026-07-27` | `2026.07.27` |
| birdnet-go-dev | `source-20260729.1` | `20260729.1` |
| browser_chromium | `version-bf9e0b4f` | `2026.08.01` (tag holds no number) |
| portainer_be | `sts` | `2026.08.01` (tag holds no number) |

Every "after" value was checked to be recognised by `awesomeversion`, to be offered by Home Assistant as an update of the "before" value, and to never repeat a version that add-on already published. The next upstream bump was simulated for each add-on with the helper from #2925 (for example `v26.2.256` → `v26.3.257` on the next LinuxServer build).

## Deliberately not included

- `zzz_archived_omada` and `zzz_archived_omada_v3` — archived add-ons, intentionally frozen; bumping them would trigger a rebuild of images nobody maintains.
- `claude_desktop` (`ubunturesolute-version-3a10bef7`) — has work in progress locally that sets its version back to a plain counter, which fixes it anyway. Worth confirming it lands.

## Expected side effect

Each of the 17 add-ons rebuilds once on merge and its users see a single update with no functional change — that is the cost of moving to a version Home Assistant can order. The changelog entry of each add-on says exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Updates**
  - Updated release labels across multiple add-ons, including BirdNET-Go, Chromium, Epic Games Free, Lidarr, Monica, NZBGet, Organizr, Photoprism, Plex, Portainer, PostgreSQL, Prowlarr, Webtop, Wger, and others.
  - Standardized versions into clearer date-based or semantic formats for improved Home Assistant display and sorting.
  - Added corresponding changelog entries dated August 1, 2026.
  - No underlying add-on functionality or upstream software versions were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->