### PR TITLE
fix(birdnet-pi): restore the ingress Caddy site (502 Bad Gateway)

### DIFF
--- a/birdnet-pi/CHANGELOG.md
+++ b/birdnet-pi/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2026.08.02 (02-08-2026)
+- Fix: ingress returned "502 Bad Gateway" because Caddy never listened on :8082. `91-nginx_ingress.sh` hooked the ingress site into `update_caddyfile.sh` with a sed anchored on `sudo caddy fmt --overwrite`, but 2026.07.10-1 strips `sudo` from every BirdNET-Pi script at build time, so the anchor stopped matching. `update_caddyfile.sh` then rewrote the Caddyfile from scratch just before Caddy started, dropping the ingress site
+- Fix: `caddy_ingress.sh` no longer appends a second `:8082` block when it runs twice (a duplicate site address makes Caddy refuse to start)
+- Fix: `02-caddy.sh` re-adds the ingress site if it is missing from the Caddyfile just before starting Caddy
 ## 2026.07.22 (22-07-2026)
 - Fix: health-check the WebUI port (8081) instead of port 80, so the standalone Docker container no longer reports "unhealthy" when ssl=false
 - Fix: health-check now probes https when ssl is enabled, and no longer silently reports "healthy" regardless of the actual result (the previous check's `&>` redirection is a bash-ism that dash, the image's /bin/sh, parses as background + no-op, discarding curl's exit status)

--- a/birdnet-pi/config.yaml
+++ b/birdnet-pi/config.yaml
@@ -116,5 +116,5 @@ tmpfs: true
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-pi
 usb: true
-version: 2026.07.22
+version: 2026.08.02
 video: true

--- a/birdnet-pi/rootfs/custom-services.d/02-caddy.sh
+++ b/birdnet-pi/rootfs/custom-services.d/02-caddy.sh
@@ -25,5 +25,15 @@ export TZ="${TZ_VALUE:-Etc/UTC}"
 # Update caddyfile with password
 "$HOME"/BirdNET-Pi/scripts/update_caddyfile.sh &> /dev/null || true
 
+# update_caddyfile.sh rewrites the Caddyfile from scratch. 91-nginx_ingress.sh
+# hooks the ingress site back into it, but if that hook ever fails to apply,
+# caddy would start without a :8082 listener and ingress would answer 502.
+# 91-nginx_ingress.sh writes /ingress_url when ingress is on and removes it when
+# it is off, so this is a no-op in standalone mode.
+if [[ -f /ingress_url ]] && ! grep -qE '^[[:space:]]*:8082[[:space:]]*\{' /etc/caddy/Caddyfile; then
+    echo "Ingress site missing from the Caddyfile, re-adding it"
+    /helpers/caddy_ingress.sh
+fi
+
 echo "Starting service: caddy"
 exec /usr/bin/caddy run --config /etc/caddy/Caddyfile

--- a/birdnet-pi/rootfs/custom-services.d/02-caddy.sh
+++ b/birdnet-pi/rootfs/custom-services.d/02-caddy.sh
@@ -30,9 +30,18 @@ export TZ="${TZ_VALUE:-Etc/UTC}"
 # caddy would start without a :8082 listener and ingress would answer 502.
 # 91-nginx_ingress.sh writes /ingress_url when ingress is on and removes it when
 # it is off, so this is a no-op in standalone mode.
-if [[ -f /ingress_url ]] && ! grep -qE '^[[:space:]]*:8082[[:space:]]*\{' /etc/caddy/Caddyfile; then
+# Require the Caddyfile to exist: if it is missing something went badly wrong
+# earlier, and caddy failing on a missing config is easier to diagnose than an
+# ingress-only Caddyfile conjured up here.
+if [[ -f /ingress_url ]] && [[ -f /etc/caddy/Caddyfile ]] \
+    && ! grep -qE '^[[:space:]]*:8082[[:space:]]*\{' /etc/caddy/Caddyfile 2> /dev/null; then
     echo "Ingress site missing from the Caddyfile, re-adding it"
-    /helpers/caddy_ingress.sh
+    if ! /helpers/caddy_ingress.sh; then
+        # Start caddy anyway: ingress stays broken, but direct access on 8081
+        # keeps working. Exiting here would only make s6 restart this service in
+        # a loop and take the WebUI down completely.
+        echo "Failed to re-add the ingress site, the ingress panel will return 502" >&2
+    fi
 fi
 
 echo "Starting service: caddy"

--- a/birdnet-pi/rootfs/etc/cont-init.d/91-nginx_ingress.sh
+++ b/birdnet-pi/rootfs/etc/cont-init.d/91-nginx_ingress.sh
@@ -26,6 +26,10 @@ ingress_entry=$(bashio::addon.ingress_entry)
 if [[ "$ingress_entry" != "/api"* ]]; then
     bashio::log.info "Ingress entry is not set, exiting configuration."
     sed -i "1a sleep infinity" /custom-services.d/02-nginx.sh
+    # This script re-runs from /etc/scripts-init on an add-on restart, so drop
+    # any marker left by an earlier run: it is what 02-caddy.sh reads to decide
+    # whether the ingress site belongs in the Caddyfile.
+    rm -f /ingress_url
     exit 0
 fi
 
@@ -68,9 +72,23 @@ sed -i "s|localhost|localhost:8082|g" "$HOME/BirdNET-Pi/scripts/utils/notificati
 
 # Update the Caddyfile if update script exists
 caddy_update_script="$HOME/BirdNET-Pi/scripts/update_caddyfile.sh"
-if [ -f "$caddy_update_script" ]; then
-    sed -i "/sudo caddy fmt --overwrite/i /helpers/caddy_ingress.sh" "$caddy_update_script"
-else
+if [ ! -f "$caddy_update_script" ]; then
     bashio::log.error "Caddy update script not found: $caddy_update_script"
     exit 1
+fi
+
+# update_caddyfile.sh rewrites /etc/caddy/Caddyfile from scratch, which drops
+# the ingress site added just above. 02-caddy.sh runs it right before starting
+# caddy, so the hook below has to re-add the site from inside that script, just
+# before it formats and reloads the config.
+# The anchor must not require "sudo": the Dockerfile strips it from every
+# BirdNET-Pi script at build time, so the shipped line is "caddy fmt --overwrite".
+if ! grep -qF "/helpers/caddy_ingress.sh" "$caddy_update_script"; then
+    sed -i -E "/^[[:space:]]*(sudo[[:space:]]+)?caddy[[:space:]]+fmt[[:space:]]+--overwrite/i /helpers/caddy_ingress.sh" "$caddy_update_script"
+fi
+
+# sed is silent when the anchor is missing; make sure the hook is really there
+if ! grep -qF "/helpers/caddy_ingress.sh" "$caddy_update_script"; then
+    bashio::log.warning "Could not anchor the ingress site in $caddy_update_script, appending it instead"
+    printf '\n/helpers/caddy_ingress.sh\n' >> "$caddy_update_script"
 fi

--- a/birdnet-pi/rootfs/helpers/caddy_ingress.sh
+++ b/birdnet-pi/rootfs/helpers/caddy_ingress.sh
@@ -6,6 +6,13 @@ set +u
 # shellcheck disable=SC1091
 source /etc/birdnet/birdnet.conf
 
+# Nothing to do if the ingress site is already there. This script runs both from
+# cont-init and from update_caddyfile.sh, and a duplicate ":8082" site address
+# makes caddy refuse to start.
+if grep -qE '^[[:space:]]*:8082[[:space:]]*\{' /etc/caddy/Caddyfile 2> /dev/null; then
+    exit 0
+fi
+
 # Create ingress configuration for Caddyfile
 cat << EOF >> /etc/caddy/Caddyfile
 :8082 {


### PR DESCRIPTION
Closes #2928

## Symptom

The BirdNET-Pi WebUI answers `502 Bad Gateway` through the Home Assistant ingress side panel, while direct access on `:8081` keeps working:

```
connect() failed (111: Connection refused) while connecting to upstream,
upstream: "http://127.0.0.1:8082/"
```

## Root cause

nginx forwards ingress traffic to `127.0.0.1:8082` ([ingress.conf:11](https://github.com/alexbelgium/hassio-addons/blob/master/birdnet-pi/rootfs/etc/nginx/servers/ingress.conf#L11)). That listener is a separate `:8082 { … }` site appended to the Caddyfile by `helpers/caddy_ingress.sh`.

The upstream BirdNET-Pi script `$HOME/BirdNET-Pi/scripts/update_caddyfile.sh` regenerates `/etc/caddy/Caddyfile` from scratch (`cat > …`), and `custom-services.d/02-caddy.sh` runs it immediately before `exec caddy run` — so the appended site is wiped every boot. To survive that, `91-nginx_ingress.sh` injected a call to `caddy_ingress.sh` back into that script:

```bash
sed -i "/sudo caddy fmt --overwrite/i /helpers/caddy_ingress.sh" "$caddy_update_script"
```

Since **2026.07.10-1** the Dockerfile strips `sudo ` from every BirdNET-Pi script at build time ([Dockerfile:110](https://github.com/alexbelgium/hassio-addons/blob/master/birdnet-pi/Dockerfile#L110)), so the shipped line is `caddy fmt --overwrite /etc/caddy/Caddyfile`. The anchor no longer matches — and `sed` exits 0 when a pattern matches nothing, so the failure was silent. Caddy then started with only the `:8081` site and nginx got connection-refused on 8082.

Confirmed by extracting the script out of the published `ghcr.io/alexbelgium/birdnet-pi-amd64` image; its last two lines are `caddy fmt --overwrite /etc/caddy/Caddyfile` and `systemctl reload caddy`, with no `sudo` anywhere in the file.

This also explains the reporter's finding that pointing Caddy at `:8082` fixed ingress but broke LAN access: the problem was never the port number on the main site, it was the missing second site.

## Fix

| File | Change |
|---|---|
| `etc/cont-init.d/91-nginx_ingress.sh` | Anchor accepts the line with or without `sudo`; injection is skipped when already present (cont-init re-runs on restart); the result is verified, falling back to appending the call if the anchor ever disappears again |
| `helpers/caddy_ingress.sh` | Returns early when a `:8082` site already exists — the script now runs from more than one place and a duplicate site address makes Caddy refuse to start |
| `custom-services.d/02-caddy.sh` | Re-adds the ingress site just before starting Caddy if it is missing, so a future upstream change to `update_caddyfile.sh` cannot silently bring the 502 back |
| `etc/cont-init.d/91-nginx_ingress.sh` | Removes `/ingress_url` when ingress is off, so that marker stays a truthful signal for the check above across an in-container restart |

## Verification

A harness replays the real boot sequence — build-time `sudo` strip, `81-modifications.sh`, `91-nginx_ingress.sh`, `02-caddy.sh` — against the actual upstream `update_caddyfile.sh`:

| scenario | master | this branch |
|---|---|---|
| fresh boot, ingress on | **0** `:8082` sites → 502 | 1 `:8082` site |
| add-on restart (cont-init re-runs) | **0** → 502 | 1 (no duplicate) |
| standalone / no ingress | 0 (correct) | 0 (correct) |
| `caddy fmt` anchor removed entirely | **0** → 502 | 1 (fallback path) |

`shellcheck -x`, `bash -n` and `git diff --check` are clean on all changed scripts.

The diagnosis and the diff were also reviewed independently by an outside agent (OpenAI Codex / gpt-5.6-sol) reading the tree on its own; it confirmed the root cause and the fix, and its one substantive finding — that `/ingress_url` could go stale across an in-container restart — is addressed above.

## Not addressed here

`02-caddy.sh:14-16` rewrites the literal `/run/php/php-fpm.sock` into the discovered socket path. After the first run the literal is gone, so if PHP-FPM ever picks a different socket name on an in-container restart the substitution no longer matches. Pre-existing, unrelated to the 502, left alone to keep this diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ingress configuration reliability when starting or updating the add-on.
  * Prevented duplicate ingress site entries and corrected configuration handling during Caddy updates.
  * Automatically restores missing ingress configuration when ingress is enabled.
  * Cleaned up stale ingress state when ingress is inactive.
* **Chores**
  * Updated BirdNET-pi to version 2026.08.02.
* **Documentation**
  * Added release notes covering the ingress configuration fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->