### PR TITLE
fix(ci): allow the github-actions bot actor, stop quarantining on systemic failure

### DIFF
--- a/.github/workflows/on_issues_ai_triage.yaml
+++ b/.github/workflows/on_issues_ai_triage.yaml
@@ -260,11 +260,14 @@ jobs:
             #    outage). That is systemic — it hits every issue in exactly
             #    the same way — so quarantining the issue would silently bury
             #    a batch a day while the real fault sits in the workflow. Fail
-            #    red, touch no labels, let the catch-up retry once it's fixed.
-            #    Classify carries continue-on-error so the restore above still
-            #    runs, which also means the action's failure would otherwise
-            #    report this job green — exactly how tier 1 stayed dead for
-            #    weeks. Re-raise it.
+            #    red and add no labels of its own, so the catch-up retries it
+            #    once the fault is fixed. (The ai:needs-info restore above has
+            #    already run on the issue_comment path — that is a restore of
+            #    the issue's prior state, not a new verdict, so it stands.)
+            #    Classify carries continue-on-error so that restore always
+            #    gets to run, which also means the action's failure would
+            #    otherwise report this job green — exactly how tier 1 stayed
+            #    dead for weeks. Re-raise it.
             if [ "${CLASSIFY_OUTCOME:-}" = "failure" ]; then
               echo "::error::the Classify action failed for #$ISSUE — this is usually a workflow-level fault affecting every issue, so the issue is left untouched for a retry. See the Classify step."
               exit 1
@@ -282,7 +285,18 @@ jobs:
             if [ "${EVENT_NAME:-}" = "workflow_dispatch" ]; then
               echo "::warning::second attempt produced no verdict, handing #$ISSUE to a human"
               gh label create ai:needs-human --repo "$REPO" --color ededed >/dev/null 2>&1 || true
-              gh issue edit "$ISSUE" --repo "$REPO" --add-label ai:needs-human >/dev/null 2>&1 || true
+              # Drop the retry triggers in the same call. The catch-up search
+              # already excludes both, so this only bites on a MANUAL
+              # re-triage of an issue that still carries them — but there it
+              # matters: leaving ai-triage would keep an issue we just handed
+              # to a human sitting in tier 2's unattended fix queue, and
+              # leaving ai:needs-info would let a reporter reply silently
+              # re-trigger classification behind the human's back. The normal
+              # verdict path below already clears stale control labels; this
+              # keeps the escalation path consistent with it.
+              gh issue edit "$ISSUE" --repo "$REPO" \
+                --add-label ai:needs-human \
+                --remove-label ai-triage --remove-label ai:needs-info >/dev/null 2>&1 || true
             fi
             exit 0
           fi

--- a/.github/workflows/on_issues_ai_triage.yaml
+++ b/.github/workflows/on_issues_ai_triage.yaml
@@ -175,6 +175,20 @@ jobs:
           # contents:read + issues:write, the model gets no credentials and no
           # Bash, and every value it produces is validated in Apply verdict.
           allowed_non_write_users: "*"
+          # Separate gate from the one above, and it bit the catch-up path in
+          # production: checkHumanActor (src/github/validation/actor.ts)
+          # rejects any actor whose account type is not User. The catch-up
+          # dispatches with GITHUB_TOKEN, so those runs arrive as
+          # github-actions[bot] and died with "Workflow initiated by non-human
+          # actor". allowed_non_write_users does NOT cover this — it is only
+          # consulted for User accounts.
+          # Named rather than "*": only this repo's own workflows can dispatch
+          # as github-actions, whereas "*" would also admit any other App that
+          # can reach a trigger. The matcher lowercases and strips a trailing
+          # [bot], so this entry matches the github-actions[bot] actor.
+          # Scheduled runs are unaffected either way — they arrive as
+          # actor=alexbelgium, a User.
+          allowed_bots: "github-actions"
           show_full_output: true
           prompt: |
             Read /tmp/ai-triage/context.md, then follow the instructions in
