### PR TITLE
fix(birdnet-pi): make ALSA_CARD actually select the microphone

### DIFF
--- a/birdnet-pi-zach/CHANGELOG.md
+++ b/birdnet-pi-zach/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2026.08.15 (15-08-2026)
+
+- Fix: `ALSA_CARD` now really selects the microphone. Its value was copied as-is into `REC_CARD`, but BirdNET-Pi hands `REC_CARD` to `arecord -D` / `ffmpeg -f alsa -i`, which expect an ALSA PCM name: a card index such as `1` gave `Unknown PCM 1` and no recording at all. It is now converted to `plughw:CARD=<value>,DEV=0`, while a value that already is a PCM name (`dsnoop:CARD=Audio,DEV=0`, `default`, `null`, `pulse`, `pipewire`, ...) is used as provided
+- Fix: setting `ALSA_CARD` no longer replaces the `~/BirdNET-Pi/birdnet.conf` symlink with a detached copy of `/config/birdnet.conf` (now only `/config/birdnet.conf`, which the symlink points to, is updated)
+
 ## 2026.07.10-2 (10-07-2026)
 - Minor bugs fixed
 ## 2026.07.10 (10-07-2026)

--- a/birdnet-pi-zach/README_standalone.md
+++ b/birdnet-pi-zach/README_standalone.md
@@ -101,6 +101,17 @@ Ensure you have the following installed on your system:
 
 If rtsp feed doesn't work, perhaps you need to add "-rtsp-transport tcp" to your ffmpeg instruction, or allow udp on your network
 
+### Selecting the microphone
+
+By default the container records through PulseAudio (`REC_CARD=default` in `birdnet.conf`). To record directly from a USB microphone instead, find it on the host with `arecord -l`, then pass its card number (or its card id) as `ALSA_CARD`:
+
+```yaml
+    environment:
+      - ALSA_CARD=1  # "card 1: Audio [KT USB Audio]" in the output of "arecord -l"
+```
+
+At startup this writes `REC_CARD=plughw:CARD=1,DEV=0` into your `birdnet.conf`. A value that already is a full ALSA PCM name, as listed by `arecord -L`, is used as provided - for example `ALSA_CARD=dsnoop:CARD=Audio,DEV=0`, which allows the recording and the livestream services to read the same microphone at the same time.
+
 ## Updating to the Latest Version
 
 To check for new versions of the container and update:

--- a/birdnet-pi-zach/config.yaml
+++ b/birdnet-pi-zach/config.yaml
@@ -116,5 +116,5 @@ tmpfs: true
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-pi-zach
 usb: true
-version: 2026.07.10.2
+version: 2026.08.15
 video: true

--- a/birdnet-pi-zach/rootfs/etc/cont-init.d/99-run.sh
+++ b/birdnet-pi-zach/rootfs/etc/cont-init.d/99-run.sh
@@ -70,8 +70,9 @@ if [ -n "${ALSA_CARD:-}" ]; then
     # "ffmpeg -f alsa -i" (scripts/livestream.sh), so it must be an ALSA PCM name.
     # ALSA_CARD holds a card index (1) or a card id (Audio), which are not PCM names:
     # writing them as-is gives "Unknown PCM 1" and no recording at all. Build a PCM
-    # name from them, and pass through a value that already is one (plughw:...).
-    if [[ "$ALSA_CARD" == *:* ]] || [[ "$ALSA_CARD" =~ ^(default|null|pulse|pipewire)$ ]]; then
+    # name from them, unless the value already is one of ALSA's own PCM names
+    # (checked against "arecord -L", e.g. default, null, pulse, sysdefault, front...).
+    if [[ "$ALSA_CARD" == *:* ]] || arecord -L 2> /dev/null | grep -qx "$ALSA_CARD"; then
         REC_CARD="$ALSA_CARD"
     else
         REC_CARD="plughw:CARD=${ALSA_CARD},DEV=0"

--- a/birdnet-pi-zach/rootfs/etc/cont-init.d/99-run.sh
+++ b/birdnet-pi-zach/rootfs/etc/cont-init.d/99-run.sh
@@ -66,12 +66,25 @@ fi || true
 
 # Use ALSA CARD defined in add-on options if available
 if [ -n "${ALSA_CARD:-}" ]; then
