### PR TITLE
perf(stargazer-map): negative-cache blank locations for 90 days

### DIFF
--- a/.github/generate_map.py
+++ b/.github/generate_map.py
@@ -117,6 +117,7 @@ def load_cache():
 
 
 def save_cache(cache):
+    """Write the cache back as username,country,last_checked."""
     CSV_PATH.parent.mkdir(parents=True, exist_ok=True)
     with CSV_PATH.open("w", newline="", encoding="utf-8") as f:
         w = csv.writer(f)

--- a/.github/generate_map.py
+++ b/.github/generate_map.py
@@ -4,7 +4,7 @@ Generate a static PNG world map colour-coded by the percentage of your
 stargazers that come from each country.  The script maintains a CSV
 in ".github/stargazer_countries.csv" cache so that locations are only looked
 up once.  Blank answers are cached too and retried at most every RECHECK_DAYS,
-no more than MAX_RECHECKS_PER_RUN of them per run.
+no more than MAX_RECHECKS_PER_RUN re-checks per run.
 """
 
 import csv
@@ -37,11 +37,12 @@ PNG_PATH = Path(".github/stargazer_map.png")
 # stamps it.
 RECHECK_DAYS = 90
 
-# Cap on how many *expired* rows one run may refresh, oldest first.  The initial
-# migration leaves ~1700 rows due at once; without a cap that lands as a single
-# 30-minute spike, and every 90 days after.  Slicing it spreads the backlog over
-# a few runs and leaves the refresh dates staggered from then on.  New
-# stargazers are never capped -- they are the ones the map is missing.
+# Cap on how many already-checked rows one run may *re*-check, oldest first.
+# It applies only to rows that carry a real last_checked date and have since
+# expired: left uncapped, they all fall due on the same day and land as one
+# spike.  Rows that have never been checked -- new stargazers, and every row
+# migrated from the pre-"last_checked" CSV -- are always looked up in full, so
+# the first run after this lands still sweeps the whole backlog.
 MAX_RECHECKS_PER_RUN = 200
 
 # ---- Rendering theme --------------------------------------------------------
@@ -383,23 +384,25 @@ def main():
 
     cache = load_cache()
 
-    # Determine which usernames need a lookup: every unknown user, plus at most
-    # MAX_RECHECKS_PER_RUN blank rows last checked more than RECHECK_DAYS ago,
-    # oldest first (an empty last_checked sorts first, so the migration backlog
-    # drains before anything else).
+    # Determine which usernames need a lookup.  Anything never checked -- a new
+    # stargazer, or a row migrated from the pre-"last_checked" CSV -- is looked
+    # up in full.  Rows that were checked before and have since expired are
+    # rate-limited to MAX_RECHECKS_PER_RUN, oldest first, so the recurring
+    # RECHECK_DAYS wave arrives in slices rather than all at once.
     now = datetime.date.today()
     today = now.isoformat()
     cutoff = (now - datetime.timedelta(days=RECHECK_DAYS)).isoformat()
-    new_users = [u for u in users if u not in cache]
+    due = [u for u in users if needs_lookup(cache.get(u), cutoff)]
+    never = [u for u in due if not cache.get(u, ("", ""))[1]]
     expired = sorted(
-        (u for u in users if u in cache and needs_lookup(cache[u], cutoff)),
+        (u for u in due if cache.get(u, ("", ""))[1]),
         key=lambda u: (cache[u][1], u),
     )
-    due = expired[:MAX_RECHECKS_PER_RUN]
-    to_lookup = new_users + due
+    rechecks = expired[:MAX_RECHECKS_PER_RUN]
+    to_lookup = never + rechecks
     print(
         f"Need geocode for {len(to_lookup)} users "
-        f"({len(new_users)} new, {len(due)} of {len(expired)} expired)"
+        f"({len(never)} never checked, {len(rechecks)} of {len(expired)} expired)"
     )
 
     for i, login in enumerate(to_lookup, 1):

--- a/.github/generate_map.py
+++ b/.github/generate_map.py
@@ -3,7 +3,8 @@
 Generate a static PNG world map colour-coded by the percentage of your
 stargazers that come from each country.  The script maintains a CSV
 in ".github/stargazer_countries.csv" cache so that locations are only looked
-up once.  Blank answers are cached too and retried at most every RECHECK_DAYS.
+up once.  Blank answers are cached too and retried at most every RECHECK_DAYS,
+no more than MAX_RECHECKS_PER_RUN of them per run.
 """
 
 import csv
@@ -35,6 +36,13 @@ PNG_PATH = Path(".github/stargazer_map.png")
 # column existed) counts as never checked and is looked up once, which
 # stamps it.
 RECHECK_DAYS = 90
