### PR TITLE
fix(komga): ship an apparmor profile so local disks can be mounted

### DIFF
--- a/komga/CHANGELOG.md
+++ b/komga/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.26.1.2 (2026-08-12)
+
+- Fix : local disks (`localdisks`) and SMB shares failed to mount with `cannot mount /dev/sdX read-only`. Without an `apparmor.txt` the add-on ran under Docker's default AppArmor profile, which denies `mount` and raw block device access. Ships the same profile as the other add-ons that mount disks
+
 ## 1.26.1.1 (2026-08-11)
 
 - Bound the nginx readiness probes (`--connect-timeout` / `--max-time`) so a stalled connection cannot hang the wait, and log a warning when Komga has not answered within 15 minutes

--- a/komga/apparmor.txt
+++ b/komga/apparmor.txt
@@ -1,0 +1,68 @@
+
+#include <tunables/global>
+
+profile komga_addon flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  capability chown,
+  capability dac_override,
+  capability dac_read_search,
+  capability fowner,
+  capability setgid,
+  capability setuid,
+  capability sys_chroot,
+  capability sys_admin,
+  file,
+  signal,
+  mount,
+  umount,
+  remount,
+  network udp,
+  network tcp,
+  network dgram,
+  network stream,
+  network inet,
+  network inet6,
+  network netlink raw,
+  network unix dgram,
+
+
+# Entrypoint stack
+  /init ix,
+  /run/{s6,s6-rc*,service}/** ix,
+  /package/** ix,
+  /command/** ix,
+  /run/{,**} rwk,
+  /dev/tty rw,
+  /bin/** ix,
+  /usr/bin/** ix,
+  /usr/lib/bashio/** ix,
+  /etc/s6/** rix,
+  /run/s6/** rix,
+  /etc/services.d/** rwix,
+  /etc/cont-init.d/** rwix,
+  /etc/cont-finish.d/** rwix,
+  /init rix,
+  /var/run/** mrwkl,
+  /var/run/ mrwkl,
+  /dev/i2c-1 mrwkl,
+  # Files required
+  /dev/fuse mrwkl,
+  /dev/sda1 mrwkl,
+  /dev/sdb1 mrwkl,
+  /dev/nvme0 mrwkl,
+  /dev/nvme1 mrwkl,
+  /dev/mmcblk0p1 mrwkl,
+  /dev/* mrwkl,
+  /tmp/** mrkwl,
+
+  # Data access
+  /data/** rw,
+
+  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
+  ptrace (trace,read) peer=docker-default,
+
+  # docker daemon confinement requires explict allow rule for signal
+  signal (receive) set=(kill,term) peer=/usr/bin/docker,
+
+}

--- a/komga/apparmor.txt
+++ b/komga/apparmor.txt
@@ -62,7 +62,7 @@ profile komga_addon flags=(attach_disconnected,mediate_deleted) {
   # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
   ptrace (trace,read) peer=docker-default,
 
-  # docker daemon confinement requires explict allow rule for signal
+  # docker daemon confinement requires explicit allow rule for signal
   signal (receive) set=(kill,term) peer=/usr/bin/docker,
 
 }

--- a/komga/config.yaml
+++ b/komga/config.yaml
@@ -101,4 +101,4 @@ schema:
 slug: komga
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/komga
-version: "1.26.1.1"
+version: "1.26.1.2"


### PR DESCRIPTION
The Komga add-on is currently broken on a host that mounts a local disk (`state=error`). This is the fix.

## The failure

Reported symptom:

```
... NAS is a device by label
[08:15:38] INFO: Mounting NAS of type ext4
mount: /mnt/NAS: cannot mount /dev/sda1 read-only.
[08:15:38] FATAL: Unable to mount local drives! Please check the name.
```

**Cause: the add-on shipped no `apparmor.txt`.** Supervisor only adds an AppArmor `security_opt`
when the add-on provides a profile:

```python
# supervisor/docker/app.py
elif self.app.apparmor == SECURITY_PROFILE:
    security.append(f"apparmor={self.app.slug}")
```

With no profile the container falls back to Docker's own `docker-default` profile, which denies
`mount()` and raw block-device access. The kernel side confirms it — the mount never got past
opening the device, and it is logged twice per attempt because `mount` retries read-only after the
read-write attempt is refused, which is exactly the message the user saw:

```
/dev/disk/by-label/NAS: Can't open blockdev
/dev/disk/by-label/NAS: Can't open blockdev
```

Diagnosis on the affected host, via the Supervisor API — 14 add-ons are configured with
`localdisks`, 13 mount the disk fine and only Komga fails, and the single differing variable is the
AppArmor mode:

| add-on | apparmor | privileged | udev | `/dev/sda1` granted | result |
|---|---|---|---|---|---|
| bazarr_nas | `profile` | SYS_ADMIN, DAC_READ_SEARCH | true | yes | mounts |
| radarr_nas | `profile` | SYS_ADMIN, DAC_READ_SEARCH | true | yes | mounts |
| qbittorrent | `profile` | SYS_ADMIN, DAC_READ_SEARCH, NET_ADMIN | true | yes | mounts |
| **komga** | **`default`** | SYS_ADMIN, DAC_READ_SEARCH | true | yes | **fails** |

There were no AppArmor denials in `dmesg`, which is consistent: `docker-default` refuses the device
open, so the failure surfaces as a filesystem error rather than an LSM audit line.

The profile added here is the one `bazarr` ships — proven on the affected host with the same
`00-local_mounts.sh` / `00-smb_mounts.sh` modules — with the profile renamed. It grants `mount`,
`umount`, `remount` and `/dev/sda1 mrwkl`, the permissions `docker-default` withholds. The internal
name does not have to match the slug: Supervisor rewrites it via `adjust_profile(self.slug, ...)`
before loading.

For the record, 119 of the repo's 122 add-ons ship `apparmor.txt`. The three that do not
(`signalk`, `spotify_to_plex`, `zoraxy`) never mount disks, so Komga was the only add-on that both
mounted disks and lacked a profile. Omitting it was my mistake in #2959.

**Users must update the add-on for this to take effect** — Supervisor loads the profile on
install/update, not on restart.

## Verification

`validate.sh komga --vs-master` clean. The diagnosis is evidence from the affected host (Supervisor
API, `dmesg`, `lsblk`). **Not verified:** that
the profile fixes the mount on the user's machine — that needs an add-on update on the affected
host, and it is the thing to check first after merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the ability to mount local disks and SMB shares in the Komga add-on.
  * Improved access to required storage devices and related system resources.

* **Chores**
  * Updated the Komga add-on to version 1.26.1.2.
  * Documented the AppArmor profile fix in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->