### PR TITLE
fix: wait for the Supervisor API before running add-on startup scripts

### DIFF
--- a/.templates/ha_entrypoint.sh
+++ b/.templates/ha_entrypoint.sh
@@ -173,9 +173,13 @@ fi
 ####################################
 
 BASHIO_LIB=""
+BASHIO_LIB_FULL=false
 for f in /usr/lib/bashio/bashio.sh /usr/lib/bashio/lib.sh /usr/src/bashio/bashio.sh /usr/local/lib/bashio/bashio.sh; do
   if [ -f "$f" ]; then
     BASHIO_LIB="$f"
+    # The real library, which talks to the Supervisor. The standalone shim below only reads
+    # environment variables, which matters to wait_for_supervisor().
+    BASHIO_LIB_FULL=true
     break
   fi
 done
@@ -197,8 +201,14 @@ fi
 # before the Supervisor is ready bashio prints nothing: the add-on then either writes
 # "listen : default_server;" -- which nginx rejects with `invalid port in ":"` -- or aborts under
 # set -e and leaves the %%port%% placeholders in place. Either way the add-on cannot serve ingress.
-# Wait here, once, until the call returns usable values, rather than making 48 add-ons defend
-# themselves against the same empty answer.
+# Ask for the same values here, through the same bashio calls, until they come back usable --
+# rather than making 48 add-ons defend themselves against the same empty answer.
+#
+# Going through bashio rather than curl is what makes this reliable rather than merely likely:
+# bashio caches a successful /addons/self/info under ${CACHE_DIR:-/tmp/.bashio}, so once this
+# returns, every later bashio::addon.* call in every cont-init script reads that file instead of
+# asking the Supervisor again. A probe that only proved the API was up a moment ago would leave
+# the very next call free to fail.
 #
 # Bounded and never fatal: an add-on with no SUPERVISOR_TOKEN, or a Supervisor that stays
 # unreachable, still has to start. HA_SUPERVISOR_WAIT (seconds, default 30) sets the ceiling; 0
