### PR TITLE
fix(birdnet-pi-zach): make ALSA_CARD actually select the microphone

### DIFF
--- a/birdnet-pi-zach/CHANGELOG.md
+++ b/birdnet-pi-zach/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 2026.08.15 (15-08-2026)
+
 - Fix: `ALSA_CARD` now really selects the microphone. Its value was copied as-is into `REC_CARD`, but BirdNET-Pi hands `REC_CARD` to `arecord -D` / `ffmpeg -f alsa -i`, which expect an ALSA PCM name: a card index such as `1` gave `Unknown PCM 1` and no recording at all. It is now converted to `plughw:CARD=<value>,DEV=0`, while a value that already is a PCM name (`dsnoop:CARD=Audio,DEV=0`, `default`, `null`, `pulse`, `pipewire`, ...) is used as provided
 - Fix: writing `REC_CARD` no longer detaches `birdnet.conf` from `/config`. `sed -i` replaced the `$HOME/BirdNET-Pi/birdnet.conf` symlink with a regular file, so later edits from the WebUI went to a different file than the one the add-on had written; it now edits `/config/birdnet.conf` with `--follow-symlinks`
+
 ## 2026.07.10-2 (10-07-2026)
 - Minor bugs fixed
 ## 2026.07.10 (10-07-2026)

--- a/birdnet-pi-zach/CHANGELOG.md
+++ b/birdnet-pi-zach/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2026.08.15 (15-08-2026)
+- Fix: `ALSA_CARD` now really selects the microphone. Its value was copied as-is into `REC_CARD`, but BirdNET-Pi hands `REC_CARD` to `arecord -D` / `ffmpeg -f alsa -i`, which expect an ALSA PCM name: a card index such as `1` gave `Unknown PCM 1` and no recording at all. It is now converted to `plughw:CARD=<value>,DEV=0`, while a value that already is a PCM name (`dsnoop:CARD=Audio,DEV=0`, `default`, `null`, `pulse`, `pipewire`, ...) is used as provided
+- Fix: writing `REC_CARD` no longer detaches `birdnet.conf` from `/config`. `sed -i` replaced the `$HOME/BirdNET-Pi/birdnet.conf` symlink with a regular file, so later edits from the WebUI went to a different file than the one the add-on had written; it now edits `/config/birdnet.conf` with `--follow-symlinks`
 ## 2026.07.10-2 (10-07-2026)
 - Minor bugs fixed
 ## 2026.07.10 (10-07-2026)

--- a/birdnet-pi-zach/config.yaml
+++ b/birdnet-pi-zach/config.yaml
@@ -116,5 +116,5 @@ tmpfs: true
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-pi-zach
 usb: true
-version: 2026.07.10.2
+version: 2026.08.15
 video: true

--- a/birdnet-pi-zach/rootfs/etc/cont-init.d/99-run.sh
+++ b/birdnet-pi-zach/rootfs/etc/cont-init.d/99-run.sh
@@ -66,12 +66,25 @@ fi || true
 
 # Use ALSA CARD defined in add-on options if available
 if [ -n "${ALSA_CARD:-}" ]; then
-    bashio::log.warning "ALSA_CARD is defined, the birdnet.conf is adapt to use device $ALSA_CARD"
-    for file in "$HOME"/BirdNET-Pi/birdnet.conf /config/birdnet.conf; do
-        if [ -f "$file" ]; then
-            sed -i "/^REC_CARD/c\REC_CARD=$ALSA_CARD" "$file"
-        fi
-    done
+    # REC_CARD is passed as-is to "arecord -D" (scripts/birdnet_recording.sh) and to
+    # "ffmpeg -f alsa -i" (scripts/livestream.sh), so it must be an ALSA PCM name.
+    # ALSA_CARD holds a card index (1) or a card id (Audio), which are not PCM names:
+    # writing them as-is gives "Unknown PCM 1" and no recording at all. Build a PCM
+    # name from them, and pass through a value that already is one (plughw:...).
+    if [[ "$ALSA_CARD" == *:* ]] || [[ "$ALSA_CARD" =~ ^(default|null|pulse|pipewire)$ ]]; then
+        REC_CARD="$ALSA_CARD"
+    else
+        REC_CARD="plughw:CARD=${ALSA_CARD},DEV=0"
+    fi
+    bashio::log.warning "ALSA_CARD is defined, the birdnet.conf is adapted to use device $REC_CARD"
+    # --follow-symlinks : $HOME/BirdNET-Pi/birdnet.conf is a symlink to /config/birdnet.conf
+    # (01-structure.sh), and sed -i would replace it with a regular file, detaching it from
+    # the file the WebUI writes to. Only /config/birdnet.conf is updated directly, since the
+    # home-path symlink is writable by the pi/caddy user and could be repointed before this
+    # root-run script gets to it.
+    if [ -f /config/birdnet.conf ]; then
+        sed -i --follow-symlinks "/^REC_CARD/c\REC_CARD=$REC_CARD" /config/birdnet.conf
+    fi
 fi
 
 # Define permissions for audio


