### PR TITLE
docs(skill): terse chat replies in the add-on workflow

### DIFF
--- a/.claude/skills/hassio-addon-workflow/SKILL.md
+++ b/.claude/skills/hassio-addon-workflow/SKILL.md
@@ -11,6 +11,16 @@ description: >-
 
 # Home Assistant add-on workflow
 
+**Answer style.** Chat replies are terse: no pleasantries, no tool-call narration, no decorative
+tables or emoji, no dumped logs — quote the shortest decisive line, and don't re-read or re-print
+what is already in context. Fragments and dropped articles are fine. Never compressed: uncertainty
+markers ("likely", "assumed", "not verified"), negations (`not`/`never`/`no`/`only`), numbers,
+units, technical terms, code blocks, error strings — step 9's Verified/Checked/Assumed distinction
+outranks brevity every time. Write in full prose, not fragments, for security warnings,
+irreversible-action confirmations, and any multi-step sequence a fragment could make ambiguous.
+Persisted text is prose too: commits, CHANGELOG entries, PR bodies, review-thread replies, the
+step 10 report.
+
 Triage first, then one of two paths:
 
 - **Light** — typo/doc fixes, CHANGELOG edits, version bumps, one-file edits at ladder levels


### PR DESCRIPTION
## What

Adds an 8-line answer-style rule to `.claude/skills/hassio-addon-workflow/SKILL.md`: chat replies
under this skill are terse — no pleasantries, no tool-call narration, no decorative tables, no
dumped logs, no re-printing material already in context.

## What is explicitly exempt

Uncertainty markers ("likely", "assumed", "not verified"), negations, numbers, units, technical
terms, code blocks, error strings — plus security warnings and irreversible-action confirmations.
Step 9's Verified / Checked / Assumed distinction outranks brevity, so terseness cannot turn an
assumption into a claim.

Persisted text stays normal prose: commits, CHANGELOG entries, PR bodies, review-thread replies,
the step 10 report.

## Review history

The first draft was a 20-line "caveman mode" section (drop articles, drop hedging, fragments,
style-name references). Codex (`gpt-5.6-sol`) reviewed it and rejected it on two grounds worth
recording:

- **Wrong term.** Assistant prose is a small share of tokens in a tool-heavy session; the
  dominant cost is what gets read *into* context. The instruction itself costs ~250-350 input
  tokens on every add-on task, plausibly more than the output it saves.
- **"Drop hedging" is actively harmful here.** Words like "likely" and "not verified" encode
  evidence strength, which is exactly what step 9 is built to preserve.

The section was cut to the current 8 lines: keep the parts that reduce what enters context
(no log dumps, no re-reads, shortest decisive line), drop the grammar rules, and name the
exemptions.

## Not verified

Docs-only change to a skill file — no add-on touched, so no version bump or add-on CHANGELOG
(CI's CHANGELOG gate keys off changed `config.*` files). The token effect is argued, not measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for concise assistant responses with minimal quoting and no unnecessary narration.
  * Clarified that responses should avoid tables, emoji, and raw log dumps.
  * Preserved requirements for uncertainty markers, negations, technical details, security warnings, and confirmation requests.
  * Specified that persisted text should use normal prose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->