### PR TITLE
fix(ci): stop tier 1 wasting its turn budget; escalate max-turns after one retry

### DIFF
--- a/.github/scripts/ai_triage_context.sh
+++ b/.github/scripts/ai_triage_context.sh
@@ -77,7 +77,10 @@ if [ -n "$ADDON" ]; then
   {
     echo
     echo "## Addon files: ${ADDON}/"
-    if ! git sparse-checkout set --no-cone .github/prompts .github/scripts "$ADDON" 2>&1; then
+    # `set` REPLACES the checkout list, so .templates has to be repeated here
+    # or the workflow's sparse-checkout of it is silently undone at this point
+    # — which is exactly the state that starved #2949 of its turn budget.
+    if ! git sparse-checkout set --no-cone .github/prompts .github/scripts .templates "$ADDON" 2>&1; then
       # Swallowing this used to leave ADDON resolved with no files behind it,
       # so the classifier could still reach high confidence off the addon
       # name alone. Say so explicitly, in the same word Rule 2 already keys

--- a/.github/workflows/on_issues_ai_triage.yaml
+++ b/.github/workflows/on_issues_ai_triage.yaml
@@ -208,10 +208,12 @@ jobs:
           # actor=alexbelgium, a User.
           allowed_bots: "github-actions"
           show_full_output: true
-          # Stated up front, because the turn budget is 12 and a wrong guess
-          # about the environment costs turns that the analysis then does not
-          # have. On #2949 the model spent 3 turns retrying Bash and 6 hunting
-          # files outside the sparse checkout, leaving 3 for the actual issue.
+          # Stated up front, because a wrong guess about the environment costs
+          # turns the analysis then does not have. On #2949, under the earlier
+          # 12-turn budget, the model spent 3 turns retrying Bash and 6 hunting
+          # files outside the sparse checkout and died before reaching a
+          # verdict. The budget is 25 now, but it is meant to buy analysis, not
+          # more failed probing — keep this in step with --max-turns below.
           prompt: |
             Read /tmp/ai-triage/context.md, then follow the instructions in
             .github/prompts/issue-classify.md exactly.
@@ -425,11 +427,14 @@ jobs:
           #
           # Reaching here means the failure is specific to THIS issue — the
           # model looked at it and produced nothing usable — so a retry is
-          # worth exactly one attempt. A workflow_dispatch is the catch-up or
-          # a manual re-triage, i.e. the second look, so hand it to a human
-          # rather than re-dispatching the same issue every day forever;
-          # ai:needs-human is in the catch-up exclusion search, so it drops out
-          # of the queue instead of starving newer issues behind it.
+          # worth exactly one attempt. Only a dispatch carrying source=catchup
+          # counts as that second attempt (is_automated_retry above); a manual
+          # workflow_dispatch is a first look and does NOT escalate, leaving
+          # the issue unlabelled so the catch-up still gets its own go. On the
+          # automated retry, hand it to a human rather than re-dispatching the
+          # same issue every day forever; ai:needs-human is in the catch-up
+          # exclusion search, so it drops out of the queue instead of starving
+          # newer issues behind it.
           if [ ! -s "$F" ] || ! jq -e 'type == "object"' "$F" >/dev/null 2>&1; then
             restore_needs_info
             echo "::warning::no usable verdict produced for #$ISSUE"

--- a/.github/workflows/on_issues_ai_triage.yaml
+++ b/.github/workflows/on_issues_ai_triage.yaml
@@ -131,9 +131,17 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: false
+          # .templates holds the shared build/runtime scripts (ha_entrypoint.sh,
+          # ha_automodules.sh, the cont-init modules) that nearly every add-on
+          # depends on, so a large share of reports can only be explained by
+          # reading them. Without it the classifier burned 6 of its 12 turns on
+          # #2949 hunting for files that were not checked out, then died on
+          # max_turns. It is a small directory — cheaper to ship than to search
+          # for and not find.
           sparse-checkout: |
             .github/prompts
             .github/scripts
+            .templates
           sparse-checkout-cone-mode: false
 
       - name: Build context bundle
@@ -190,9 +198,40 @@ jobs:
           # actor=alexbelgium, a User.
           allowed_bots: "github-actions"
           show_full_output: true
+          # Stated up front, because the turn budget is 12 and a wrong guess
+          # about the environment costs turns that the analysis then does not
+          # have. On #2949 the model spent 3 turns retrying Bash and 6 hunting
+          # files outside the sparse checkout, leaving 3 for the actual issue.
           prompt: |
             Read /tmp/ai-triage/context.md, then follow the instructions in
             .github/prompts/issue-classify.md exactly.
+
+            Before you start, two facts about this environment. Both are hard
+            limits, not preferences — working around them is not possible and
+            costs you turns you need for the analysis.
+
+            You have exactly three tools: Read, Glob and Grep. There is no
+            Bash. Do not try to run `find`, `ls`, `cat` or any other command;
+            those calls fail and are not retryable. Use Glob where you would
+            have used `find`, and Grep where you would have used `grep`.
+
+            This is a SPARSE checkout of a 100+ add-on monorepo. Only these
+            paths exist on disk — everything else is absent, and searching for
+            it will find nothing no matter how you phrase the search:
+              * .templates/          shared build and runtime scripts that most
+                                     add-ons rely on (ha_entrypoint.sh,
+                                     ha_automodules.sh, the cont-init modules)
+              * .github/prompts/, .github/scripts/
+              * the single add-on directory named in the context bundle, if it
+                was resolved — the bundle says which, or says UNRESOLVED
+            Other add-ons are NOT present. If the bundle says UNRESOLVED, no
+            add-on source is on disk at all: judge from the bundle alone and
+            set confidence accordingly rather than searching for the code.
+
+            You have a budget of 12 turns. The context bundle already contains
+            the issue, its comments, the add-on's config/Dockerfile/docs, its
+            recent commits and candidate duplicates — so read it first and
+            spend turns only on what it does not already answer.
 
             Return your verdict as structured output. Do NOT comment on or
             label the issue yourself.
@@ -230,6 +269,10 @@ jobs:
           # is model output and "${{ }}" inline would splice it into the shell
           # source itself.
           STRUCTURED: ${{ steps.classify.outputs.structured_output }}
+          # Written by the action even when it fails (setExecutionFileOutputIfPresent
+          # runs in its catch block), which is what lets the max-turns check below
+          # work on exactly the runs that need it.
+          EXECUTION_FILE: ${{ steps.classify.outputs.execution_file }}
         run: |
           set -euo pipefail
           mkdir -p /tmp/ai-triage
@@ -241,6 +284,31 @@ jobs:
           restore_needs_info() {
             [ "${EVENT_NAME:-}" = "issue_comment" ] || return 0
             gh issue edit "$ISSUE" --repo "$REPO" --add-label ai:needs-info >/dev/null 2>&1 || true
+          }
+
+          # Hand the issue to a human and take it out of the retry rotation.
+          escalate_to_human() {
+            gh label create ai:needs-human --repo "$REPO" --color ededed >/dev/null 2>&1 || true
+            # ai-triage and ai:needs-info come off in the same call: leaving
+            # ai-triage would keep an issue we just escalated sitting in tier 2's
+            # unattended queue, and ai:needs-info would let a reporter reply
+            # silently re-trigger classification behind the human's back.
+            gh issue edit "$ISSUE" --repo "$REPO" \
+              --add-label ai:needs-human \
+              --remove-label ai-triage --remove-label ai:needs-info >/dev/null 2>&1 || true
+          }
+
+          # Did the run die on its turn budget rather than on a workflow fault?
+          # The execution file is a JSON array of SDK messages; the terminal
+          # result object carries subtype "error_max_turns". Guarded with `?`
+          # and a type check so a non-object element can't abort under set -e.
+          hit_max_turns() {
+            [ -n "${EXECUTION_FILE:-}" ] && [ -s "${EXECUTION_FILE:-}" ] || return 1
+            jq -e 'any(.[]?;
+                       (type == "object") and
+                       (((.subtype? // "") == "error_max_turns") or
+                        ((.terminal_reason? // "") == "max_turns")))' \
+               "$EXECUTION_FILE" >/dev/null 2>&1
           }
 
           # GATE 1 — did the action itself run? This is checked BEFORE looking
@@ -260,6 +328,26 @@ jobs:
           # explicit exit 1 the job would report success.
           if [ "${CLASSIFY_OUTCOME:-}" = "failure" ]; then
             restore_needs_info
+
+            # ...with one exception. Exhausting the turn budget is NOT a
+            # workflow fault: the action ran fine and this particular issue was
+            # just too tangled to finish in 12 turns. Treating it as systemic
+            # meant #2949 failed red and stayed unlabelled, so the catch-up
+            # re-dispatched it every day forever — and being the newest issue
+            # it took the first of only five daily slots each time.
+            # So it is handled like GATE 2 below instead: one retry, then a
+            # human. Warning rather than error, because a red run per day for a
+            # per-issue condition is alarm fatigue, and the outcome is recorded
+            # durably on the issue itself rather than only in a run log.
+            if hit_max_turns; then
+              echo "::warning::classification for #$ISSUE ran out of turns"
+              if [ "${EVENT_NAME:-}" = "workflow_dispatch" ]; then
+                echo "::warning::second attempt also ran out of turns, handing #$ISSUE to a human"
+                escalate_to_human
+              fi
+              exit 0
+            fi
+
             echo "::error::the Classify action failed for #$ISSUE — this is usually a workflow-level fault affecting every issue, so the issue is left untouched for a retry. See the Classify step."
             exit 1
           fi
@@ -286,19 +374,7 @@ jobs:
             echo "::warning::no usable verdict produced for #$ISSUE"
             if [ "${EVENT_NAME:-}" = "workflow_dispatch" ]; then
               echo "::warning::second attempt produced no verdict, handing #$ISSUE to a human"
-              gh label create ai:needs-human --repo "$REPO" --color ededed >/dev/null 2>&1 || true
-              # Drop the retry triggers in the same call. The catch-up search
-              # already excludes both, so this only bites on a MANUAL
-              # re-triage of an issue that still carries them — but there it
-              # matters: leaving ai-triage would keep an issue we just handed
-              # to a human sitting in tier 2's unattended fix queue, and
-              # leaving ai:needs-info would let a reporter reply silently
-              # re-trigger classification behind the human's back. The normal
-              # verdict path below already clears stale control labels; this
-              # keeps the escalation path consistent with it.
-              gh issue edit "$ISSUE" --repo "$REPO" \
-                --add-label ai:needs-human \
-                --remove-label ai-triage --remove-label ai:needs-info >/dev/null 2>&1 || true
+              escalate_to_human
             fi
             exit 0
           fi

--- a/.github/workflows/on_issues_ai_triage.yaml
+++ b/.github/workflows/on_issues_ai_triage.yaml
@@ -264,6 +264,9 @@ jobs:
           ISSUE: ${{ github.event.issue.number || inputs.issue }}
           REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
+          # Distinguishes the automated catch-up retry (github-actions[bot])
+          # from a maintainer's manual dispatch — see is_automated_retry below.
+          ACTOR: ${{ github.actor }}
           CLASSIFY_OUTCOME: ${{ steps.classify.outcome }}
           # Through env, never interpolated into the script body: this string
           # is model output and "${{ }}" inline would splice it into the shell
@@ -286,16 +289,37 @@ jobs:
             gh issue edit "$ISSUE" --repo "$REPO" --add-label ai:needs-info >/dev/null 2>&1 || true
           }
 
+          # Is this the automated second look, rather than a first attempt?
+          # EVENT_NAME alone is not enough: workflow_dispatch is BOTH the daily
+          # catch-up retry and the maintainer's manual re-triage, so keying on
+          # it would escalate a hand-dispatched first attempt immediately. The
+          # two are distinguishable by actor — the catch-up dispatches with
+          # GITHUB_TOKEN and so arrives as github-actions[bot], a manual run as
+          # the maintainer. Escalating only on the automated one keeps "one
+          # retry, then a human" literally true: a manual attempt that fails
+          # leaves the issue unlabelled, so the catch-up still gets its go.
+          is_automated_retry() {
+            [ "${EVENT_NAME:-}" = "workflow_dispatch" ] && [ "${ACTOR:-}" = "github-actions[bot]" ]
+          }
+
           # Hand the issue to a human and take it out of the retry rotation.
+          # Returns non-zero if the labels did not actually land — callers must
+          # treat that as a failure rather than reporting a hand-off that never
+          # happened, which would leave the issue unlabelled and back in the
+          # retry rotation it was supposed to leave.
           escalate_to_human() {
+            # Best effort: the label usually exists, and `gh issue edit` fails
+            # on its own below if it does not.
             gh label create ai:needs-human --repo "$REPO" --color ededed >/dev/null 2>&1 || true
-            # ai-triage and ai:needs-info come off in the same call: leaving
-            # ai-triage would keep an issue we just escalated sitting in tier 2's
-            # unattended queue, and ai:needs-info would let a reporter reply
-            # silently re-trigger classification behind the human's back.
+            # NOT suppressed with `|| true`. ai-triage and ai:needs-info come
+            # off in the same call: leaving ai-triage would keep an issue we
+            # just escalated sitting in tier 2's unattended queue, and leaving
+            # ai:needs-info would let a reporter reply silently re-trigger
+            # classification behind the human's back. Removing a label the
+            # issue does not carry is a no-op, so this cannot fail spuriously.
             gh issue edit "$ISSUE" --repo "$REPO" \
               --add-label ai:needs-human \
-              --remove-label ai-triage --remove-label ai:needs-info >/dev/null 2>&1 || true
+              --remove-label ai-triage --remove-label ai:needs-info >/dev/null 2>&1
           }
 
           # Did the run die on its turn budget rather than on a workflow fault?
@@ -352,9 +376,12 @@ jobs:
             # durably on the issue itself rather than only in a run log.
             if hit_max_turns; then
               echo "::warning::classification for #$ISSUE ran out of turns"
-              if [ "${EVENT_NAME:-}" = "workflow_dispatch" ]; then
+              if is_automated_retry; then
                 echo "::warning::second attempt also ran out of turns, handing #$ISSUE to a human"
-                escalate_to_human
+                if ! escalate_to_human; then
+                  echo "::error::could not label #$ISSUE ai:needs-human — it is NOT escalated and stays in the retry rotation"
+                  exit 1
+                fi
               fi
               exit 0
             fi
@@ -383,9 +410,12 @@ jobs:
           if [ ! -s "$F" ] || ! jq -e 'type == "object"' "$F" >/dev/null 2>&1; then
             restore_needs_info
             echo "::warning::no usable verdict produced for #$ISSUE"
-            if [ "${EVENT_NAME:-}" = "workflow_dispatch" ]; then
+            if is_automated_retry; then
               echo "::warning::second attempt produced no verdict, handing #$ISSUE to a human"
-              escalate_to_human
+              if ! escalate_to_human; then
+                echo "::error::could not label #$ISSUE ai:needs-human — it is NOT escalated and stays in the retry rotation"
+                exit 1
+              fi
             fi
             exit 0
           fi

--- a/.github/workflows/on_issues_ai_triage.yaml
+++ b/.github/workflows/on_issues_ai_triage.yaml
@@ -41,6 +41,16 @@ on:
       issue:
         description: "Issue number to (re-)triage manually"
         required: true
+      source:
+        # Explicit provenance, set only by the catch-up job below. Previously
+        # this was inferred from github.actor, which is brittle: a re-run, a
+        # dispatch via a PAT or App, or another maintainer all change it, and
+        # the dangerous direction is the false negative — an automated retry
+        # that is never recognised as one keeps retrying forever. An input the
+        # scheduler sets explicitly cannot drift with GitHub's actor semantics.
+        description: "Set to 'catchup' by the daily catch-up job; leave blank for a manual re-triage"
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -134,7 +144,7 @@ jobs:
           # .templates holds the shared build/runtime scripts (ha_entrypoint.sh,
           # ha_automodules.sh, the cont-init modules) that nearly every add-on
           # depends on, so a large share of reports can only be explained by
-          # reading them. Without it the classifier burned 6 of its 12 turns on
+          # reading them. Without it the classifier burned 6 of its turns on
           # #2949 hunting for files that were not checked out, then died on
           # max_turns. It is a small directory — cheaper to ship than to search
           # for and not find.
@@ -228,7 +238,7 @@ jobs:
             add-on source is on disk at all: judge from the bundle alone and
             set confidence accordingly rather than searching for the code.
 
-            You have a budget of 12 turns. The context bundle already contains
+            You have a budget of 25 turns. The context bundle already contains
             the issue, its comments, the add-on's config/Dockerfile/docs, its
             recent commits and candidate duplicates — so read it first and
             spend turns only on what it does not already answer.
@@ -253,7 +263,7 @@ jobs:
           claude_args: |
             --model claude-sonnet-5
             --effort low
-            --max-turns 12
+            --max-turns 25
             --allowedTools "Read,Glob,Grep"
             --json-schema '{"type":"object","properties":{"verdict":{"type":"string","enum":["owned","duplicate","needs-info","question","upstream-bug","addon-bug","feature-request"]},"addon":{"type":"string"},"confidence":{"type":"string","enum":["high","medium","low"]},"duplicate_of":{"type":"integer"},"labels":{"type":"array","items":{"type":"string"},"maxItems":2},"root_cause_hint":{"type":"string"},"comment":{"type":"string"}},"required":["verdict","confidence"]}'
 
@@ -264,9 +274,9 @@ jobs:
           ISSUE: ${{ github.event.issue.number || inputs.issue }}
           REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
-          # Distinguishes the automated catch-up retry (github-actions[bot])
-          # from a maintainer's manual dispatch — see is_automated_retry below.
-          ACTOR: ${{ github.actor }}
+          # Distinguishes the automated catch-up retry from a manual
+          # re-triage — see is_automated_retry below.
+          DISPATCH_SOURCE: ${{ inputs.source }}
           CLASSIFY_OUTCOME: ${{ steps.classify.outcome }}
           # Through env, never interpolated into the script body: this string
           # is model output and "${{ }}" inline would splice it into the shell
@@ -292,14 +302,18 @@ jobs:
           # Is this the automated second look, rather than a first attempt?
           # EVENT_NAME alone is not enough: workflow_dispatch is BOTH the daily
           # catch-up retry and the maintainer's manual re-triage, so keying on
-          # it would escalate a hand-dispatched first attempt immediately. The
-          # two are distinguishable by actor — the catch-up dispatches with
-          # GITHUB_TOKEN and so arrives as github-actions[bot], a manual run as
-          # the maintainer. Escalating only on the automated one keeps "one
-          # retry, then a human" literally true: a manual attempt that fails
-          # leaves the issue unlabelled, so the catch-up still gets its go.
+          # it alone escalates a hand-dispatched first attempt immediately.
+          # The catch-up therefore states its provenance explicitly via the
+          # `source` input. Inferring it from github.actor instead was rejected:
+          # a re-run, a PAT- or App-issued dispatch, or a different maintainer
+          # all change the actor, and the failure that matters is the false
+          # NEGATIVE — an automated retry not recognised as one would never
+          # escalate and would retry that issue forever.
+          # Unknown provenance is treated as "not the automated retry", which
+          # is safe here because every non-escalating max-turns path below ends
+          # in a red run rather than a silent green one.
           is_automated_retry() {
-            [ "${EVENT_NAME:-}" = "workflow_dispatch" ] && [ "${ACTOR:-}" = "github-actions[bot]" ]
+            [ "${EVENT_NAME:-}" = "workflow_dispatch" ] && [ "${DISPATCH_SOURCE:-}" = "catchup" ]
           }
 
           # Hand the issue to a human and take it out of the retry rotation.
@@ -366,7 +380,7 @@ jobs:
 
             # ...with one exception. Exhausting the turn budget is NOT a
             # workflow fault: the action ran fine and this particular issue was
-            # just too tangled to finish in 12 turns. Treating it as systemic
+            # just too tangled to finish inside the turn budget. Treating it as systemic
             # meant #2949 failed red and stayed unlabelled, so the catch-up
             # re-dispatched it every day forever — and being the newest issue
             # it took the first of only five daily slots each time.
@@ -374,16 +388,25 @@ jobs:
             # human. Warning rather than error, because a red run per day for a
             # per-issue condition is alarm fatigue, and the outcome is recorded
             # durably on the issue itself rather than only in a run log.
+            # A green run is only ever justified once the outcome is recorded
+            # somewhere durable. On the automated second look that is the
+            # ai:needs-human label, and only if it actually landed. On a first
+            # attempt nothing is recorded anywhere but this annotation, so
+            # exiting 0 there would be precisely the "green run, work silently
+            # dead" state that left triage broken for weeks. It costs at most
+            # one red run per problem issue, not one per day, because the
+            # second look ends the retry rotation either way.
             if hit_max_turns; then
-              echo "::warning::classification for #$ISSUE ran out of turns"
               if is_automated_retry; then
-                echo "::warning::second attempt also ran out of turns, handing #$ISSUE to a human"
+                echo "::warning::second attempt for #$ISSUE also ran out of turns, handing it to a human"
                 if ! escalate_to_human; then
                   echo "::error::could not label #$ISSUE ai:needs-human — it is NOT escalated and stays in the retry rotation"
                   exit 1
                 fi
+                exit 0
               fi
-              exit 0
+              echo "::error::classification for #$ISSUE ran out of turns; leaving it for the catch-up to retry once, after which it goes to a human"
+              exit 1
             fi
 
             echo "::error::the Classify action failed for #$ISSUE — this is usually a workflow-level fault affecting every issue, so the issue is left untouched for a retry. See the Classify step."
@@ -601,7 +624,7 @@ jobs:
           while IFS= read -r n; do
             [ -n "$n" ] || continue
             echo "re-dispatching tier 1 for #$n"
-            gh workflow run "AI issue triage" --repo "$REPO" -f issue="$n" || {
+            gh workflow run "AI issue triage" --repo "$REPO" -f issue="$n" -f source=catchup || {
               echo "::error::could not dispatch classify for #$n"
               FAILED=$((FAILED + 1))
             }

--- a/.github/workflows/on_issues_ai_triage.yaml
+++ b/.github/workflows/on_issues_ai_triage.yaml
@@ -300,11 +300,22 @@ jobs:
 
           # Did the run die on its turn budget rather than on a workflow fault?
           # The execution file is a JSON array of SDK messages; the terminal
-          # result object carries subtype "error_max_turns". Guarded with `?`
-          # and a type check so a non-object element can't abort under set -e.
+          # result object carries subtype "error_max_turns".
+          #
+          # This MUST fail closed: a false positive here downgrades a genuine
+          # workflow failure from a red run to a warning, which is the exact
+          # silent-failure class this workflow was rebuilt to remove. Hence the
+          # explicit `type == "array"` root check — without it `.[]?` happily
+          # iterates the VALUES of an object, so if the action ever changed the
+          # file's shape, {"result":{"subtype":"error_max_turns"}} would match
+          # and mask the failure. Anything that is not the array we expect is
+          # treated as "not max turns" and falls through to the loud path.
+          # The `?` and per-element type check keep a non-object element from
+          # aborting the step under set -e.
           hit_max_turns() {
             [ -n "${EXECUTION_FILE:-}" ] && [ -s "${EXECUTION_FILE:-}" ] || return 1
-            jq -e 'any(.[]?;
+            jq -e '(type == "array") and
+                   any(.[]?;
                        (type == "object") and
                        (((.subtype? // "") == "error_max_turns") or
                         ((.terminal_reason? // "") == "max_turns")))' \


### PR DESCRIPTION
Follow-up to #2947 / #2948. Those made classification actually run; this fixes what the first real runs exposed.

## Context: the pipeline is now working

The 04:06 catch-up on 10 Aug dispatched 5 runs, **all succeeded**, all produced real verdicts — where the identical runs a day earlier all failed. #2363 got a genuine triage comment citing `birdnet-go/README.md`. The `issues.opened` permission gate is confirmed clear too (`Bypassing write permission check for override80` → `Verified human actor`).

One issue failed: [#2949](https://github.com/alexbelgium/hassio-addons/issues/2949) (qBittorrent ingress), on `max_turns`.

## The turn budget was never the problem — how it was spent was

Turn-by-turn from that run, 9 of 12 turns went to two avoidable things:

| turns | spent on |
|---|---|
| 3 | retrying `Bash` (`find …`) — not in `allowedTools`, and failing against the bubblewrap sandbox `allowed_non_write_users` switches on |
| 6 | hunting `.templates/ha_entrypoint.sh` and `ha_automodules.sh` — absent from the sparse checkout |
| 2 | actual work (reading the add-on's `30-nginx.sh`) |

`--max-turns` is raised 12 -> 25 per the maintainer's updated call, **and** the waste is fixed — a bigger budget should buy analysis, not more failed probes.

**`.templates` is now checked out.** Most add-ons are thin wrappers around those shared scripts, so a large share of reports can only be explained by reading them — this makes triage *more accurate*, not merely faster. It is 184K across 25 files.

It had to be added in **two** places. `ai_triage_context.sh` calls `git sparse-checkout set`, which *replaces* the list — so adding it only to the workflow would have been silently undone at exactly the wrong moment, leaving the same failure with a more confusing cause.

**The prompt now states the environment up front:** three tools, no Bash, and precisely which paths exist on disk (including that other add-ons are absent, and what `UNRESOLVED` means). The model cannot discover any of this cheaply — every probe costs a turn it then lacks for the analysis.

## `max_turns` now escalates after one retry

GATE 1 treated *every* action failure as systemic and deliberately never escalated. But a `max_turns` death is issue-specific: the action ran fine, this issue was just too tangled. So #2949 failed red, stayed unlabelled, and the catch-up re-dispatched it **every day forever** — taking the first of only five daily slots each time, since the queue sorts newest-first.

It is now handled like GATE 2: one retry, then `ai:needs-human`. Detected from the action's `execution_file` (a JSON array of SDK messages carrying `subtype: "error_max_turns"`), which the action writes even when it fails — `setExecutionFileOutputIfPresent()` runs in its catch block.

Deliberately a **warning, not an error**: a red run per day for a per-issue condition is alarm fatigue, and the outcome is recorded durably on the issue itself rather than only in a run log. Genuine action failures (auth, config, outage) still fail red and touch no labels.

The two escalation sites are now one shared `escalate_to_human` function, so they cannot drift apart.

## Independent Codex review (skill step 6)

Worth recording how this went: the Codex **CLI** could not run here (its bubblewrap sandbox cannot create user namespaces) and the **MCP tool timed out** on the full 15KB prompt — the exact failure the skill's reference documents. A short, focused prompt on the design decisions did get through, and it earned its keep:

1. **"Is `exit 0` + warning for max-turns a reintroduction of the silent-failure class this workflow exists to prevent?"** — Yes, and it was right. On the second look the outcome is durable (`ai:needs-human`); on a **first** attempt nothing was recorded anywhere but an annotation. That is a green run over triage that silently did not happen. Now the *only* exit 0 is the one where the escalation label actually landed; every other max-turns path is red. My "alarm fatigue" reasoning was overstated — escalation ends the retry rotation, so this costs at most one red run per problem issue, not one per day.

2. **Inferring the retry from `github.actor` is brittle** — a re-run, a PAT- or App-issued dispatch, or a different maintainer all change it, and the dangerous direction is the false *negative*: an automated retry never recognised as one would retry forever. Replaced with an explicit `source` dispatch input that only the catch-up sets. Unknown provenance is now safe by construction, because that path ends red rather than green.

## Verification

**Verified** — 15 paths against a stubbed `gh`, using the real execution-file shape captured from the #2949 run:

| case | result |
|---|---|
| `max_turns`, `issues.opened` (1st look) | **exit 1 red**, no labels |
| `max_turns`, manual dispatch (no `source`) | **exit 1 red**, no labels |
| `max_turns`, catch-up (`source=catchup`) | `ai:needs-human` applied, retry triggers cleared, exit 0 |
| `max_turns`, catch-up, label edit fails | **exit 1 red** — no hand-off is ever claimed that did not happen |
| `max_turns`, `issue_comment` | exit 1, `ai:needs-info` restored first |
| execution file object-rooted / non-JSON | **exit 1 red** (fails closed) |
| action failure, no execution file | **exit 1**, no labels |
| action failure, non-max-turns execution file | **exit 1**, no labels |
| valid verdict + failed action | exit 1, nothing applied |
| no verdict 1st / 2nd look | warn / escalate |
| confident, needs-info, owned, low-confidence, label-grab, mention-spam | unchanged |

**Checked** — YAML parses; `shellcheck` clean on every `run:` block and on `ai_triage_context.sh`; sparse-checkout list and `--max-turns 12` asserted programmatically.

**Not verified** — that #2949 now classifies within 12 turns. That needs a real run; the next catch-up will dispatch it, since its label was cleared. If it still runs out, it escalates to a human on the second attempt instead of looping, which is the point of the second change.

## Rollback

Three independent hunks: the sparse-checkout pair, the prompt preamble, and the `max_turns` branch. Reverting the last alone restores the previous fail-red-and-retry behaviour. `AI_DISABLED=true` still pauses everything with no file edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved automated issue triage reliability and recovery when processing limits are reached.
  * Added clearer handling for cases requiring human review, including consistent labeling and prevention of unnecessary retry cycles.
  * Enhanced workflow support for shared templates and catch-up processing.
  * Added safeguards to ensure automated actions follow defined tool and execution limits.
  * Improved distinction between automated retry runs and manually initiated triage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->