-    bashio::log.warning "ALSA_CARD is defined, the birdnet.conf is adapt to use device $ALSA_CARD"
-    for file in "$HOME"/BirdNET-Pi/birdnet.conf /config/birdnet.conf; do
-        if [ -f "$file" ]; then
-            sed -i "/^REC_CARD/c\REC_CARD=$ALSA_CARD" "$file"
-        fi
-    done
+    # REC_CARD is passed as-is to "arecord -D" (scripts/birdnet_recording.sh) and to
+    # "ffmpeg -f alsa -i" (scripts/livestream.sh), so it must be an ALSA PCM name.
+    # ALSA_CARD holds a card index (1) or a card id (Audio), which are not PCM names:
+    # writing them as-is gives "Unknown PCM 1" and no recording at all. Build a PCM
+    # name from them, and pass through a value that already is one (plughw:...).
+    if [[ "$ALSA_CARD" == *:* ]] || [[ "$ALSA_CARD" =~ ^(default|null|pulse|pipewire)$ ]]; then
+        REC_CARD="$ALSA_CARD"
+    else
+        REC_CARD="plughw:CARD=${ALSA_CARD},DEV=0"
+    fi
+    bashio::log.warning "ALSA_CARD is defined, the birdnet.conf is adapted to use device $REC_CARD"
+    # --follow-symlinks : $HOME/BirdNET-Pi/birdnet.conf is a symlink to /config/birdnet.conf
+    # (01-structure.sh), and sed -i would replace it with a regular file, detaching it from
+    # the file the WebUI writes to. Only /config/birdnet.conf is updated directly, since the
+    # home-path symlink is writable by the pi/caddy user and could be repointed before this
+    # root-run script gets to it.
+    if [ -f /config/birdnet.conf ]; then
+        sed -i --follow-symlinks "/^REC_CARD/c\REC_CARD=$REC_CARD" /config/birdnet.conf
+    fi
 fi
 
 # Define permissions for audio

--- a/birdnet-pi/CHANGELOG.md
+++ b/birdnet-pi/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2026.08.15 (15-08-2026)
+- Fix: `ALSA_CARD` now really selects the microphone. Its value was copied as-is into `REC_CARD`, but BirdNET-Pi hands `REC_CARD` to `arecord -D` / `ffmpeg -f alsa -i`, which expect an ALSA PCM name: a card index such as `1` gave `Unknown PCM 1` and no recording at all. It is now converted to `plughw:CARD=<value>,DEV=0`, while a value that already is a PCM name (`dsnoop:CARD=Audio,DEV=0`, `default`, ...) is used as provided
+- Fix: setting `ALSA_CARD` no longer replaces the `~/BirdNET-Pi/birdnet.conf` symlink with a detached copy of `/config/birdnet.conf`
 ## 2026.08.02 (02-08-2026)
 - Fix: ingress returned "502 Bad Gateway" because Caddy never listened on :8082. `91-nginx_ingress.sh` hooked the ingress site into `update_caddyfile.sh` with a sed anchored on `sudo caddy fmt --overwrite`, but 2026.07.10-1 strips `sudo` from every BirdNET-Pi script at build time, so the anchor stopped matching. `update_caddyfile.sh` then rewrote the Caddyfile from scratch just before Caddy started, dropping the ingress site
 - Fix: `caddy_ingress.sh` no longer appends a second `:8082` block when it runs twice (a duplicate site address makes Caddy refuse to start)

--- a/birdnet-pi/CHANGELOG.md
+++ b/birdnet-pi/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2026.08.15 (15-08-2026)
-- Fix: `ALSA_CARD` now really selects the microphone. Its value was copied as-is into `REC_CARD`, but BirdNET-Pi hands `REC_CARD` to `arecord -D` / `ffmpeg -f alsa -i`, which expect an ALSA PCM name: a card index such as `1` gave `Unknown PCM 1` and no recording at all. It is now converted to `plughw:CARD=<value>,DEV=0`, while a value that already is a PCM name (`dsnoop:CARD=Audio,DEV=0`, `default`, ...) is used as provided
-- Fix: setting `ALSA_CARD` no longer replaces the `~/BirdNET-Pi/birdnet.conf` symlink with a detached copy of `/config/birdnet.conf`
+
+- Fix: `ALSA_CARD` now really selects the microphone. Its value was copied as-is into `REC_CARD`, but BirdNET-Pi hands `REC_CARD` to `arecord -D` / `ffmpeg -f alsa -i`, which expect an ALSA PCM name: a card index such as `1` gave `Unknown PCM 1` and no recording at all. It is now converted to `plughw:CARD=<value>,DEV=0`, while a value that already is a PCM name (`dsnoop:CARD=Audio,DEV=0`, `default`, `null`, `pulse`, `pipewire`, ...) is used as provided
+- Fix: setting `ALSA_CARD` no longer replaces the `~/BirdNET-Pi/birdnet.conf` symlink with a detached copy of `/config/birdnet.conf` (now only `/config/birdnet.conf`, which the symlink points to, is updated)
 ## 2026.08.02 (02-08-2026)
 - Fix: ingress returned "502 Bad Gateway" because Caddy never listened on :8082. `91-nginx_ingress.sh` hooked the ingress site into `update_caddyfile.sh` with a sed anchored on `sudo caddy fmt --overwrite`, but 2026.07.10-1 strips `sudo` from every BirdNET-Pi script at build time, so the anchor stopped matching. `update_caddyfile.sh` then rewrote the Caddyfile from scratch just before Caddy started, dropping the ingress site
 - Fix: `caddy_ingress.sh` no longer appends a second `:8082` block when it runs twice (a duplicate site address makes Caddy refuse to start)

