### PR TITLE
fix(qbittorrent): allow ::/0 so WireGuard stops dropping IPv6 traffic

### DIFF
--- a/qbittorrent/CHANGELOG.md
+++ b/qbittorrent/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 5.2.3.3 (2026-08-13)
+
+- Fix : with WireGuard, IPv6 traffic was silently dropped. When the WireGuard config declared an IPv6 `Address` (Mullvad, AirVPN and ProtonVPN all do), `vpn` added a default IPv6 route into the tunnel but never added `::/0` to the peer's `allowed-ips`, so WireGuard discarded every outgoing IPv6 packet. `::/0` is now allowed for IPv6 tunnels, mirroring the existing `0.0.0.0/0` handling for IPv4
+
 ## 5.2.3.2 (2026-08-12)
 
 - Fix : ingress could fail permanently with `nginx: [emerg] invalid port in ":"`. `30-nginx.sh` pastes `bashio::addon.ip_address` and `bashio::addon.ingress_port` straight into the nginx config; when the Supervisor answers before it is ready both come back empty and the config gets `listen : default_server;`. The add-on entrypoint now waits (up to 30s, tunable with `HA_SUPERVISOR_WAIT`) for the Supervisor to report the add-on's network details before any startup script runs

--- a/qbittorrent/config.yaml
+++ b/qbittorrent/config.yaml
@@ -143,4 +143,4 @@ schema:
 slug: qbittorrent
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "5.2.3.2"
+version: "5.2.3.3"

--- a/qbittorrent/rootfs/usr/local/sbin/vpn
+++ b/qbittorrent/rootfs/usr/local/sbin/vpn
@@ -293,6 +293,7 @@ _wireguard_up() {
         elif [ "${result}" -eq 2 ]; then
             config["IPv6Enabled"]="true"
             local_ip_types["${local_ip}"]="ipv6"
+            allowed_ip_types["::/0"]="ipv6"
             _cmd "ip addr add ${local_ip} dev ${config["Interface"]}" || return 1
         else
             bashio::log.warning "Ignoring invalid local IP address: ${local_ip}"


### PR DESCRIPTION
Closes #2139

## Root cause

`qbittorrent/rootfs/usr/local/sbin/vpn`, `_wireguard_up()`, lines **291-296**.

The loop over the WireGuard config's `Address` entries builds the peer's `allowed-ips` set. The IPv4 branch adds the catch-all; the IPv6 branch does not:

```bash
if [ "${result}" -eq 1 ]; then
    config["IPv4Enabled"]="true"
    local_ip_types["${local_ip}"]="ipv4"
    allowed_ip_types["0.0.0.0/0"]="ipv4"      # <- present
elif [ "${result}" -eq 2 ]; then
    config["IPv6Enabled"]="true"
    local_ip_types["${local_ip}"]="ipv6"
                                              # <- ::/0 missing
```

So for a dual-stack config — `Address = 10.66.1.2/32, fc00:bbbb:bbbb:bb01::5:1234/128`, the shape Mullvad, AirVPN and ProtonVPN all ship — the peer ends up with:

```
allowed-ips = 0.0.0.0/0, 10.66.1.2/32, fc00:bbbb:bbbb:bb01::5:1234/128
```

Meanwhile `_routing_add()` (lines 175-177) sees `IPv6Enabled=true` and installs `ip -6 route add default dev <iface> table <table>`. Every outbound IPv6 packet is therefore routed *into* the WireGuard device and then discarded by WireGuard's crypto-routing, because no peer claims the destination.

IPv6 fails silently: no error, no log line. The tunnel comes up, the handshake succeeds, IPv4 works — so the add-on looks healthy while IPv6 trackers and peers just time out.

**Regression from 7af8610a25** ("qBittorrent upnp and firewall for VPN", 2026-03-21). Before that refactor the same loop did `allowed_ips="${allowed_ips},::/0"` in the IPv6 branch. The refactor moved the IPv4 catch-all into `allowed_ip_types` and dropped the IPv6 one. Both are also left commented out in the second loop (lines 312 and 315), which is what makes the omission look accidental rather than deliberate.

## The change

One line, mirroring the IPv4 path:

```bash
elif [ "${result}" -eq 2 ]; then
    config["IPv6Enabled"]="true"
    local_ip_types["${local_ip}"]="ipv6"
    allowed_ip_types["::/0"]="ipv6"
    _cmd "ip addr add ${local_ip} dev ${config["Interface"]}" || return 1
```

It only fires when the WireGuard config actually declares an IPv6 `Address`, so IPv4-only setups are untouched. It cannot cause an IP leak: it moves traffic *into* the tunnel, never out of it.

No route-loop risk when the endpoint itself is IPv6. This script does not use `wg-quick`'s fwmark trick — it selects the tunnel with `ip -6 rule ... from <tunnel address> table <table>`. WireGuard's own encrypted packets are sourced from the container's real address, so they never match that rule and keep using the main table. Same reasoning as the IPv4 `0.0.0.0/0` entry that already works today.

## Verification

- `shellcheck --shell=bash --severity=style` on the modified file: 27 findings before, 27 after. All pre-existing (SC2086 / SC2155 / SC2068 elsewhere in the file), none on the new line.
- Diff compared against the pre-7af8610a25 version of the same loop, which had `::/0`.
- **Not runtime-tested.** I have no WireGuard provider config and no Home Assistant host in this environment, so I could not bring a tunnel up and confirm IPv6 egress. The reasoning above is static analysis of the script plus its git history.

To confirm on a real system: with a dual-stack config and `wireguard_enabled: true`, `wg show <iface> allowed-ips` should now list `::/0`, and `curl -6 --interface <iface> https://icanhazip.com` should return the VPN's IPv6 address instead of hanging.

## Note for @alexbelgium

The AI-fix rules forbid me touching `version` in `config.yaml`, so the CHANGELOG entry is filed under **5.2.3.3** while `config.yaml` still says `5.2.3.2` — bump it to release.

Related: because no `config.*` file changed, `onpr_check-pr.yaml` computes an empty add-on matrix, so lint and the Docker build are skipped on this PR.

This is automated analysis pending your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WireGuard IPv6 routing to support the default IPv6 route (`::/0`).
  * Prevented outgoing IPv6 traffic from being unintentionally discarded when IPv6 is enabled.
  * Improved IPv6 connectivity for configurations using a default IPv6 route.

* **Documentation**
  * Added release notes for version 5.2.3.3.

* **Updates**
  * Updated the add-on to version 5.2.3.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->