### PR TITLE
fix(ente): unbreak build — base image moved to ghcr.io/ente/server

### DIFF
--- a/ente/CHANGELOG.md
+++ b/ente/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.4.25 (08-08-2026)
+- Update to latest version from ente/ente (changelog : https://github.com/ente/ente/releases)
+- Fix build failure: upstream renamed the `ente-io` org to `ente`, so the base image is now `ghcr.io/ente/server` (GHCR does not follow the rename)
+
  
 ## 4.4.23 (2026-06-11)
 - Update to latest version from ente-io/ente (changelog : https://github.com/ente-io/ente/releases)

--- a/ente/CHANGELOG.md
+++ b/ente/CHANGELOG.md
@@ -1,8 +1,7 @@
-## 4.4.25 (08-08-2026)
+## 4.4.25 (2026-08-08)
 - Update to latest version from ente/ente (changelog : https://github.com/ente/ente/releases)
 - Fix build failure: upstream renamed the `ente-io` org to `ente`, so the base image is now `ghcr.io/ente/server` (GHCR does not follow the rename)
 
- 
 ## 4.4.23 (2026-06-11)
 - Update to latest version from ente-io/ente (changelog : https://github.com/ente-io/ente/releases)
 ## 1.7.24 (2026-06-05)

--- a/ente/Dockerfile
+++ b/ente/Dockerfile
@@ -30,7 +30,7 @@ RUN set -eux; \
 
 # Pull the web source
 WORKDIR /src
-RUN git clone --depth 1 --branch "${ENTE_WEB_TAG}" https://github.com/ente-io/ente.git .
+RUN git clone --depth 1 --branch "${ENTE_WEB_TAG}" https://github.com/ente/ente.git .
 
 # Build web workspace (lives in ./web)
 WORKDIR /src/web
@@ -52,7 +52,7 @@ RUN npm run build:memories
 #################
 # 1) Base image #
 #################
-FROM ghcr.io/ente-io/server:latest
+FROM ghcr.io/ente/server:latest
 
 ##################
 # 2) Tune image  #

--- a/ente/README.md
+++ b/ente/README.md
@@ -31,7 +31,7 @@ _Thanks to everyone having starred my repo! To star it click on the image below,
 
 ---
 
-[Ente](https://github.com/ente-io/ente) is a self-hosted, end-to-end encrypted photo and video storage solution. This addon provides a complete Ente server setup including the museum API server and MinIO S3-compatible storage backend.
+[Ente](https://github.com/ente/ente) is a self-hosted, end-to-end encrypted photo and video storage solution. This addon provides a complete Ente server setup including the museum API server and MinIO S3-compatible storage backend.
 
 Ente offers:
 - End-to-end encrypted photo and video backup
@@ -41,7 +41,7 @@ Ente offers:
 - Album sharing with family and friends
 - Full control over your data with self-hosting
 
-This addon is based on the official Ente server: https://github.com/ente-io/ente/tree/main/server
+This addon is based on the official Ente server: https://github.com/ente/ente/tree/main/server
 
 ## Configuration
 

--- a/ente/build.json
+++ b/ente/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/ente-io/server:927c6a316f181c7901446311f0085593b346b336",
-    "amd64": "ghcr.io/ente-io/server:927c6a316f181c7901446311f0085593b346b336"
+    "aarch64": "ghcr.io/ente/server:927c6a316f181c7901446311f0085593b346b336",
+    "amd64": "ghcr.io/ente/server:927c6a316f181c7901446311f0085593b346b336"
   }
 }

--- a/ente/config.yaml
+++ b/ente/config.yaml
@@ -131,6 +131,6 @@ schema:
 slug: ente
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "4.4.23"
+version: "4.4.25"
 video: true
 webui: http://[HOST]:[PORT:3000]

--- a/ente/updater.json
+++ b/ente/updater.json
@@ -1,9 +1,9 @@
 {
   "github_beta": "false",
-  "last_update": "2026-06-11",
+  "last_update": "2026-08-08",
   "repository": "alexbelgium/hassio-addons",
   "slug": "ente",
   "source": "github",
-  "upstream_repo": "ente-io/ente",
-  "upstream_version": "4.4.23"
+  "upstream_repo": "ente/ente",
+  "upstream_version": "4.4.25"
 }


### PR DESCRIPTION
## Problem

`Build {aarch64,amd64} ente add-on` failed in [run 31227202542](https://github.com/alexbelgium/hassio-addons/actions/runs/31227202542):

```
ERROR: failed to build: failed to solve: ghcr.io/ente-io/server:latest:
failed to resolve source metadata for ghcr.io/ente-io/server:latest: not found
```

Upstream renamed the GitHub org **`ente-io` → `ente`** (`gh api repos/ente-io/ente --jq .full_name` now returns `ente/ente`). github.com issues HTTP redirects for renamed orgs, so the web-builder's `git clone` still worked — but **GHCR does not redirect**, so the base image reference is now a hard 404 and every rebuild fails. The updater bot's `4.4.25` bump was auto-reverted in 63d8f6b38e as a result.

## Change

- `FROM ghcr.io/ente-io/server:latest` → `FROM ghcr.io/ente/server:latest`
- `git clone .../ente-io/ente.git` → `.../ente/ente.git` (worked via redirect, but no reason to keep relying on it)
- `updater.json` `upstream_repo` → `ente/ente`
- Re-lands the reverted `4.4.25` bump

## Verified

- `ghcr.io/ente/server:latest` exists and is anonymously pullable, and its OCI index carries both `linux/amd64` and `linux/arm64` — matching the add-on's declared `arch:`.
- Upstream `server/RUNNING.md` documents `ghcr.io/ente/server` as the image to pull, confirming the new name is the intended one rather than a mirror.
- All 11 `build:*` npm scripts the web-builder stage invokes (`photos`, `albums`, `accounts`, `auth`, `cast`, `share`, `embed`, `paste`, `locker`, `memories`) still exist in `web/package.json` on `main`.
- `validate.sh ente --vs-master` passes, no new lint findings.

## Not verified

- The Docker build — no dockerd locally, **CI is the gate**. In particular the web-builder stage (11 Next.js apps + Rust/wasm) never got to run in the failing run, since the failure was at base-image resolution. If CI now fails *inside* the web build, that is a second, separate breakage this PR does not address.

## Also worth knowing (not fixed here)

`updater.json` tracks `github` releases for `ente/ente` with no `github_tagfilter`. That repo tags per-app (`auth-v4.4.25`, `photos-v1.3.59`, `ensu-v0.1.19`, …), so this add-on's version has been tracking whichever app released last — `4.4.25` comes from the **auth** app, not the server. That is why the version history jumps around (`4.4.22` → `1.7.24` → `4.4.23`). Worth a `github_tagfilter`, but it is a separate change.

## Rollback

Revert `ente/Dockerfile` alone; note this restores a base image that no longer exists, so it only makes sense together with reverting the whole PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Ente add-on to version 4.4.25.
  * Updated upstream source and server image references to the current Ente project location.

* **Chores**
  * Refreshed release metadata, repository links, and changelog information for the latest update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->