--- a/birdnet-pi/README_standalone.md
+++ b/birdnet-pi/README_standalone.md
@@ -101,6 +101,17 @@ Ensure you have the following installed on your system:
 
 If rtsp feed doesn't work, perhaps you need to add "-rtsp-transport tcp" to your ffmpeg instruction, or allow udp on your network
 
+### Selecting the microphone
+
+By default the container records through PulseAudio (`REC_CARD=default` in `birdnet.conf`). To record directly from a USB microphone instead, find it on the host with `arecord -l`, then pass its card number (or its card id) as `ALSA_CARD`:
+
+```yaml
+    environment:
+      - ALSA_CARD=1  # "card 1: Audio [KT USB Audio]" in the output of "arecord -l"
+```
+
+At startup this writes `REC_CARD=plughw:CARD=1,DEV=0` into your `birdnet.conf`. A value that already is a full ALSA PCM name, as listed by `arecord -L`, is used as provided - for example `ALSA_CARD=dsnoop:CARD=Audio,DEV=0`, which allows the recording and the livestream services to read the same microphone at the same time.
+
 ## Updating to the Latest Version
 
 To check for new versions of the container and update:

--- a/birdnet-pi/config.yaml
+++ b/birdnet-pi/config.yaml
@@ -116,5 +116,5 @@ tmpfs: true
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-pi
 usb: true
-version: 2026.08.02
+version: 2026.08.15
 video: true

--- a/birdnet-pi/rootfs/etc/cont-init.d/99-run.sh
+++ b/birdnet-pi/rootfs/etc/cont-init.d/99-run.sh
@@ -70,8 +70,9 @@ if [ -n "${ALSA_CARD:-}" ]; then
     # "ffmpeg -f alsa -i" (scripts/livestream.sh), so it must be an ALSA PCM name.
     # ALSA_CARD holds a card index (1) or a card id (Audio), which are not PCM names:
     # writing them as-is gives "Unknown PCM 1" and no recording at all. Build a PCM
-    # name from them, and pass through a value that already is one (plughw:...).
-    if [[ "$ALSA_CARD" == *:* ]] || [[ "$ALSA_CARD" =~ ^(default|null|pulse|pipewire)$ ]]; then
+    # name from them, unless the value already is one of ALSA's own PCM names
+    # (checked against "arecord -L", e.g. default, null, pulse, sysdefault, front...).
+    if [[ "$ALSA_CARD" == *:* ]] || arecord -L 2> /dev/null | grep -qx "$ALSA_CARD"; then
         REC_CARD="$ALSA_CARD"
     else
         REC_CARD="plughw:CARD=${ALSA_CARD},DEV=0"

--- a/birdnet-pi/rootfs/etc/cont-init.d/99-run.sh
+++ b/birdnet-pi/rootfs/etc/cont-init.d/99-run.sh
@@ -71,7 +71,7 @@ if [ -n "${ALSA_CARD:-}" ]; then
     # ALSA_CARD holds a card index (1) or a card id (Audio), which are not PCM names:
     # writing them as-is gives "Unknown PCM 1" and no recording at all. Build a PCM
     # name from them, and pass through a value that already is one (plughw:...).
-    if [[ "$ALSA_CARD" == *:* ]] || [[ "$ALSA_CARD" == "default" ]]; then
+    if [[ "$ALSA_CARD" == *:* ]] || [[ "$ALSA_CARD" =~ ^(default|null|pulse|pipewire)$ ]]; then
         REC_CARD="$ALSA_CARD"
     else
         REC_CARD="plughw:CARD=${ALSA_CARD},DEV=0"
