### PR TITLE
fix(portainer): request identity encoding on the ingress listener

### DIFF
--- a/portainer/CHANGELOG.md
+++ b/portainer/CHANGELOG.md
@@ -1,6 +1,6 @@
  
 ## 2.44.0.1 (2026-08-05)
-- Ingress: request uncompressed responses from Portainer so they carry a Content-Length and stay on the Home Assistant relay's buffered path. Portainer compresses its own responses, and the Accept-Encoding strip in proxy_params.conf never applied because the location block declares its own proxy_set_header directives, which discards the server-level ones. Partial mitigation for #2766: the page itself and all assets under 4 MB are now buffered, but the two large JavaScript bundles still exceed the relay's 4 MB buffering threshold. Direct access on the web UI port keeps compression
+- Ingress: request uncompressed responses from Portainer so they carry a Content-Length and stay on the Home Assistant relay's buffered path. Portainer compresses its own responses, and the Accept-Encoding strip in proxy_params.conf never applied because the location block declares its own proxy_set_header directives, which makes nginx discard the server-level ones. Partial mitigation for #2766: the page itself and all assets under 4 MB are now buffered, but the two large JavaScript bundles still exceed the relay's 4 MB buffering threshold. Direct access on the web UI port keeps compression
  
 ## 2.44.0 (2026-08-01)
 - Update to latest version from portainer/portainer (changelog : https://github.com/portainer/portainer/releases)

--- a/portainer/CHANGELOG.md
+++ b/portainer/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## 2.44.0.1 (2026-08-05)
+- Ingress: request uncompressed responses from Portainer so they carry a Content-Length and stay on the Home Assistant relay's buffered path. Portainer compresses its own responses, and the Accept-Encoding strip in proxy_params.conf never applied because the location block declares its own proxy_set_header directives, which discards the server-level ones. Partial mitigation for #2766: the page itself and all assets under 4 MB are now buffered, but the two large JavaScript bundles still exceed the relay's 4 MB buffering threshold. Direct access on the web UI port keeps compression
+ 
 ## 2.44.0 (2026-08-01)
 - Update to latest version from portainer/portainer (changelog : https://github.com/portainer/portainer/releases)
  

--- a/portainer/config.yaml
+++ b/portainer/config.yaml
@@ -42,4 +42,4 @@ schema:
 slug: portainer
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "2.44.0"
+version: "2.44.0.1"

--- a/portainer/rootfs/etc/nginx/nginx.conf
+++ b/portainer/rootfs/etc/nginx/nginx.conf
@@ -56,7 +56,7 @@ http {
     # port is templated from the add-on config, so defaulting to identity keeps
     # ingress correct even if that port ever changes.
     map $server_port $upstream_accept_encoding {
-        default "";
+        default identity;
         9099    $http_accept_encoding;
     }
 

--- a/portainer/rootfs/etc/nginx/nginx.conf
+++ b/portainer/rootfs/etc/nginx/nginx.conf
@@ -49,6 +49,17 @@ http {
         ''      close;
     }
 
+    # Ingress needs Portainer to answer uncompressed, so the responses carry a
+    # Content-Length and stay on the relay's buffered path. Direct access on
+    # 9099 does not go through the relay, so it keeps compression.
+    # Keyed on the direct-access port rather than the ingress port: the ingress
+    # port is templated from the add-on config, so defaulting to identity keeps
+    # ingress correct even if that port ever changes.
+    map $server_port $upstream_accept_encoding {
+        default "";
+        9099    $http_accept_encoding;
+    }
+
     include /etc/nginx/includes/resolver.conf;
     include /etc/nginx/includes/upstream.conf;
 

--- a/portainer/rootfs/etc/nginx/templates/ingress.gtpl
+++ b/portainer/rootfs/etc/nginx/templates/ingress.gtpl
@@ -20,5 +20,13 @@ server {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-Host $http_host;
+
+    # Portainer gzips its own responses, which makes them chunked with no
+    # Content-Length. Home Assistant's ingress relay only buffers responses
+    # under 4 MB that carry a Content-Length, so everything else falls into
+    # its streaming path. Asking upstream for identity keeps the small
+    # responses buffered. The map in nginx.conf applies this to the ingress
+    # listener only, so direct access on 9099 keeps compression.
+    proxy_set_header Accept-Encoding $upstream_accept_encoding;
   }
 }


### PR DESCRIPTION
Partial mitigation for #2766 (Portainer 502 Bad Gateway via ingress). Supersedes the 2.43.0.1 attempt, which fixed the wrong compressor.

## What is actually happening

The add-on's own nginx logs `200` for the exact requests the browser sees as `502`, so the failure is in the Home Assistant relay, not in the add-on.

Both relay hops — Supervisor `api/ingress.py` and Core `components/hassio/ingress.py` — buffer a response only when it carries a `Content-Length` under 4 MB. Anything else goes down the streaming path, where an `aiohttp.ClientError` is returned to the browser as `502 Bad Gateway`. Today **every** ingress response takes the streaming path, because Portainer gzips its own responses and therefore sends them chunked with no `Content-Length`.

The `proxy_set_header Accept-Encoding "";` line in `proxy_params.conf` was supposed to prevent this, but it never applied: `proxy_params.conf` is included at server level, and the `location /` block declares its own `proxy_set_header` directives, which makes nginx discard **all** server-level ones. The comment directly above those lines warns about exactly this trap. So the strip was dead config, and 2.43.0.1's `gzip off` disabled nginx's own gzip module — not the compressor that was actually running.

## What changed

`proxy_set_header Accept-Encoding $upstream_accept_encoding;` inside the `location /` block, where it actually takes effect, plus a `map $server_port` in `nginx.conf` that scopes it.

The scoping matters because the same server block serves both the ingress listener and the direct web UI port. Stripping compression unconditionally would have cost direct-access users ~13.7 MB instead of ~3.3 MB per cold load for no benefit — they never touch the relay. The map keys on the direct-access port (`9099`) rather than the templated ingress port, so the default stays correct even if `ingress_port` ever changes.

## Measured

Local nginx running the rendered config against the live Portainer backend:

| Case | Result |
|---|---|
| Ingress listener, client sends `Accept-Encoding: gzip, deflate` | identity, `Content-Length: 14203` |
| Same request with the new line removed (control) | `Content-Encoding: gzip`, chunked, no `Content-Length` |
| Direct listener `:9099`, same request | gzip preserved |
| Direct listener `:9099`, no `Accept-Encoding` | identity, `Content-Length` |
| Websocket upgrade via ingress | reaches Portainer, `401` (auth required) |

Portainer's backend probed directly (no nginx in path) returns `Content-Encoding: gzip` + chunked, confirming Portainer is the compressor.

## Verified / not verified

- **Verified:** the encoding and `Content-Length` behaviour above; `nginx -t` passes on both the ssl and non-ssl rendered variants; the `30-nginx.sh` `sed` transforms still land correctly (the ssl line-8 cert insert is unaffected, the new directive stays inside `location /` in both branches).
- **Checked:** `validate.sh portainer --vs-master` reports no new lint findings; CHANGELOG updated and version bumped.
- **Not verified:** the 502 itself. It does not reproduce on my host, and the reporter's environment (Core 2025.11.3) is the failing one. Docker build is untested locally — CI is the gate.

## Honest limitation

This does **not** close #2766. `vendor.js` (5.7 MB) and `main.js` (7.0 MB) exceed the 4 MB threshold uncompressed and still stream. If the reporter's streaming path is genuinely broken, the expected outcome is that the 502 page is replaced by a partially-loading or blank UI — which would itself confirm the diagnosis and point squarely at the relay. The issue should stay open until the reporter confirms the full UI loads.

## Rollback

Revert the single `proxy_set_header` line in `ingress.gtpl` (the map in `nginx.conf` is inert without it).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ingress response handling by requesting uncompressed content to reduce buffering issues.
  * Preserved compressed responses for direct web UI access.
  * Documented remaining limitations affecting two JavaScript bundles larger than 4 MB.

* **Chores**
  * Updated the Portainer add-on to version 2.44.0.1.
  * Added release notes describing the updated response and compression behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->