@@ -238,28 +252,38 @@ jobs:
               gh issue edit "$ISSUE" --repo "$REPO" --add-label ai:needs-info >/dev/null 2>&1 || true
             fi
 
-            # Classify carries continue-on-error so the restore above always
-            # gets to run. That also means a hard failure inside the action
-            # reports the job green — which is exactly how tier 1 stayed dead
-            # for weeks while every run showed success. Re-raise it here.
+            # Two very different failures land here, and they need opposite
+            # handling. Telling them apart is the whole point of reading
+            # steps.classify.outcome rather than just "is the file empty".
+            #
+            # 1. The ACTION itself failed (auth, config, a bad input, an
+            #    outage). That is systemic — it hits every issue in exactly
+            #    the same way — so quarantining the issue would silently bury
+            #    a batch a day while the real fault sits in the workflow. Fail
+            #    red, touch no labels, let the catch-up retry once it's fixed.
+            #    Classify carries continue-on-error so the restore above still
+            #    runs, which also means the action's failure would otherwise
+            #    report this job green — exactly how tier 1 stayed dead for
+            #    weeks. Re-raise it.
             if [ "${CLASSIFY_OUTCOME:-}" = "failure" ]; then
-              echo "::error::classification failed (see the Classify step); no verdict produced for #$ISSUE"
-              # A workflow_dispatch here is the daily catch-up (or a manual
-              # re-triage) — i.e. this issue has already had at least one shot
-              # and failed again. Hand it to a human rather than letting the
-              # catch-up re-dispatch the same issue every day forever; the
-              # label is in catchup's exclusion search, so it drops out of the
-              # queue instead of starving the newer issues behind it.
-              if [ "${EVENT_NAME:-}" = "workflow_dispatch" ]; then
-                gh label create ai:needs-human --repo "$REPO" --color ededed >/dev/null 2>&1 || true
-                gh issue edit "$ISSUE" --repo "$REPO" --add-label ai:needs-human >/dev/null 2>&1 || true
-              fi
+              echo "::error::the Classify action failed for #$ISSUE — this is usually a workflow-level fault affecting every issue, so the issue is left untouched for a retry. See the Classify step."
               exit 1
             fi
 
-            # Action succeeded but produced nothing usable: leave the issue
-            # untriaged so tomorrow's catch-up picks it up, and stay green.
-            echo "::warning::no usable verdict produced, leaving issue untouched"
+            # 2. The action RAN and produced nothing usable. That is specific
+            #    to this issue (the model couldn't reach a verdict on it), so
+            #    a retry is worth exactly one attempt. A workflow_dispatch
+            #    here is the catch-up or a manual re-triage — i.e. the second
+            #    look — so hand it to a human now rather than re-dispatching
+            #    the same issue every day forever; ai:needs-human is in the
+            #    catch-up exclusion search, so it drops out of the queue
+            #    instead of starving newer issues behind it.
+            echo "::warning::no usable verdict produced for #$ISSUE"
+            if [ "${EVENT_NAME:-}" = "workflow_dispatch" ]; then
+              echo "::warning::second attempt produced no verdict, handing #$ISSUE to a human"
+              gh label create ai:needs-human --repo "$REPO" --color ededed >/dev/null 2>&1 || true
+              gh issue edit "$ISSUE" --repo "$REPO" --add-label ai:needs-human >/dev/null 2>&1 || true
+            fi
             exit 0
           fi
 

--- a/.github/workflows/on_issues_ai_triage.yaml
+++ b/.github/workflows/on_issues_ai_triage.yaml
@@ -234,53 +234,55 @@ jobs:
           set -euo pipefail
           mkdir -p /tmp/ai-triage
           F=/tmp/ai-triage/verdict.json