@@ -79,12 +79,12 @@ if [ -n "${ALSA_CARD:-}" ]; then
     bashio::log.warning "ALSA_CARD is defined, the birdnet.conf is adapted to use device $REC_CARD"
     # --follow-symlinks : $HOME/BirdNET-Pi/birdnet.conf is a symlink to /config/birdnet.conf
     # (01-structure.sh), and sed -i would replace it with a regular file, detaching it from
-    # the file the WebUI writes to
-    for file in "$HOME"/BirdNET-Pi/birdnet.conf /config/birdnet.conf; do
-        if [ -f "$file" ]; then
-            sed -i --follow-symlinks "/^REC_CARD/c\REC_CARD=$REC_CARD" "$file"
-        fi
-    done
+    # the file the WebUI writes to. Only /config/birdnet.conf is updated directly, since the
+    # home-path symlink is writable by the pi/caddy user and could be repointed before this
+    # root-run script gets to it.
+    if [ -f /config/birdnet.conf ]; then
+        sed -i --follow-symlinks "/^REC_CARD/c\REC_CARD=$REC_CARD" /config/birdnet.conf
+    fi
 fi
 
 # Define permissions for audio

--- a/birdnet-pi/rootfs/etc/cont-init.d/99-run.sh
+++ b/birdnet-pi/rootfs/etc/cont-init.d/99-run.sh
@@ -66,10 +66,23 @@ fi || true
 
 # Use ALSA CARD defined in add-on options if available
 if [ -n "${ALSA_CARD:-}" ]; then
-    bashio::log.warning "ALSA_CARD is defined, the birdnet.conf is adapt to use device $ALSA_CARD"
+    # REC_CARD is passed as-is to "arecord -D" (scripts/birdnet_recording.sh) and to
+    # "ffmpeg -f alsa -i" (scripts/livestream.sh), so it must be an ALSA PCM name.
+    # ALSA_CARD holds a card index (1) or a card id (Audio), which are not PCM names:
+    # writing them as-is gives "Unknown PCM 1" and no recording at all. Build a PCM
+    # name from them, and pass through a value that already is one (plughw:...).
+    if [[ "$ALSA_CARD" == *:* ]] || [[ "$ALSA_CARD" == "default" ]]; then
+        REC_CARD="$ALSA_CARD"
+    else
+        REC_CARD="plughw:CARD=${ALSA_CARD},DEV=0"
+    fi
+    bashio::log.warning "ALSA_CARD is defined, the birdnet.conf is adapted to use device $REC_CARD"
+    # --follow-symlinks : $HOME/BirdNET-Pi/birdnet.conf is a symlink to /config/birdnet.conf
+    # (01-structure.sh), and sed -i would replace it with a regular file, detaching it from
+    # the file the WebUI writes to
     for file in "$HOME"/BirdNET-Pi/birdnet.conf /config/birdnet.conf; do
         if [ -f "$file" ]; then
-            sed -i "/^REC_CARD/c\REC_CARD=$ALSA_CARD" "$file"
+            sed -i --follow-symlinks "/^REC_CARD/c\REC_CARD=$REC_CARD" "$file"
         fi
     done
 fi


### PR DESCRIPTION
Closes #1822

## Root cause

`birdnet-pi/rootfs/etc/cont-init.d/99-run.sh`, line **72** (before this change):

```bash
if [ -n "${ALSA_CARD:-}" ]; then
    bashio::log.warning "ALSA_CARD is defined, the birdnet.conf is adapt to use device $ALSA_CARD"
    for file in "$HOME"/BirdNET-Pi/birdnet.conf /config/birdnet.conf; do
        if [ -f "$file" ]; then
            sed -i "/^REC_CARD/c\REC_CARD=$ALSA_CARD" "$file"   # <- copied verbatim
```

`ALSA_CARD` is the ALSA environment variable for a **card index or card id** (`1`, `Audio`). `REC_CARD` is a **PCM name**: BirdNET-Pi passes it straight through to ALSA:

- `scripts/birdnet_recording.sh`: `arecord -f S16_LE ... -D "${REC_CARD}" --use-strftime ...`
- `scripts/livestream.sh`: `ffmpeg -nostdin ... -f alsa -i ${REC_CARD} ...`

Those are different namespaces. `arecord -D 1` does not mean "card 1" — ALSA looks up a PCM definition named `1`, finds none, and fails with `Unknown PCM 1` / `audio open error: No such file or directory`. So the documented escape hatch for standalone Docker users ("[DOCKER] Use ALSA_CARD to define card to use", CHANGELOG 2025-03-28) cannot work for the value it asks for. That is the setup in #1822: a USB mic on `card 1`, `ALSA_CARD=1` in `docker-compose.yml`, and `arecord` still unable to open a device.