+
+# Cap on how many *expired* rows one run may refresh, oldest first.  The initial
+# migration leaves ~1700 rows due at once; without a cap that lands as a single
+# 30-minute spike, and every 90 days after.  Slicing it spreads the backlog over
+# a few runs and leaves the refresh dates staggered from then on.  New
+# stargazers are never capped -- they are the ones the map is missing.
+MAX_RECHECKS_PER_RUN = 200
 
 # ---- Rendering theme --------------------------------------------------------
 # Dark, opaque panel: GitHub does not swap the image between README themes, so
@@ -375,13 +383,24 @@ def main():
 
     cache = load_cache()
 
-    # Determine which usernames need a lookup: unknown users, plus blank rows
-    # last checked more than RECHECK_DAYS ago.
+    # Determine which usernames need a lookup: every unknown user, plus at most
+    # MAX_RECHECKS_PER_RUN blank rows last checked more than RECHECK_DAYS ago,
+    # oldest first (an empty last_checked sorts first, so the migration backlog
+    # drains before anything else).
     now = datetime.date.today()
     today = now.isoformat()
     cutoff = (now - datetime.timedelta(days=RECHECK_DAYS)).isoformat()
-    to_lookup = [u for u in users if needs_lookup(cache.get(u), cutoff)]
-    print(f"Need geocode for {len(to_lookup)} users")
+    new_users = [u for u in users if u not in cache]
+    expired = sorted(
+        (u for u in users if u in cache and needs_lookup(cache[u], cutoff)),
+        key=lambda u: (cache[u][1], u),
+    )
+    due = expired[:MAX_RECHECKS_PER_RUN]
+    to_lookup = new_users + due
+    print(
+        f"Need geocode for {len(to_lookup)} users "
+        f"({len(new_users)} new, {len(due)} of {len(expired)} expired)"
+    )
 
     for i, login in enumerate(to_lookup, 1):
         country = username_to_country(login)

--- a/.github/generate_map.py
+++ b/.github/generate_map.py
@@ -3,10 +3,11 @@
 Generate a static PNG world map colour-coded by the percentage of your
 stargazers that come from each country.  The script maintains a CSV
 in ".github/stargazer_countries.csv" cache so that locations are only looked