+
+          # A reporter reply consumed ai:needs-info in the claim step above, so
+          # every early exit below has to restore it or the next reply could
+          # never re-trigger. Defined once here rather than repeated per exit.
+          restore_needs_info() {
+            [ "${EVENT_NAME:-}" = "issue_comment" ] || return 0
+            gh issue edit "$ISSUE" --repo "$REPO" --add-label ai:needs-info >/dev/null 2>&1 || true
+          }
+
+          # GATE 1 — did the action itself run? This is checked BEFORE looking
+          # at the payload, because the action can fail *after* having written
+          # a valid structured output: the object would sail through the shape
+          # check below, labels and a comment would be applied, and the step
+          # would exit 0 — a green run on a failed action, which is the exact
+          # silent-failure mode this workflow was rebuilt to eliminate.
+          # A failed action means its output is not trustworthy, full stop.
+          #
+          # This branch is also deliberately label-neutral. An action failure
+          # (auth, config, an outage) is systemic — it hits every issue the
+          # same way — so quarantining here would silently bury a batch a day
+          # while the real fault sits in the workflow. Fail red, add nothing,
+          # let the catch-up retry once it's fixed. Classify carries
+          # continue-on-error so this step still runs at all; without the
+          # explicit exit 1 the job would report success.
+          if [ "${CLASSIFY_OUTCOME:-}" = "failure" ]; then
+            restore_needs_info
+            echo "::error::the Classify action failed for #$ISSUE — this is usually a workflow-level fault affecting every issue, so the issue is left untouched for a retry. See the Classify step."
+            exit 1
+          fi
+
           # The verdict arrives as the action's schema-validated structured
           # output rather than a file the model wrote — see the Classify step.
-          # Materialise it here so the validation below is unchanged.
           printf '%s' "${STRUCTURED:-}" > "$F"
-          # `jq -e .` alone accepts any truthy JSON, so a verdict of `[1,2]` or
-          # `"hi"` passes here and then dies on `.verdict` below with "Cannot
-          # index array with string" — set -e kills the step before the
-          # ai:needs-info restore below, stranding the issue so no later reply
-          # can ever re-trigger it. Require an object.
+
+          # GATE 2 — the action ran, but is the payload usable? `jq -e .` alone
+          # accepts any truthy JSON, so a verdict of `[1,2]` or `"hi"` would
+          # pass and then die on `.verdict` below with "Cannot index array with
+          # string", killing the step under set -e before the restore. Require
+          # an object.
+          #
+          # Reaching here means the failure is specific to THIS issue — the
+          # model looked at it and produced nothing usable — so a retry is
+          # worth exactly one attempt. A workflow_dispatch is the catch-up or
+          # a manual re-triage, i.e. the second look, so hand it to a human
+          # rather than re-dispatching the same issue every day forever;
+          # ai:needs-human is in the catch-up exclusion search, so it drops out
+          # of the queue instead of starving newer issues behind it.
           if [ ! -s "$F" ] || ! jq -e 'type == "object"' "$F" >/dev/null 2>&1; then
-            # A reporter reply consumed ai:needs-info in the claim step above.
-            # With no verdict we would otherwise leave the issue with the flag
-            # gone, so the next reply could never re-trigger — restore it.
-            # Do this FIRST, before any exit path below.
-            if [ "${EVENT_NAME:-}" = "issue_comment" ]; then
-              gh issue edit "$ISSUE" --repo "$REPO" --add-label ai:needs-info >/dev/null 2>&1 || true
-            fi
-
-            # Two very different failures land here, and they need opposite
-            # handling. Telling them apart is the whole point of reading
-            # steps.classify.outcome rather than just "is the file empty".
-            #
-            # 1. The ACTION itself failed (auth, config, a bad input, an
-            #    outage). That is systemic — it hits every issue in exactly
-            #    the same way — so quarantining the issue would silently bury
-            #    a batch a day while the real fault sits in the workflow. Fail
-            #    red and add no labels of its own, so the catch-up retries it
-            #    once the fault is fixed. (The ai:needs-info restore above has
-            #    already run on the issue_comment path — that is a restore of
-            #    the issue's prior state, not a new verdict, so it stands.)
-            #    Classify carries continue-on-error so that restore always
-            #    gets to run, which also means the action's failure would
-            #    otherwise report this job green — exactly how tier 1 stayed
-            #    dead for weeks. Re-raise it.
-            if [ "${CLASSIFY_OUTCOME:-}" = "failure" ]; then
-              echo "::error::the Classify action failed for #$ISSUE — this is usually a workflow-level fault affecting every issue, so the issue is left untouched for a retry. See the Classify step."
-              exit 1
-            fi
-
-            # 2. The action RAN and produced nothing usable. That is specific
-            #    to this issue (the model couldn't reach a verdict on it), so
-            #    a retry is worth exactly one attempt. A workflow_dispatch
-            #    here is the catch-up or a manual re-triage — i.e. the second
-            #    look — so hand it to a human now rather than re-dispatching
-            #    the same issue every day forever; ai:needs-human is in the
-            #    catch-up exclusion search, so it drops out of the queue
-            #    instead of starving newer issues behind it.
+            restore_needs_info
             echo "::warning::no usable verdict produced for #$ISSUE"
             if [ "${EVENT_NAME:-}" = "workflow_dispatch" ]; then
               echo "::warning::second attempt produced no verdict, handing #$ISSUE to a human"