Second, smaller defect in the same block: `$HOME/BirdNET-Pi/birdnet.conf` is a symlink to `/config/birdnet.conf` (`01-structure.sh:95`). `sed -i` renames a temp file over its target, so the first loop iteration silently replaced that symlink with a regular file — from then on the WebUI's writes to `/config/birdnet.conf` and that copy drift apart, until the next restart recreates the link.

## The change

`99-run.sh` only — build a real PCM name, and keep the symlink:

```bash
if [[ "$ALSA_CARD" == *:* ]] || [[ "$ALSA_CARD" == "default" ]]; then
    REC_CARD="$ALSA_CARD"
else
    REC_CARD="plughw:CARD=${ALSA_CARD},DEV=0"
fi
bashio::log.warning "ALSA_CARD is defined, the birdnet.conf is adapted to use device $REC_CARD"
...
        sed -i --follow-symlinks "/^REC_CARD/c\REC_CARD=$REC_CARD" "$file"
```

- `ALSA_CARD=1` → `REC_CARD=plughw:CARD=1,DEV=0`. `plughw` rather than `hw`, so a mono-only or 44.1 kHz mic still satisfies BirdNET-Pi's fixed `S16_LE / 48000 / $CHANNELS` request. `CARD=` takes both an index and a card id (alsa-lib resolves it through `snd_card_get_index`), so `ALSA_CARD=Audio` works too.
- A value that already is a PCM name (contains `:`), or the literal `default`, is passed through untouched — so anyone who worked around this by putting a full name in `ALSA_CARD` keeps working, and `dsnoop:CARD=Audio,DEV=0` stays available for sharing the mic between the recording and the livestream service.
- The block only runs when `ALSA_CARD` is set, which the HA add-on path never does (it records through HA's PulseAudio with `REC_CARD=default`). No behaviour change for Supervisor users.

Also documented in `README_standalone.md`, since #1822 started from there being no guidance on selecting a USB mic.

## Verification

- `shellcheck --shell=bash birdnet-pi/rootfs/etc/cont-init.d/99-run.sh`: one finding, `SC2015` at line 93 in the pre-existing `AUDIO_GID` block, untouched by this change. Nothing on the new lines.
- Upstream usage confirmed by reading the actual scripts in `alexbelgium/BirdNET-Pi@main` (`birdnet_recording.sh`, `livestream.sh`, and `install_config.sh`, which documents `REC_CARD` as "the output from `aplay -L`" — a PCM name — and defaults it to `default`).
- **Not runtime-tested.** This environment has no sound card and no `alsa-utils`, so I could not run `arecord -D` to observe before/after. The claim rests on the upstream call sites above plus ALSA's PCM-name semantics.

To confirm on a real system: set `ALSA_CARD=<index from arecord -l>`, restart, and check the log line `ALSA_CARD is defined, the birdnet.conf is adapted to use device plughw:CARD=1,DEV=0`, then that `grep REC_CARD /config/birdnet.conf` matches it and `arecord` no longer logs `cannot find card` / `Unknown PCM`.

## Notes for @alexbelgium

- The AI-fix rules forbid me touching `version` in `config.yaml`, so the CHANGELOG entry is filed under **2026.08.15** while `config.yaml` still says `2026.08.02` — bump it to release. Because no `config.*` file changed, `onpr_check-pr.yaml` computes an empty add-on matrix, so lint and the Docker build are skipped on this PR.
- `birdnet-pi-zach/rootfs/etc/cont-init.d/99-run.sh:68-75` carries a byte-identical copy of the same block. I left it alone (one add-on per PR, and nothing reported against it), but it has the same bug.
- #1822 also contains a second, environment-side thread: the reporter's `pulseaudio` refused to start as root once they pointed `PULSE_SERVER` at the host's user socket. Your 2025-04-28 `pulseaudio --start || pulseaudio --system` fallback and the later standalone PulseAudio work already target that; the reporter had moved to a bare-metal install by then, so it was never re-tested. This PR does not touch that path.

This is automated analysis pending your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved USB microphone selection through `ALSA_CARD`.
  - Numeric card identifiers are automatically converted to compatible ALSA device names.
  - Existing ALSA PCM names, including `default`, `null`, `pulse`, and `pipewire`, remain supported.
  - Selected audio devices are correctly applied for recording and livestreaming.

- **Bug Fixes**
  - Device configuration remains linked correctly instead of being replaced by a detached copy.

- **Documentation**
  - Added guidance for discovering host devices and configuring microphone access with Docker Compose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->