### PR TITLE
fix(templates): use exact ntfs-3g package name instead of glob on apt

### DIFF
--- a/.templates/ha_automatic_packages.sh
+++ b/.templates/ha_automatic_packages.sh
@@ -65,7 +65,7 @@ for files in "/etc/cont-init.d" "/etc/services.d"; do
     if grep -q -rnw "$files/" -e "$COMMAND"; then
         [ "$VERBOSE" = true ] && echo "$COMMAND required"
         [ "$PACKMANAGER" = "apk" ] && PACKAGES="$PACKAGES exfatprogs ntfs-3g ntfs-3g-progs squashfs-tools fuse lsblk"
-        [ "$PACKMANAGER" = "apt" ] && PACKAGES="$PACKAGES exfat* ntfs* squashfs-tools util-linux"
+        [ "$PACKMANAGER" = "apt" ] && PACKAGES="$PACKAGES exfat* ntfs-3g squashfs-tools util-linux"
         #[ "$PACKMANAGER" = "pacman" ] && PACKAGES="$PACKAGES ntfs-3g"
     fi
 


### PR DESCRIPTION
## Problem

The `Builder` workflow has been failing repeatedly on `master` — most recently [run 30686772951](https://github.com/alexbelgium/hassio-addons/actions/runs/30686772951/job/91334128582) (`Build aarch64 scrutiny_fa add-on`), and also for `scrutiny`.

The build dies at the `ha_autoapps.sh` step:

```
#16 19.98 Error : ntfs* not found
#16 ERROR: process "/usr/bin/sh -c chmod 744 /ha_autoapps.sh && /ha_autoapps.sh \"$PACKAGES\" && rm /ha_autoapps.sh" did not complete successfully: exit code: 1
```

## Root cause

The `mount` auto-detection block in `.templates/ha_automatic_packages.sh` appends the literal glob `ntfs*` to the apt install list. Packages are installed one at a time, and any failure touches `/ERROR`, which makes the script exit 1 at the end.

On the `scrutiny` / `scrutiny_fa` base image (`ghcr.io/starosdev/scrutiny:latest-omnibus`, Debian **trixie**) that glob fails to resolve, even though the real package `ntfs-3g` is present in `trixie`/`main`.

This has looped several times today: the updater bumps the add-on version, the build fails, the bump gets reverted, and the cycle repeats — because reverting the version bump never touched the actual bug in the shared template.

## Fix

Use the exact package name instead of the glob, matching the `apk` branch directly above it, which already uses `ntfs-3g` explicitly:

```diff
-[ "$PACKMANAGER" = "apt" ] && PACKAGES="$PACKAGES exfat* ntfs* squashfs-tools util-linux"
+[ "$PACKMANAGER" = "apt" ] && PACKAGES="$PACKAGES exfat* ntfs-3g squashfs-tools util-linux"
```

## Notes

- `.templates/` is shared build infrastructure, so this affects any apt-based add-on whose init scripts mention `mount`. `exfat*` is left as-is since it resolves fine and covers the renamed `exfatprogs`/`exfat-utils` split.
- No add-on `config.yaml` changed, so the CHANGELOG check does not apply to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the apt package selection to install the specific `ntfs-3g` dependency for mount command support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->