### PR DESCRIPTION
Ports the `ALSA_CARD` fix from #2972 to the sibling add-on, which carries the identical defect.

## Why this is an exact port, not an adaptation

`birdnet-pi-zach` wraps the [zach7036 BirdNET-Pi fork](https://github.com/zach7036/BirdNET-Pi-Enhanced-Version), but the add-on layer is shared:

- `99-run.sh` was **byte-identical** to `birdnet-pi`'s before #2972 (`diff` against `origin/master:birdnet-pi/...` returns nothing)
- `01-structure.sh` is **still byte-identical**, so the symlink premise the fix depends on holds unchanged
- the result of this patch is **byte-identical** to the fixed file on `ai-fix/birdnet-pi-1822`

So there is no behavioural guesswork: the same code had the same bug, and now has the same fix.

## The bug

`ALSA_CARD` was copied straight into `REC_CARD`, but BirdNET-Pi hands `REC_CARD` to `arecord -D` and `ffmpeg -f alsa -i`, which expect an ALSA **PCM name**. A card index like `1` or an id like `Audio` is not one — it produces `Unknown PCM 1` and nothing records at all. It is now converted to `plughw:CARD=<value>,DEV=0`, while a value that already is a PCM name (`dsnoop:CARD=Audio,DEV=0`, `default`, `null`, `pulse`, `pipewire`) is passed through untouched.

Second defect in the same block: `sed -i` **replaces a symlink with a regular file**. `01-structure.sh` links `$HOME/BirdNET-Pi/birdnet.conf` -> `/config/birdnet.conf` (same `CONFIG_FILES` loop, confirmed present here), so the old code detached the config from the file the WebUI writes to. It now edits `/config/birdnet.conf` directly with `--follow-symlinks`.

## Version

`2026.07.10.2` -> `2026.08.15`, matching the new CHANGELOG heading.

Not a `.N` counter increment: this add-on's `updater.json` has an empty `upstream_version` and is `paused`, so there is no upstream prefix to measure a counter against. That is the "leave the counter alone, a human decides" case, and the decision here follows the family's date convention — the same one `birdnet-pi` uses, where every version lines up with a dated CHANGELOG heading.

The bump is what makes the fix real: Supervisor only offers a rebuild when `version` changes, so without it this would merge and the add-on would keep running the old image with `ALSA_CARD` still broken.

## Verification

**Verified** — the patched file is byte-identical to the fixed `birdnet-pi` version; `bash -n` parses; `2026.08.15 > 2026.07.10.2` under component-wise comparison, so Supervisor sees it as newer; `config.yaml` parses and `slug` is unchanged.

**Checked** — `shellcheck` reports only two **pre-existing** `SC2015` warnings in the unrelated `AUDIO_GID` block; both are present on `master` and deliberately untouched. The diff is a single hunk confined to the `ALSA_CARD` block.

**Not verified** — the runtime behaviour on real hardware. I have no BirdNET-Pi with a USB microphone to exercise `arecord`, and CI only builds the image. The reasoning is inherited from #2972, where the same change is under review against the original report (#1822).

## Separate PR on purpose

Kept off #2972 rather than appended to it: the repo's own fix rules are one add-on per branch, one branch per pull request, and #2972 is already in review — widening its scope mid-review would surprise its reviewers and mean a failure in either add-on blocks both. Happy to squash them together if you would rather have one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ALSA microphone selection by supporting card indices, IDs, and existing PCM device names.
  * Ensured configuration updates correctly follow symlinks and modify the active configuration file.

* **Chores**
  * Updated the add-on version to `2026.08.15`.
  * Documented the fixes in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->