-up once (unless the country entry is blank).
+up once.  Blank answers are cached too and retried at most every RECHECK_DAYS.
 """
 
 import csv
+import datetime
 import math
 import os
 import sys
@@ -25,6 +26,15 @@ REPO = os.getenv("REPO")  # expected   "owner/repo"
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")  # provided by workflow
 CSV_PATH = Path(".github/stargazer_countries.csv")
 PNG_PATH = Path(".github/stargazer_map.png")
+
+# ---- Cache policy -----------------------------------------------------------
+# Most blank rows are permanent: the user simply has no public "location" on
+# their profile.  Re-asking GitHub and Nominatim for them every week is ~1700
+# wasted requests per run, so a blank answer is cached too and only refreshed
+# after RECHECK_DAYS.  Rows written before the "last_checked" column existed are
+# treated as checked on BACKFILL_DATE (the day the column was introduced).
+RECHECK_DAYS = 90
+BACKFILL_DATE = "2026-08-10"
 
 # ---- Rendering theme --------------------------------------------------------
 # Dark, opaque panel: GitHub does not swap the image between README themes, so
@@ -83,19 +93,36 @@ def fetch_stargazer_usernames():
 
 
 def load_cache():
+    """username -> (country, last_checked). Reads 2- and 3-column CSVs."""
     if not CSV_PATH.exists():
         return {}
     with CSV_PATH.open(newline="", encoding="utf-8") as f:
-        return {row["username"]: row["country"] for row in csv.DictReader(f)}
+        return {
+            row["username"]: (
+                row["country"],
+                (row.get("last_checked") or "").strip() or BACKFILL_DATE,
+            )
+            for row in csv.DictReader(f)
+        }
 
 
 def save_cache(cache):
     CSV_PATH.parent.mkdir(parents=True, exist_ok=True)
     with CSV_PATH.open("w", newline="", encoding="utf-8") as f:
         w = csv.writer(f)
-        w.writerow(["username", "country"])
-        for user, country in sorted(cache.items()):
-            w.writerow([user, country or ""])
+        w.writerow(["username", "country", "last_checked"])
+        for user, (country, last_checked) in sorted(cache.items()):
+            w.writerow([user, country or "", last_checked])
+
+
+def needs_lookup(entry, cutoff):
+    """True if this cache entry has to be (re)queried. entry is None if absent."""
+    if entry is None:
+        return True  # new stargazer
+    country, last_checked = entry
+    if country:
+        return False  # a known country never changes here
+    return last_checked < cutoff  # blank, and stale enough to retry
 
 
 def username_to_country(login):
@@ -124,7 +151,7 @@ def username_to_country(login):
 
 def count_by_country(cache):
     """Counter of country name -> stargazers, ignoring blank locations."""
-    return Counter(c for c in cache.values() if c)
+    return Counter(country for country, _ in cache.values() if country)
 
 
 def _log_ticks(lo, hi):
@@ -335,20 +362,24 @@ def main():
 
     cache = load_cache()
 
-    # Determine which usernames need a lookup
-    to_lookup = [u for u in users if cache.get(u, "") == ""]
+    # Determine which usernames need a lookup: unknown users, plus blank rows
+    # last checked more than RECHECK_DAYS ago.
+    now = datetime.date.today()
+    today = now.isoformat()
+    cutoff = (now - datetime.timedelta(days=RECHECK_DAYS)).isoformat()
+    to_lookup = [u for u in users if needs_lookup(cache.get(u), cutoff)]
     print(f"Need geocode for {len(to_lookup)} users")
 
     for i, login in enumerate(to_lookup, 1):
         country = username_to_country(login)
-        cache[login] = country
+        cache[login] = (country, today)
         print(f"{i}/{len(to_lookup)}: {login:<20} -> {country}")
         # Nominatim polite usage
         time.sleep(1)
 
     # Ensure all stargazers are in cache (even those with blank location)
     for u in users:
-        cache.setdefault(u, "")
+        cache.setdefault(u, ("", today))
 
     save_cache(cache)
 

--- a/.github/generate_map.py
+++ b/.github/generate_map.py
@@ -103,7 +103,7 @@ def _checked_date(value):
 
 
 def load_cache():
-    """username -> (country, last_checked). Reads 2- and 3-column CSVs."""
+    """Map each username to (country, last_checked). Reads 2- and 3-column CSVs."""
     if not CSV_PATH.exists():
         return {}
     with CSV_PATH.open(newline="", encoding="utf-8") as f:

--- a/.github/generate_map.py
+++ b/.github/generate_map.py
@@ -31,10 +31,10 @@ PNG_PATH = Path(".github/stargazer_map.png")
 # Most blank rows are permanent: the user simply has no public "location" on
 # their profile.  Re-asking GitHub and Nominatim for them every week is ~1700
 # wasted requests per run, so a blank answer is cached too and only refreshed
-# after RECHECK_DAYS.  Rows written before the "last_checked" column existed are
-# treated as checked on BACKFILL_DATE (the day the column was introduced).
+# after RECHECK_DAYS.  A row with no "last_checked" (i.e. written before the
+# column existed) counts as never checked and is looked up once, which
+# stamps it.
 RECHECK_DAYS = 90
-BACKFILL_DATE = "2026-08-10"
 
 # ---- Rendering theme --------------------------------------------------------
 # Dark, opaque panel: GitHub does not swap the image between README themes, so
@@ -92,6 +92,16 @@ def fetch_stargazer_usernames():
     return [s["login"] for s in github_paginated(url)]
 
 
+def _checked_date(value):
+    """Normalise a last_checked cell: a non-ISO-date value reads as never."""
+    value = (value or "").strip()
+    try:
+        datetime.date.fromisoformat(value)
+    except ValueError:
+        return ""
+    return value
+
+
 def load_cache():
     """username -> (country, last_checked). Reads 2- and 3-column CSVs."""
     if not CSV_PATH.exists():
@@ -100,7 +110,7 @@ def load_cache():
         return {
             row["username"]: (
                 row["country"],
-                (row.get("last_checked") or "").strip() or BACKFILL_DATE,
+                _checked_date(row.get("last_checked")),
             )
             for row in csv.DictReader(f)
         }
@@ -116,12 +126,14 @@ def save_cache(cache):
 
 
 def needs_lookup(entry, cutoff):
-    """True if this cache entry has to be (re)queried. entry is None if absent."""
+    """True if this entry must be (re)queried. entry is None if absent."""
     if entry is None:
         return True  # new stargazer
     country, last_checked = entry
     if country:
         return False  # a known country never changes here
+    if not last_checked:
+        return True  # blank, never checked (pre-"last_checked" row)
     return last_checked < cutoff  # blank, and stale enough to retry
 
 


### PR DESCRIPTION
## Problem

`.github/generate_map.py` picks the users to geocode with:

```python
to_lookup = [u for u in users if cache.get(u, "") == ""]
```

A blank `country` is indistinguishable from "not cached", so **every blank row is re-queried on
every weekly run, forever**.

Measured on the committed cache (`.github/stargazer_countries.csv`, 2652 rows): **963 rows have a
country, 1689 are blank**. Each blank costs one `GET /users/<login>` plus the unconditional
`time.sleep(1)`, i.e. ~1689 API calls and ~28 minutes of sleeping per run to re-derive the same
blank answer.

Sampling 89 of those blanks against the GitHub API: **87 (97.8 %) have no `location` field at
all**. These are not transient failures - they will keep returning blank indefinitely. Repeating
identical requests indefinitely is also against the spirit of the Nominatim usage policy.

## Change

Negative caching keyed on a check date. One file, ~50 lines changed.

- The CSV gains a third column, `last_checked` (ISO `YYYY-MM-DD`).
- `load_cache()` reads both the old 2-column and the new 3-column file. A missing, empty, or
  non-ISO-date `last_checked` normalises to `""`, meaning **never checked**.
- `save_cache()` writes all three columns.
- New `needs_lookup(entry, cutoff)`:
  - user absent from the cache (new stargazer) -> query;
  - non-blank country -> never re-queried (unchanged), whatever `last_checked` says;
  - blank country + no `last_checked` -> query now;
  - blank country + a real date -> query only if it is **more than `RECHECK_DAYS = 90`** days old.
- Any user actually queried gets `last_checked = today` regardless of outcome.
- Cache values are now `(country, last_checked)` tuples; `count_by_country()` and the
  `setdefault` in `main()` were updated to match. Rendering is untouched.
- Rows for users who unstarred stay in the CSV and stay excluded from rendering (unchanged).

**Deliberate one-off cost:** every row in the committed 2-column CSV has no `last_checked`, so the
**first run after merge does the full ~1689-user sweep once** (verified below) and stamps every row
with today's date. That is the intent - it gives the blanks one fresh chance under the current
code. From the second run onwards the volume drops to new stargazers only, and the blanks come back
into rotation in ~90-day slices instead of weekly.

## Verified (run locally, no network)

Throwaway script against the real committed CSV and the real rendering path:

```
[1] rows=2652 located=963 blank=1689 rows_with_non_empty_last_checked=0
[1] users queried on first run after merge=1689 (expected 1689)
[2] blank + empty last_checked       -> needs_lookup=True  (expected True)
[2] blank + malformed last_checked   -> needs_lookup=True  (expected True)
[2] non-blank + empty last_checked   -> needs_lookup=False (expected False)
[2] blank + checked today            -> needs_lookup=False (expected False)
[2] blank + 90 days ago (boundary)   -> needs_lookup=False (expected False)
[2] blank + 91 days ago              -> needs_lookup=True  (expected True)
[2] non-blank + 2 years ago          -> needs_lookup=False (expected False)
[2] unknown user (None)              -> needs_lookup=True  (expected True)
[3] header='username,country,last_checked' first_row='0ln,,'
[3] round trip equal=True rows=2653
[4] located stargazers counted=963 distinct country names=63 distinct ISO-3=63
[4] top5=[('United States', 221), ('Germany', 146), ('United Kingdom', 61), ('Netherlands', 58), ('France', 54)]
[4] PNG rendered bytes=391674
```

i.e. the migrated cache renders the same 963 located stargazers across 63 countries as before, and
a save -> load round trip is lossless. `black --check` clean.

## Not verified

- No live run of the workflow (needs `GITHUB_TOKEN` and hits the GitHub + Nominatim APIs). The
  network path of `username_to_country()` is unchanged, only its call frequency.
- The 97.8 % figure comes from an 89-user sample, not the full 1689.

## Notes

- `.github/workflows/generate_stargazer_map.yml` is unchanged - it does not need to be.
- No add-on directory is touched, so the CHANGELOG / version-bump CI gates do not apply.
- The committed `stargazer_countries.csv` and `stargazer_map.png` are **not** modified here; the
  first scheduled run after merge rewrites the CSV with the third column.
- #2953 touched the same file (rendering half) and is already merged; this branch is off master
  and includes it, so there is no conflict.

## Rollback

Single-file revert: `git revert <sha>`. The 3-column CSV that the workflow will have written by
then is still readable by the reverted code - `csv.DictReader` ignores the extra `last_checked`
column, and the old `save_cache()` simply drops it on the next run.

## Judgement calls

- **90 days** for the retry window; change `RECHECK_DAYS` if you want a different cadence.
- `last_checked` is compared as a lexicographic string rather than parsed, which is safe because
  `load_cache()` has already rejected anything that is not an ISO date.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cache entries now track when each location was last checked.
  * Blank locations are automatically retried after 90 days, with up to 200 oldest entries processed per run.
  * Existing cache files continue to work through automatic date backfilling.
  * Location results and newly cached entries are refreshed with the current date.
  * Country totals continue to reflect the latest available location information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->