### PR TITLE
fix(ci): retry a failed add-on build once before auto-reverting the push

### DIFF
--- a/.github/workflows/onpush_builder.yaml
+++ b/.github/workflows/onpush_builder.yaml
@@ -285,8 +285,52 @@ jobs:
             echo "${{ matrix.arch }} is not a valid architecture for ${{ matrix.addon }}, skipping build."
           fi
 
+      # A single failing leg here auto-reverts the whole push (revert-on-failure
+      # below), so a transient error inside the build - a truncated download in
+      # a RUN layer, a registry hiccup - silently undoes a perfectly good
+      # version bump. Seen on zoneminder 1.38.4 (run 31678876409): the aarch64
+      # leg died on "curl: (92) HTTP/2 stream 1 was not closed cleanly:
+      # REFUSED_STREAM", the commit was reverted, and a manual re-run of the
+      # identical source then went green. (A lost runner or a cancelled job is
+      # not covered by this - no later step gets to run at all.)
+      #
+      # So: build once tolerantly, and only let a second failure reach the
+      # revert. A genuinely broken add-on fails twice and is still reverted,
+      # one build later. Retrying is unconditional rather than gated on the
+      # log text looking "transient" - BuildKit reformats error strings and
+      # registry/runner failures spell themselves a dozen ways, so classifying
+      # by log text would silently stop reverting real breakage. It is also
+      # cheap: the add-ons that fail deterministically on every push each fail
+      # in 16-34 s.
       - name: Build ${{ matrix.addon }} add-on
+        id: build
         if: steps.info.outputs.build_arch == 'true' && steps.info.outputs.has_dockerfile == 'true'
+        continue-on-error: true
+        uses: home-assistant/builder/actions/build-image@2026.06.0
+        with:
+          arch: ${{ matrix.arch }}
+          cache-gha: "false"
+          cache-gha-scope: ${{ matrix.addon }}-${{ matrix.arch }}
+          context: ./${{ matrix.addon }}
+          file: ${{ steps.info.outputs.dockerfile }}
+          image: ${{ steps.info.outputs.image }}
+          image-tags: |
+            ${{ steps.info.outputs.version }}
+            latest
+          version: ${{ steps.info.outputs.version }}
+          push: "true"
+          cosign: "false"
+          container-registry-password: ${{ secrets.GITHUB_TOKEN }}
+          labels: ${{ steps.info.outputs.labels }}
+          build-args: ${{ steps.info.outputs.build_args }}
+
+      # Keep these inputs identical to the first attempt above - this step is
+      # that attempt, run a second time, and nothing else. There is deliberately
+      # no pause in between: re-running the earlier layers already spaces the
+      # two network windows apart, and a sleep step would only add somewhere
+      # else for the retry to be skipped from.
+      - name: Build ${{ matrix.addon }} add-on (retry after failed attempt)
+        if: steps.build.outcome == 'failure'
         uses: home-assistant/builder/actions/build-image@2026.06.0
         with:
           arch: ${{ matrix.arch }}


### PR DESCRIPTION
## Problem

One failing matrix leg in `Builder` reverts the whole push. That safety net is worth keeping, but
it currently fires on infrastructure noise as readily as on a broken add-on.