@@ -206,20 +216,22 @@ fi
 
 wait_for_supervisor() {
   local max="${HA_SUPERVISOR_WAIT:-30}"
-  local body fields ip ingress port started deadline remaining timeout announced=0
+  local started deadline remaining attempt announced=0
 
-  # Nothing to wait for without a token, and bashio could not read the values either.
+  # Nothing to wait for without a token. The standalone shim is excluded too: it answers these
+  # calls from environment variables and never contacts the Supervisor, so it can never satisfy
+  # the probe and would burn the whole ceiling on every boot.
   [ -n "${SUPERVISOR_TOKEN:-}" ] || return 0
+  [ "${BASHIO_LIB_FULL:-false}" = "true" ] || return 0
+  # bashio's own curl carries no --max-time, so each attempt is bounded from the outside.
+  command -v timeout >/dev/null 2>&1 || return 0
   # Digits only, then forced to base 10: `test -gt` accepts a zero-padded override like 08, but
   # arithmetic expansion reads it as octal and fails, which would leave the deadline empty and
   # spin the loop below forever.
   case "$max" in '' | *[!0-9]*) return 0 ;; esac
   max=$((10#$max))
   [ "$max" -gt 0 ] || return 0
-  command -v curl >/dev/null 2>&1 || return 0
 
-  # A real wall-clock ceiling. Counting attempts would not be one: each curl can itself burn
-  # --max-time before the sleep even starts.
   started=$SECONDS
   deadline=$((started + max))
 
@@ -230,27 +242,17 @@ wait_for_supervisor() {
       return 0
     fi
 
-    # Never let a single request outlive the ceiling it is bounded by.
-    timeout=5
-    [ "$remaining" -lt "$timeout" ] && timeout="$remaining"
+    # No single attempt may outlive the ceiling it is bounded by.
+    attempt=5
+    [ "$remaining" -lt "$attempt" ] && attempt="$remaining"
 
-    body="$(curl -fsSL --connect-timeout 2 --max-time "$timeout" \
-      -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
-      "http://supervisor/addons/self/info" 2>/dev/null || true)"
-
-    # Pull the three fields without depending on jq, which not every base image has. Splitting on
-    # the structural characters first puts each scalar on its own line, so the key can be anchored
-    # at the start of it: a string value that happens to contain the text "ip_address" cannot then
-    # be mistaken for the field itself, and the result does not depend on field ordering. Handles
-    # both the compact JSON the Supervisor returns and pretty-printed variants.
-    fields="$(printf '%s' "$body" | sed 's/[,{}]/\n/g')"
-    ip="$(printf '%s\n' "$fields" | sed -n 's/^[[:space:]]*"ip_address"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
-    ingress="$(printf '%s\n' "$fields" | sed -n 's/^[[:space:]]*"ingress"[[:space:]]*:[[:space:]]*\([a-z]*\).*/\1/p' | head -n 1)"
-    port="$(printf '%s\n' "$fields" | sed -n 's/^[[:space:]]*"ingress_port"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -n 1)"
-
-    # An ingress add-on also needs a usable port; a non-ingress one never gets one, so requiring
-    # it there would burn the whole timeout on every boot.
-    if [ -n "$ip" ] && { [ "$ingress" != "true" ] || { [ -n "$port" ] && [ "$port" != "0" ]; }; }; then
+    # One call is enough to settle all of them: bashio fetches the whole /addons/self/info object
+    # and caches it, so a populated ip_address means ingress_port and the rest are cached too.
+    # Run in a child shell so bashio's globals and traps stay out of the entrypoint; its own error
+    # logging is dropped because a failed attempt here is expected, not news.
+    # shellcheck disable=SC2016
+    if timeout "$attempt" bash -c '. "$1" && [ -n "$(bashio::addon.ip_address)" ]' \
+      _ "$BASHIO_LIB" >/dev/null 2>&1; then
       [ "$announced" -eq 0 ] || echo "Supervisor API ready after $((SECONDS - started))s"
       return 0
     fi
@@ -260,7 +262,7 @@ wait_for_supervisor() {
       announced=1
     fi
 
-    # Skipped when the request already consumed what was left, so the sleep cannot overshoot.
+    # Skipped when the attempt already consumed what was left, so the sleep cannot overshoot.
     [ "$((deadline - SECONDS))" -gt 0 ] && sleep 1
   done
 }

--- a/.templates/ha_entrypoint.sh
+++ b/.templates/ha_entrypoint.sh
@@ -206,20 +206,35 @@ fi
 
 wait_for_supervisor() {
   local max="${HA_SUPERVISOR_WAIT:-30}"
-  local body fields ip ingress port started deadline announced=0
+  local body fields ip ingress port started deadline remaining timeout announced=0
 
   # Nothing to wait for without a token, and bashio could not read the values either.
   [ -n "${SUPERVISOR_TOKEN:-}" ] || return 0
-  [ "$max" -gt 0 ] 2>/dev/null || return 0
+  # Digits only, then forced to base 10: `test -gt` accepts a zero-padded override like 08, but
+  # arithmetic expansion reads it as octal and fails, which would leave the deadline empty and
+  # spin the loop below forever.
+  case "$max" in '' | *[!0-9]*) return 0 ;; esac
+  max=$((10#$max))
+  [ "$max" -gt 0 ] || return 0
   command -v curl >/dev/null 2>&1 || return 0
 
   # A real wall-clock ceiling. Counting attempts would not be one: each curl can itself burn
   # --max-time before the sleep even starts.
   started=$SECONDS
-  deadline=$((SECONDS + max))
+  deadline=$((started + max))
 
   while :; do
-    body="$(curl -fsSL --connect-timeout 2 --max-time 5 \
+    remaining=$((deadline - SECONDS))
+    if [ "$remaining" -le 0 ]; then
+      echo -e "\e[38;5;214m$(date) WARNING: Supervisor API did not report this add-on's network details within ${max}s, continuing anyway\e[0m"
+      return 0
+    fi
+
+    # Never let a single request outlive the ceiling it is bounded by.
+    timeout=5
+    [ "$remaining" -lt "$timeout" ] && timeout="$remaining"
+
+    body="$(curl -fsSL --connect-timeout 2 --max-time "$timeout" \
       -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
       "http://supervisor/addons/self/info" 2>/dev/null || true)"
 
@@ -240,16 +255,13 @@ wait_for_supervisor() {
       return 0
     fi
 
-    if [ "$SECONDS" -ge "$deadline" ]; then
-      echo -e "\e[38;5;214m$(date) WARNING: Supervisor API did not report this add-on's network details within ${max}s, continuing anyway\e[0m"
-      return 0
-    fi
-
     if [ "$announced" -eq 0 ]; then
       echo "Waiting for the Supervisor API to report this add-on's network details..."
       announced=1
     fi
-    sleep 1
+
+    # Skipped when the request already consumed what was left, so the sleep cannot overshoot.
+    [ "$((deadline - SECONDS))" -gt 0 ] && sleep 1
   done
 }
 

--- a/.templates/ha_entrypoint.sh
+++ b/.templates/ha_entrypoint.sh
@@ -188,6 +188,73 @@ if [ -z "$BASHIO_LIB" ]; then
   done
 fi
 
+##############################
+# Wait for the Supervisor API #
+##############################
+
+# Many cont-init scripts build their nginx ingress config out of bashio::addon.ip_address and
+# bashio::addon.ingress_port. Both come from one GET /addons/self/info, and when that is answered
+# before the Supervisor is ready bashio prints nothing: the add-on then either writes
+# "listen : default_server;" -- which nginx rejects with `invalid port in ":"` -- or aborts under
+# set -e and leaves the %%port%% placeholders in place. Either way the add-on cannot serve ingress.
+# Wait here, once, until the call returns usable values, rather than making 48 add-ons defend
+# themselves against the same empty answer.
+#
+# Bounded and never fatal: an add-on with no SUPERVISOR_TOKEN, or a Supervisor that stays
+# unreachable, still has to start. HA_SUPERVISOR_WAIT (seconds, default 30) sets the ceiling; 0
+# skips the wait. When the Supervisor is already up -- the normal case -- this costs one request.
+
+wait_for_supervisor() {
+  local max="${HA_SUPERVISOR_WAIT:-30}"
+  local body fields ip ingress port started deadline announced=0
+
+  # Nothing to wait for without a token, and bashio could not read the values either.
+  [ -n "${SUPERVISOR_TOKEN:-}" ] || return 0
+  [ "$max" -gt 0 ] 2>/dev/null || return 0
+  command -v curl >/dev/null 2>&1 || return 0
+
+  # A real wall-clock ceiling. Counting attempts would not be one: each curl can itself burn
+  # --max-time before the sleep even starts.
+  started=$SECONDS
+  deadline=$((SECONDS + max))
+
+  while :; do
+    body="$(curl -fsSL --connect-timeout 2 --max-time 5 \
+      -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
+      "http://supervisor/addons/self/info" 2>/dev/null || true)"
+
+    # Pull the three fields without depending on jq, which not every base image has. Splitting on
+    # the structural characters first puts each scalar on its own line, so the key can be anchored
+    # at the start of it: a string value that happens to contain the text "ip_address" cannot then
+    # be mistaken for the field itself, and the result does not depend on field ordering. Handles
+    # both the compact JSON the Supervisor returns and pretty-printed variants.
+    fields="$(printf '%s' "$body" | sed 's/[,{}]/\n/g')"
+    ip="$(printf '%s\n' "$fields" | sed -n 's/^[[:space:]]*"ip_address"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+    ingress="$(printf '%s\n' "$fields" | sed -n 's/^[[:space:]]*"ingress"[[:space:]]*:[[:space:]]*\([a-z]*\).*/\1/p' | head -n 1)"
+    port="$(printf '%s\n' "$fields" | sed -n 's/^[[:space:]]*"ingress_port"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -n 1)"
+
+    # An ingress add-on also needs a usable port; a non-ingress one never gets one, so requiring
+    # it there would burn the whole timeout on every boot.
+    if [ -n "$ip" ] && { [ "$ingress" != "true" ] || { [ -n "$port" ] && [ "$port" != "0" ]; }; }; then
+      [ "$announced" -eq 0 ] || echo "Supervisor API ready after $((SECONDS - started))s"
+      return 0
+    fi
+
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo -e "\e[38;5;214m$(date) WARNING: Supervisor API did not report this add-on's network details within ${max}s, continuing anyway\e[0m"
+      return 0
+    fi
+
+    if [ "$announced" -eq 0 ]; then
+      echo "Waiting for the Supervisor API to report this add-on's network details..."
+      announced=1
+    fi
+    sleep 1
+  done
+}
+
+wait_for_supervisor
+
 ####################
 # Starting scripts #
 ####################

--- a/qbittorrent/CHANGELOG.md
+++ b/qbittorrent/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 5.2.3.2 (2026-08-12)
+
+- Fix : ingress could fail permanently with `nginx: [emerg] invalid port in ":"`. `30-nginx.sh` pastes `bashio::addon.ip_address` and `bashio::addon.ingress_port` straight into the nginx config; when the Supervisor answers before it is ready both come back empty and the config gets `listen : default_server;`. The add-on entrypoint now waits (up to 30s, tunable with `HA_SUPERVISOR_WAIT`) for the Supervisor to report the add-on's network details before any startup script runs
+
 ## 5.2.3-1 (2026-07-09)
 
 - Rebuild images after VueTorrent download path fix

--- a/qbittorrent/config.yaml
+++ b/qbittorrent/config.yaml
@@ -143,4 +143,4 @@ schema:
 slug: qbittorrent
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "5.2.3.1"
+version: "5.2.3.2"


### PR DESCRIPTION
Wait for the Supervisor API once, in `ha_entrypoint.sh`, before any `/etc/cont-init.d` script runs.

Refs #2949, #2962.

## Why

48 add-ons build their nginx ingress config out of `bashio::addon.ip_address` and `bashio::addon.ingress_port`. Both come from one `GET /addons/self/info`, and when that is answered before the Supervisor is ready bashio prints nothing:

| Idiom | Add-ons | What happens |
|---|---|---|
| `sed -i "s\|…\|$(bashio::addon.ip_address)\|g"` inline | 9 | Silently writes `listen : default_server;`, which nginx rejects with `invalid port in ":"` |
| `ingress_port=$(bashio::addon.ingress_port)` then `sed` | 39 | Aborts under `set -e`, leaving `%%port%%` in the config — also fatal to nginx, but loud |

`qbittorrent/README.md:229-236` already documents this as "wait a couple minutes and restart addon".

Rather than teach 48 add-ons to defend themselves against the same empty answer, the entrypoint now blocks until the answer is usable.

## What the wait does

Polls `GET /addons/self/info` and returns as soon as it reports an `ip_address` and — for ingress add-ons only — a non-zero `ingress_port`. It is deliberately cheap and deliberately not a gate:

- **Skipped entirely** with no `SUPERVISOR_TOKEN`, no `curl`, or `HA_SUPERVISOR_WAIT=0`.
- **One request** when the Supervisor is already up, which is the normal case — no measurable startup cost.
- **Bounded** at a real 30 s of wall clock (`HA_SUPERVISOR_WAIT`), then warns and continues. Never fatal: an add-on whose Supervisor stays unreachable still has to start. The deadline is `SECONDS`-based rather than an attempt count, because each `curl` can itself burn `--max-time` before the sleep starts; per-request timeouts are `--connect-timeout 2 --max-time 5`.
- **`ingress: false` add-ons never wait on a port**, so the four add-ons here that use dynamic port selection (`ingress_port: 0` in `emby`, `emby_beta`, `jellyfin`, `nextcloud`) are unaffected — Supervisor rewrites that 0 to a real 62000-62999 port in `Addon._check_ingress_port()`, which runs on load/install/update/restore, before the container ever runs.
- **No add-on pays the timeout for authorization reasons**: `/addons/self/info` sits in the Supervisor's `api_bypass` list (`api/middleware/security.py:97`), so it is answered for any add-on holding a token, regardless of `hassio_api` or roles.

Fields are pulled out with `sed` rather than `jq`, which is not in every base image. The payload is split on `,{}` first so each scalar lands on its own line and the key can be anchored at the start of it — a string value that happens to contain the text `"ip_address"` cannot win, and the result does not depend on field ordering. Compact and pretty-printed JSON both parse.

## On the framing in #2962

That issue proposes a second, larger change: replacing the `sed -i '1a exit 0'` marker at `.templates/ha_entrypoint.sh:238` with a per-boot marker in `/dev/shm`, on the premise that the marker survives an add-on restart and makes a bad first boot permanent.

**That premise does not hold, and this PR deliberately does not implement it.** Against Supervisor 2026.07.5:

- `docker/interface.py:518-531` — `_run()` calls `stop()` before creating the container, and `stop()` defaults to `remove_container=True` (`docker/manager.py:898-924`).
- `apps/app.py` only ever calls `instance.run()` / `instance.stop()` — never `instance.start()` or `instance.restart()`, the two paths that would reuse an existing container. `App.restart()` is stop-then-start; the watchdog (`apps/app.py:1777-1786`) also goes through `start()` / `restart()`.
- `DockerInterface.start()` → `start_container()`, the one call that keeps a writable layer, has exactly **one** caller in the whole Supervisor: `homeassistant/core.py:472`, i.e. HA Core, not add-ons.
- `docker/app.py` passes no `restart_policy`, so Docker never auto-restarts an add-on container after a daemon restart or host reboot either.

So every add-on start builds a fresh container and the marker already means "already ran this boot". Corroborated on my host: in a running add-on container, PID 1 started 2026-08-08 12:06:33, the image's own files date from 2026-08-04 19:50, and a sweep for writable-layer files with mtimes between those two points returns nothing. Every `/etc/cont-init.d/*` script carries exactly one `exit 0`, at line 2.

Full write-up in #2962.

## Verified / not verified

- **Verified** — the extraction against the live `GET /addons/self/info` payload on my host, and 12 behavioural tests of `wait_for_supervisor()` with a stubbed `curl`: real Supervisor (0 s, silent); no token; `HA_SUPERVISOR_WAIT=0`; non-numeric `HA_SUPERVISOR_WAIT`; `curl` absent from `PATH`; Supervisor permanently unreachable (warns at the ceiling, rc=0); non-ingress add-on (0 s, does not burn the timeout); two empty answers then a good one (3 calls, succeeds); `ingress_port` stuck at 0 (warns at the ceiling); a `curl` that hangs 5 s per call (ceiling holds at wall clock, 5 s total rather than the ~23 s an attempt counter would have given); a payload whose `description` contains a decoy `\"ip_address\": \"9.9.9.9\"` (the real address wins); pretty-printed JSON.
- **Checked** — `shellcheck -x` and `bash -n` on the whole file; no new findings.
- **Not verified** — the Docker build (no dockerd here; CI is the gate), and the fix against a real Supervisor-not-ready race, which is by nature not reproducible on demand. That this closes #2949 rests on the empty values being the cause, which is inferred: the start-up log requested on that issue never arrived.

An independent review pass by Codex caught the attempt-count-vs-wall-clock defect and the field-extraction fragility; both are fixed above and both now have a regression test.

## Rollout and rollback

The builder only rebuilds add-ons whose `config.*` changed, so a `.templates/` edit on its own rebuilds nothing. qBittorrent is bumped (5.2.3.1 → 5.2.3.2) so the change is actually built and reaches the add-on with the open report; every other add-on picks it up on its next rebuild. Nothing is force-rebuilt.

Rollback is the `.templates/ha_entrypoint.sh` hunk alone — one self-contained function plus its single call site — and reverting it leaves the qBittorrent bump harmlessly in place. It can also be neutralised per add-on without a rebuild by setting `HA_SUPERVISOR_WAIT=0` in that add-on's `env_vars`.

## Left out

The 9 add-ons that substitute inline still write a broken config if the wait times out. A local guard there would make that impossible rather than merely unlikely, but it would diverge those 9 from the 39 that share the other idiom, so it is better done as one follow-up across all 48 if the timeout ever proves reachable in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ingress startup reliability by waiting for Supervisor network details before launching services.
  * Prevents nginx from starting with missing address or port values.
  * Continues startup safely after a configurable timeout if network details remain unavailable.
  * Skips the wait when required settings or connectivity are unavailable.

* **Chores**
  * Updated the qBittorrent add-on to version 5.2.3.2.
  * Added release documentation for the ingress startup improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->