### PR TITLE
fix(komga): bound the nginx readiness probes

### DIFF
--- a/komga/CHANGELOG.md
+++ b/komga/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.26.1.1 (2026-08-11)
+
+- Bound the nginx readiness probes (`--connect-timeout` / `--max-time`) so a stalled connection cannot hang the wait, and log a warning when Komga has not answered within 15 minutes
+
 ## 1.26.1 (2026-08-11)
 
 - Initial release, based on gotson/komga ([changelog](https://github.com/gotson/komga/releases))

--- a/komga/config.yaml
+++ b/komga/config.yaml
@@ -101,4 +101,4 @@ schema:
 slug: komga
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/komga
-version: "1.26.1"
+version: "1.26.1.1"

--- a/komga/rootfs/etc/services.d/nginx/run
+++ b/komga/rootfs/etc/services.d/nginx/run
@@ -8,12 +8,23 @@ set -e
 # bashio::net.wait_for : bashio takes (port host timeout) while the bundled
 # bashio-standalone.sh takes (host port timeout), and picking the wrong one
 # would either fail instantly or block for the whole timeout.
+# The per probe timeouts keep the 15 minute ceiling real : without them a
+# half open connection would hang a single probe, and the loop, forever.
+komga_ready=false
 for _ in $(seq 1 180); do
-    if curl -sf -o /dev/null "http://127.0.0.1:25600/komga/"; then
+    if curl -sf --connect-timeout 2 --max-time 5 -o /dev/null "http://127.0.0.1:25600/komga/"; then
+        komga_ready=true
         break
     fi
     sleep 5
 done
+
+# Deliberately not fatal : nginx serving a 502 tells the user something is wrong
+# and starts working by itself once komga finally answers, while refusing to
+# start would take ingress down for good after ha_entrypoint gives up retrying.
+if [ "$komga_ready" != true ]; then
+    bashio::log.warning "Komga did not answer within 15 minutes. Starting NGinx anyway : ingress will return 502 until it does."
+fi
 
 bashio::log.info "Starting NGinx..."
 exec nginx

--- a/komga/rootfs/etc/services.d/nginx/run
+++ b/komga/rootfs/etc/services.d/nginx/run
@@ -10,8 +10,12 @@ set -e
 # would either fail instantly or block for the whole timeout.
 # The per probe timeouts keep the 15 minute ceiling real : without them a
 # half open connection would hang a single probe, and the loop, forever.
+# A wall clock deadline, not an attempt count : a failed probe costs up to
+# max-time on top of the sleep, so counting attempts would stretch the wait to
+# roughly twice the advertised ceiling.
 komga_ready=false
-for _ in $(seq 1 180); do
+deadline=$((SECONDS + 900))
+while [ "$SECONDS" -lt "$deadline" ]; do
     if curl -sf --connect-timeout 2 --max-time 5 -o /dev/null "http://127.0.0.1:25600/komga/"; then
         komga_ready=true
         break


### PR DESCRIPTION
Follow-up to #2960, which was merged one commit before this fix landed on the branch — so it never
made it onto master. Same change, now with the version bump and CHANGELOG entry it needs on its own.

## What it fixes

The nginx service waits for Komga before serving ingress. Two defects, both found in review:

- `curl -sf` had no timeout flags, so a socket that accepts and never replies hangs a probe forever.
  Measured: `timeout 15 curl -sf ...` was still hanging when killed (exit 124); with
  `--connect-timeout 2 --max-time 5` curl gives up on its own in 5.011 s.
- With per-probe timeouts, an attempt *count* stretches the total wait to roughly twice the
  advertised ceiling. Measured against a silent listener, scaled to a 30 s ceiling: attempt-count
  1m0.123s versus wall-clock-deadline 0m30.062s.

The wait is now a `deadline=$((SECONDS + 900))` loop with bounded probes.

## What it deliberately does not do

Exit non-zero when every probe fails. `ha_entrypoint.sh` gives up after five restarts of a
`services.d` run script, so failing the start would take ingress down permanently on a host where
Komga is merely slow to boot. Serving a 502 is self-healing and is a visible symptom; exhaustion
now logs a warning instead.

---

**Note added after merge:** an earlier edit to this description wrongly also described an AppArmor
fix for local disk mounting. That fix is **not** in this PR — it is in the follow-up. Corrected here
to describe only what this PR actually changed.