--- a/.github/workflows/on_pr_coderabbit.yml
+++ b/.github/workflows/on_pr_coderabbit.yml
@@ -87,6 +87,17 @@ jobs:
           # coderabbitai[bot], the review submitter. AI_PR_TOKEN, not
           # GITHUB_TOKEN, so the pushed fixes re-trigger CI on the PR.
           github_token: ${{ secrets.AI_PR_TOKEN }}
+          # Latent until now only because this job has never reached the action:
+          # every run so far skipped on the `ai-fix/*` branch guard. On the
+          # first real firing github.actor is coderabbitai[bot], and
+          # checkHumanActor (src/github/validation/actor.ts) rejects any actor
+          # whose account type is not User — a different gate from the write
+          # check above, which does return early for a [bot] actor. Without
+          # this the whole CodeRabbit follow-up tier would fail on its first
+          # genuine invocation. Named, not "*": the job `if` already requires
+          # the review to come from coderabbitai[bot], so nothing else can get
+          # here anyway, and "*" would only widen it if that guard changed.
+          allowed_bots: "coderabbitai"
           prompt: |
             CodeRabbit has reviewed pull request #${{ github.event.pull_request.number }}
             on ${{ github.repository }}. You are on that PR's branch. Follow


### PR DESCRIPTION
Follow-up to #2947, from watching it actually run. Two findings, one of them a defect in that PR.

## The good news: root cause 2 is confirmed fixed in production

The 03:58 catch-up **dispatched for the first time ever** — five `workflow_dispatch` runs. The `HTTP 403: Resource not accessible by personal access token` that had silently blocked the safety net every night is gone.

## The bad news: those five runs then failed

```
Actor type: Bot
##[error]Action failed with error: Workflow initiated by non-human actor: github-actions (type: Bot).
         Add bot to allowed_bots list or use '*' to allow all bots.
```

`checkHumanActor` (`src/github/validation/actor.ts`) is a **separate gate** from the write-permission one fixed in #2947, and it rejects any actor whose account type is not `User`. `allowed_non_write_users` does not cover it — reading the source, that input is only consulted for User accounts:

> `// Regular User account. allowed_bots is only for bot actors and is not consulted here`

Switching the catch-up to `GITHUB_TOKEN` in #2947 is what exposed this: those runs now arrive as `github-actions[bot]` instead of the PAT's human identity. I traded the 403 for a bot rejection.

**Fix:** `allowed_bots: "github-actions"`. Named rather than `"*"` — only this repo's own workflows can dispatch as that actor, whereas `"*"` would also admit any other App that can reach a trigger. The matcher lowercases and strips a trailing `[bot]`, so this entry matches.

Confirmed from the run metadata that this is scoped to the dispatch path only:

| trigger | actor | affected |
|---|---|---|
| `AI fix sweep` (schedule) | `alexbelgium` (User) | no — never hit this gate |
| triage catch-up (dispatch) | `github-actions[bot]` | **yes** |
| triage on `issues.opened` | the reporter (User) | no — handled by `allowed_non_write_users` |