Measured case — zoneminder 1.38.4, run
[31678876409](https://github.com/alexbelgium/hassio-addons/actions/runs/31678876409), attempt 1:

- `Build aarch64 zoneminder` failed after 44 s, inside `RUN … /ha_autoapps.sh` (`Dockerfile:66`):

  ```
  curl: (92) HTTP/2 stream 1 was not closed cleanly: REFUSED_STREAM (err 7)
  gzip: stdin: unexpected end of file
  tar: Child returned status 1
  tar: Error is not recoverable: exiting now
  ```

- `Build amd64 zoneminder` succeeded and pushed `1.38.4` + `latest` to GHCR.
- `revert-on-failure` ran 07:45:16 → 07:45:29 and pushed `0ee26fc` reverting the version bump.
- A manual *re-run failed jobs* on the identical source then went fully green — aarch64 built,
  `make-changelog` ran, `revert-on-failure` skipped.

Note the reporting trap: that re-run flips the run's conclusion to `success`, so this incident
does not appear in any run-conclusion statistic. 34 of the last 300 `Builder` runs concluded
`failure`, and zoneminder is not among them.

## Change

The build-image step now runs tolerantly (`continue-on-error: true`, `id: build`) and is repeated
once when the first attempt fails. Only a second failure reaches `revert-on-failure`. The two
`with:` blocks are identical — the retry is the same attempt run again, nothing else — and that is
asserted by parsing the YAML, not by eye.

There is deliberately no pause between the attempts. An earlier draft had a jittered 10–30 s
sleep; re-running the earlier layers already spaces the two network windows apart, and a separate
step is one more place the retry could be skipped from (a step `if:` without a status function
carries an implicit `success()`, so a failed sleep would silently cancel the retry).

Behaviour on a genuinely broken add-on is unchanged apart from timing: it fails twice, the job
goes red, the push is reverted one build later than before.

The retry is unconditional rather than gated on the log text looking transient. BuildKit reformats
error strings and registry/runner failures spell themselves many different ways, so a text
classifier would eventually stop reverting real breakage — a much worse failure than one wasted
build. It is also cheap: the add-ons that fail deterministically on every push (`ente`, `comixed`,
`binance-trading-bot`) each fail in 16–34 s.

Considered and rejected: having a job call the *re-run failed jobs* API and gating the revert on
`github.run_attempt >= 2`. It would also have covered transients outside the docker build
(checkout, `pip install pyyaml`, runner loss), but a job cannot re-run its own still-running
workflow — that needs a separate `workflow_run` controller, and a failed API call there would mean
a broken version sits on master with no revert at all.

## Not verified

- Not exercised in CI. The retry path only runs when a build actually fails, which this PR cannot
  manufacture; this branch's own CI touches no `*/config.*`, so `Builder` will not even run on it.
  `actionlint` is clean and `yamllint` reports only the pre-existing `on:` truthy warning.
- Calling `home-assistant/builder/actions/build-image@2026.06.0` twice in one job is believed
  safe but has not been observed. Checked, from the failed run's own log: each invocation runs
  `docker buildx create --name builder-<fresh uuid>` and its own GHCR login, so the two
  end-of-job cleanups remove two distinct builders rather than colliding. Assumed: that the
  duplicated post-steps cannot themselves fail the job after a successful retry.
- Unchanged and still true: image publication is not transactional. In the zoneminder case amd64
  had already pushed tags before aarch64 failed, and a git revert cannot unpublish them.

## Out of scope (separate defect, worth its own issue)

The revert is all-or-nothing across a push, so a wide change is reverted by an add-on that was
*already* broken before it. Run
[30817794984](https://github.com/alexbelgium/hassio-addons/actions/runs/30817794984) — "Migrate
legacy addon_config maps to app_config" (#2933) — had 170+ green build legs and was reverted
because `ente` and `comixed` failed, as they do on every push. Selectively reverting only the
commits touching failed add-ons is a trap (one commit can touch several add-ons; shared
`.templates/` changes affect add-ons without touching their directories). An explicit quarantine
list for known-broken add-ons, with an owner and an expiry, is the honest guard.

Also confirmed while investigating, no change needed: `lint_config` failures do **not** trigger the
revert. In run 30817794984, 86 lint legs failed and every `build` job still ran, so `needs` sees
that `continue-on-error` job as non-failing — and `failure()` in `revert-on-failure` reads the same
results.

## Rollback

Single commit, single file, one hunk. `git revert 24e9c38` restores the previous behaviour
exactly; there is no state anywhere else to unwind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability by automatically retrying failed builds without an added delay.
  * The initial build failure no longer immediately triggers rollback.
  * Build failures now trigger rollback only after both build attempts fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->