### PR TITLE
fix(komga): rewrite the cookie path so ingress logins stick

### DIFF
--- a/komga/CHANGELOG.md
+++ b/komga/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.26.1.3 (2026-08-12)
+
+- Fix : 401 errors after a successful login through ingress. Komga scopes its session cookies to its servlet context path (`Path=/komga`), which the browser never sends back from the ingress url, so every request after the login was anonymous. Nginx now rewrites the cookie path onto the ingress entry
+
 ## 1.26.1.2 (2026-08-12)
 
 - Fix : local disks (`localdisks`) and SMB shares failed to mount with `cannot mount /dev/sdX read-only`. Without an `apparmor.txt` the add-on ran under Docker's default AppArmor profile, which denies `mount` and raw block device access. Ships the same profile as the other add-ons that mount disks

--- a/komga/config.yaml
+++ b/komga/config.yaml
@@ -101,4 +101,4 @@ schema:
 slug: komga
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/komga
-version: "1.26.1.2"
+version: "1.26.1.3"

--- a/komga/rootfs/etc/nginx/servers/ingress.conf
+++ b/komga/rootfs/etc/nginx/servers/ingress.conf
@@ -33,6 +33,13 @@ server {
         proxy_redirect http://127.0.0.1:25600/ %%ingress_entry%%/;
         proxy_redirect / %%ingress_entry%%/;
 
+        # Komga scopes its cookies to the servlet context path
+        # (Set-Cookie: ...; Path=/komga). The browser lives under the ingress
+        # entry, so such a cookie is never sent back : login succeeds, then
+        # every following request arrives anonymous and Komga answers 401.
+        proxy_cookie_path /komga %%ingress_entry%%/komga;
+        proxy_cookie_path / %%ingress_entry%%/;
+
         # Komga renders its index page with Thymeleaf @{...} link expressions,
         # so every asset url and window.resourceBaseUrl carry the context path
         # (/komga). Ingress strips its own prefix before forwarding, so the


### PR DESCRIPTION
Logging in through ingress succeeded and then every following request returned 401. Fixed by
rewriting the cookie path in nginx.

## The failure

From the add-on log on the affected host — the login itself works, the requests right after it do not:

```
POST /komga/api/v1/claim                     200   <- admin user created
GET  /komga/api/v2/users/me?remember-me=true 200   <- login succeeds (Basic auth header)
GET  /komga/api/v1/libraries                 401   <- next request is anonymous
GET  /komga/sse/v1/events                    401
```

**Cause: Komga scopes its cookies to the servlet context path.** Observed directly against the
running instance:

```
$ curl -D - -u wrong:wrong http://<addon>:25600/komga/api/v2/users/me
HTTP/1.1 401
Set-Cookie: komga-remember-me=; ...; Path=/komga
```

The browser is not at `/komga/...` but at `/api/hassio_ingress/<token>/komga/...`, so a cookie
scoped to `Path=/komga` is never sent back. The Basic-auth login request carries its credentials in
a header and therefore works; everything after it depends on the session cookie and arrives
anonymous.

## The fix

```nginx
proxy_cookie_path /komga %%ingress_entry%%/komga;
proxy_cookie_path / %%ingress_entry%%/;
```

Rewriting in nginx keeps the cookie scoped as tightly as before. The alternative — setting
`server.servlet.session.cookie.path=/` on Komga — would widen the cookie to every path on the Home
Assistant host, including Home Assistant's own requests, which is worse.

Direct access on port 25600 is untouched: nginx only listens on the ingress port.

## Verified against the live instance

The add-on nginx was pointed at the real running Komga (not a stub) for these:

| case | before | after |
|---|---|---|
| `Set-Cookie` path | `Path=/komga` | `Path=/api/hassio_ingress/<token>/komga` |
| ingress panel root `/` | 302 → `<entry>/komga/` | unchanged |
| `/komga` (Spring's own redirect) | 302 → `<entry>/komga/` | unchanged |
| real index html | `resourceBaseUrl` + asset urls prefixed | unchanged |
| json api response | untouched by sub_filter | unchanged |

`validate.sh komga --vs-master` is clean.

**Not verified:** an actual browser login through ingress, which needs credentials I do not have.
The cookie rewrite is proven at the header level and applies to every `Set-Cookie` Komga emits,
including the session cookie — but confirming the UI works after login is the last step, and it
belongs to whoever merges this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication issues that could cause 401 errors after signing in through the ingress.
  * Improved cookie handling so authenticated sessions work correctly under the proxied Komga path.

* **Chores**
  * Updated the Komga add-on to version 1.26.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->