### PR TITLE
docs(stargazer map): credit OpenStreetMap for the geocoding (ODbL attribution)

### DIFF
--- a/.github/generate_map.py
+++ b/.github/generate_map.py
@@ -240,7 +240,9 @@ def build_figure(counts, total_stargazers):
         dict(
             text="Countries in grey have no located stargazer.<br>"
             "Location is read from the public GitHub profile,<br>"
-            "so the map covers the located subset only.",
+            "so the map covers the located subset only.<br>"
+            "Country lookup by Nominatim geocoding,<br>"
+            "data © OpenStreetMap contributors.",
             x=0.988,
             y=0.05,
             xref="paper",


### PR DESCRIPTION
## Why

`.github/generate_map.py` resolves each stargazer's country by geocoding their free-text GitHub
`location` with **Nominatim** (via geopy). Nominatim serves OpenStreetMap data, which is licensed
**ODbL** and requires attribution — "© OpenStreetMap contributors" — wherever the derived data is
displayed. The map's footnote credited only the GitHub profile, so that licence obligation was
unmet. This PR meets it.

## Important nuance

The country **shapes** drawn by plotly are **Natural Earth**, not OpenStreetMap. Only the
geocoding (free-text location string → country) comes from Nominatim/OSM. The wording therefore
credits OSM for the *lookup*, and deliberately avoids any phrasing ("map data", "basemap") that
would imply the basemap is OSM.

## What changed

Two lines appended to the existing bottom-right footnote annotation in `build_figure()`. Nothing
else: no new annotation block, no colour/layout/font changes, no change to the geocoding, caching
or fetch logic, and no change to `.github/workflows/generate_stargazer_map.yml`.

Final footnote text:

```
Countries in grey have no located stargazer.
Location is read from the public GitHub profile,
so the map covers the located subset only.
Country lookup by Nominatim geocoding,
data © OpenStreetMap contributors.
```

The credit is split across two lines so neither is wider than the existing longest footnote line —
this keeps the block clear of the bottom-centre colourbar. The annotation is `yanchor="bottom"` at
`y=0.05`, so the extra lines grow upward into empty ocean and cannot clip off the canvas bottom.

## Verified

Rendered the map offline from the committed `.github/stargazer_countries.csv` (no network:
imported `load_cache` / `count_by_country` / `build_choropleth` directly) to a scratch PNG and
**visually inspected the result**. Both new lines are present, legible at the footnote's 12 px
muted style, right-aligned with the three existing lines, not clipped, and not overlapping the
colourbar, its tick labels, or the map. The `©` character renders correctly through kaleido.

The committed `.github/stargazer_map.png` and `.github/stargazer_countries.csv` are untouched —
the map PNG will be regenerated by the existing weekly workflow.

## Not verified

The scheduled workflow run itself (it needs `GITHUB_TOKEN` and live network); only the rendering
path was exercised locally.

## Rollback

Single-hunk change: revert this commit, or delete the two added `<br>`-joined string lines in
`build_figure()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Nominatim/OpenStreetMap attribution beneath map location explanations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->