### PR TITLE
fix(webtrees): custom module installation fails — /config/modules_v4 owned by the wrong uid

### DIFF
--- a/webtrees/CHANGELOG.md
+++ b/webtrees/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 2.2.6.1 (2026-08-05)
+- Fix custom modules failing to install from the webtrees UI (e.g. with the Custom Module Manager plugin) : /config/modules_v4 was left owned by the base image's original www-data uid (33) while the app runs as PUID:PGID, so it was not writable (https://github.com/alexbelgium/hassio-addons/issues/2940)
+
 ## 2.2.6 (2026-05-09)
 - Update to latest version from nathanvaughn/webtrees-docker (changelog : https://github.com/nathanvaughn/webtrees-docker/releases)
 

--- a/webtrees/config.yaml
+++ b/webtrees/config.yaml
@@ -117,5 +117,5 @@ services:
 slug: webtrees
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "2.2.6"
+version: "2.2.6.1"
 webui: "[PROTO:ssl]://[HOST]:[PORT:80]"

--- a/webtrees/rootfs/etc/cont-init.d/99-run.sh
+++ b/webtrees/rootfs/etc/cont-init.d/99-run.sh
@@ -56,10 +56,15 @@ rm -r /var2/www/webtrees/modules_v4
 ln -sf "/config/modules_v4" /var2/www/webtrees/modules_v4
 
 # Update permissions on target directories
+# /docker-entrypoint.py renumbers www-data to PUID:PGID (usermod/groupmod) after this
+# script has run, and then only re-chowns its DATA_DIR. Chowning by name here would
+# therefore leave everything else -- notably /config/modules_v4 -- owned by the image's
+# original www-data uid (33), which the running Apache/PHP process can no longer write to.
+# Chown by the numeric ids the app will actually run as instead.
 echo "... update permissions"
-chown -R www-data:www-data "$DATA_LOCATION"
+chown -R "${PUID:-1000}:${PGID:-1000}" "$DATA_LOCATION"
 chmod -R 755 "$DATA_LOCATION"
-chown -R www-data:www-data "/config"
+chown -R "${PUID:-1000}:${PGID:-1000}" "/config"
 chmod -R 755 "/config"
 
 # Remove /data/data


### PR DESCRIPTION
Fixes #2940

## Symptom

Installing any custom module from the webtrees UI (e.g. via the [Custom Module Manager](https://github.com/Jefferson49/CustomModuleManager) plugin) fails and is rolled back:

```
The installation of module _dead-record-detective_ was rolled back, because the module created errors.
Unable to write file at location: module.php. Unable to create a directory at
/var2/www/webtrees/app/Factories/../../modules_v4/dead-record-detective.
```

## Root cause

`modules_v4` is the only persistent directory that ends up owned by a uid the app does not run as.

1. `99-run.sh` symlinks `/var2/www/webtrees/modules_v4` → `/config/modules_v4`, then runs
   `chown -R www-data:www-data /config`. At that point `www-data` is still the base image's
   **uid 33**, so `/config/modules_v4` is left `33:33`, mode 755.
2. `99-run.sh` then execs `/docker-entrypoint.py`, whose `perms()`
   ([upstream lines 335-337](https://github.com/NathanVaughn/webtrees-docker/blob/main/docker/docker-entrypoint.py))
   **renumbers** `www-data` to `PUID:PGID` via `groupmod`/`usermod` — `1000:1000`, per the
   `environment:` block in `config.yaml`.
3. `perms()` then re-chowns only its `DATA_DIR`, which this add-on has already sed'd to
   `$DATA_LOCATION`. So the data directory is fixed up to `1000:1000` and normal webtrees use
   (trees, media, uploads) keeps working — which is why nobody noticed.
4. `/config/modules_v4` is never re-chowned. Apache/PHP now run as uid 1000 against a
   `33:33` mode-755 directory, so `mkdir` inside it returns `EACCES`.

This matches the failure point precisely: the Custom Module Manager downloads and unzips into
`data/tmp/upgrade/` and `data/tmp/backup/`
([`ModuleUpgradeWizardStep.php:96-102`](https://github.com/Jefferson49/CustomModuleManager/blob/main/src/RequestHandlers/ModuleUpgradeWizardStep.php)),
which live under the correctly-chowned data dir and succeed. Only the final copy into
`modules_v4/` fails.

It affects every user of the add-on, not just this reporter — `PUID`/`PGID` are fixed at `1000`
in `config.yaml` and are not exposed in the option schema, so the renumbering always happens.

## Fix

Chown by the **numeric** ids the app will actually run as, instead of by a name that gets
renumbered a moment later. Three lines changed in the script that already did the chown — no new
script, service or option.

```diff
-chown -R www-data:www-data "$DATA_LOCATION"
+chown -R "${PUID:-1000}:${PGID:-1000}" "$DATA_LOCATION"
 chmod -R 755 "$DATA_LOCATION"
-chown -R www-data:www-data "/config"
+chown -R "${PUID:-1000}:${PGID:-1000}" "/config"
 chmod -R 755 "/config"
```

`${PUID:-1000}` is the same expression this script already uses two blocks earlier when patching
the entrypoint's own defaults, so the two can't disagree. Existing installs are repaired in place
on the next start — no migration step needed.

## Scope / what is *not* changed

- `chmod -R 755` on `$DATA_LOCATION` and `/config` is pre-existing behaviour, left alone.
- The set of paths chowned is unchanged; only the ownership value is corrected.
- No change to `PUID`/`PGID`, the symlink layout, the schema, or the Dockerfile.

## Alternative considered

An independent review (Codex / gpt-5.6-sol) confirmed the causal chain and the ordering, and
suggested a narrower variant: keep `chown -R www-data:www-data /config` as-is and *append* a
second, numeric `chown -R "${PUID:-1000}:${PGID:-1000}" /config/modules_v4`.

I went with correcting the existing chown instead, because:

- The **set of files touched is identical** either way — the current line already recurses over
  all of `/config`. Only the resulting uid changes, from 33 (which nothing runs as) to 1000
  (which the app does). So the "don't recursively chown arbitrary user files" objection applies
  equally to the code that is already there.
- Correcting the value is a smaller diff than adding a compensating chown after a knowingly-wrong
  one, and doesn't leave two contradictory chowns in the same block for the next reader.
- It fixes the whole class rather than one directory: the existing line's evident intent is
  "`/config` is owned by the web process", and today that intent is met for nothing except what
  upstream happens to repair.

The reviewer also noted (correctly) that the `$DATA_LOCATION` chown is **redundant** — upstream
re-chowns `DATA_DIR` after renumbering. It is changed here only for consistency within the block;
`chown` behaves identically whether given a name or a numeric id, so this is neutral on
CIFS/`networkdisks` data locations (where `chown` may fail today and would fail identically
after this change — the script does not use `errexit`).

## Verification status

- **Verified:** `bash -n`, shellcheck, hadolint, yamllint, config.yaml schema, and the repo's
  `--vs-master` lint diff — the change introduces no new findings.
- **Verified by reading the code:** the ordering (cont-init `99-run.sh` chown → `perms()`
  `usermod` → `perms()` chown of `DATA_DIR` only) and the fact that the Custom Module Manager's
  temp dirs sit under the correctly-chowned data dir.
- **Not verified:** the image build (no dockerd available locally — CI is the gate), and the
  end-to-end module install, which needs a running add-on with the plugin. @alexbelgium /
  the reporter would need to confirm on the rebuilt image.

## Rollback

Single commit, self-contained: revert
`webtrees/rootfs/etc/cont-init.d/99-run.sh` to `www-data:www-data` on both chown lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed custom module installation when running with a configured user and group ID.
  * Updated directory ownership handling so application files match the configured runtime user.

* **Chores**
  * Updated the Webtrees add-on to version 2.2.6.1.
  * Added release notes documenting the ownership fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->