## A third, latent instance of the same gate

Auditing every `claude-code-action` call site for this gate turned up one more, not yet triggered:

`on_pr_coderabbit.yml` fires on a review submitted by `coderabbitai[bot]`, so its `github.actor` is a Bot-type account and `checkHumanActor` rejects it. Every run to date skipped on the `ai-fix/*` branch guard before reaching the action, so it has never surfaced — it would have failed on the **first genuine invocation**, taking the whole CodeRabbit follow-up tier with it. Note this is *not* covered by the write-permission check returning early for `[bot]` actors; that is a different gate.

Fixed with `allowed_bots: "coderabbitai"`. Full audit of all five call sites:

| workflow | actor when it fires | needs `allowed_bots` |
|---|---|---|
| `on_issues_ai_triage` (dispatch) | `github-actions[bot]` | **yes — added** |
| `on_pr_coderabbit` | `coderabbitai[bot]` | **yes — added** |
| `on_claude_mention` | `alexbelgium` | no |
| `on_issue_approved` | `alexbelgium` (gated on sender) | no |
| `daily_ai_fix` (schedule) | `alexbelgium` | no |

The three "no" rows are confirmed from run metadata, not assumed.

## A design error in #2947, exposed by the same run

#2947 quarantined an issue with `ai:needs-human` when **the action failed**. That is exactly backwards:

- An **action failure** is systemic — auth, config, an outage — and hits every issue identically. Quarantining buries a batch a day while the real fault sits in the workflow. That is precisely what happened here: all five issues were labelled `ai:needs-human` for a fault that had nothing to do with them.
- The **issue-specific** case is the opposite one: the action ran fine and the model still produced no usable verdict.

Inverted accordingly:

| case | behaviour |
|---|---|
| action failed | fail red, touch no labels, let the catch-up retry once fixed |
| ran but no verdict, 1st look | warn, leave for the catch-up |
| ran but no verdict, 2nd look (dispatch) | `ai:needs-human` — bounded at two attempts |

This still answers the unbounded-retry concern from the review of #2947 (a permanently unclassifiable issue drops out after two looks) without letting a workflow-level fault quarantine the queue.

## Verification

**Verified** — all branches re-exercised against a stubbed `gh`:

| case | result |
|---|---|
| action failed, `issues.opened` | exit 1, no labels touched |
| action failed, `workflow_dispatch` | exit 1, **no quarantine** (was: quarantined) |
| action failed, `issue_comment` | exit 1, `ai:needs-info` still restored first |
| no verdict, 1st look | exit 0, warn only |
| no verdict, 2nd look | exit 0 + `ai:needs-human` |
| confident verdict | unchanged |

**Checked** — YAML parses, `shellcheck` clean, `claude_args` still tokenises to 10 args with the schema intact, `allowed_bots`/`allowed_non_write_users` present as intended.

**Not verified** — that a dispatched run now clears the bot gate. Same limitation as before: only a real run proves it. The next 03:30 catch-up is the test, and it will fail red rather than silently if I am still wrong.

## Cleanup needed after merge

Five issues were quarantined by the old rule and will not re-enter the catch-up queue until the label is removed:

```bash
for n in 2847 2850 2852 2896 2918; do gh issue edit "$n" --repo alexbelgium/hassio-addons --remove-label ai:needs-human; done
```

## Rollback

Two independent hunks. `allowed_bots` alone restores the dispatch failure; the quarantine hunk alone restores the over-eager labelling. `AI_DISABLED=true` still pauses everything with no file edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved issue classification handling when automated results are missing or invalid.
  - Failed classification attempts now leave issues unchanged and report a failed job for retry.
  - If a manually retried attempt also fails, the issue is marked for human review and retry-triggering labels are removed.
  - Automated classification can now be triggered by approved workflow activity, improving issue triage consistency.

- **Improvements**
  - Enabled approved automated pull request review follow-ups to run reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->