### PR TITLE
fix(seerr): add trailing slash to ingress root-link rewrites (#2975)

### DIFF
--- a/seerr/CHANGELOG.md
+++ b/seerr/CHANGELOG.md
@@ -1,4 +1,8 @@
  
+## 3.4.1.1 (2026-08-16)
+
+- Fixed `404: Not Found` when clicking **Discover** in the sidebar through ingress (#2975). Seerr's Discover link points at `/`, which nginx rewrote to the ingress entry without a trailing slash; Home Assistant only routes ingress on `/api/hassio_ingress/<token>/…`, so the request was rejected by Home Assistant before reaching the add-on. Only ingress was affected; the directly published port 5055 always worked.
+
 ## 3.4.1 (2026-08-01)
 - Update to latest version from seerr-team/seerr (changelog : https://github.com/seerr-team/seerr/releases)
 ## 3.3.0.1 (2026-07-28)

--- a/seerr/config.yaml
+++ b/seerr/config.yaml
@@ -96,4 +96,4 @@ schema:
 slug: seerr
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/seerr
-version: "3.4.1"
+version: "3.4.1.1"

--- a/seerr/rootfs/etc/nginx/servers/ingress.conf
+++ b/seerr/rootfs/etc/nginx/servers/ingress.conf
@@ -46,9 +46,14 @@ server {
         # Do not rewrite every response type blindly.
         sub_filter_types text/html application/javascript text/javascript application/json;
 
-        sub_filter 'href="/"' 'href="$app"';
+        # The trailing slash is required: Home Assistant routes ingress on
+        # "/api/hassio_ingress/{token}/{path:.*}", so the bare entry without it
+        # matches no route and Home Assistant answers its own plain-text
+        # "404: Not Found" before the request ever reaches this add-on. Seerr's
+        # Discover link is href="/", so without the slash every click on it 404s.
+        sub_filter 'href="/"' 'href="$app/"';
         sub_filter 'href="/login"' 'href="$app/login"';
-        sub_filter 'href:"/"' 'href:"$app"';
+        sub_filter 'href:"/"' 'href:"$app/"';
         sub_filter '\/_next' '%%ingress_entry_escaped%%\/_next';
         sub_filter '/_next' '$app/_next';
         sub_filter '/api/v1' '$app/api/v1';


### PR DESCRIPTION
## Root cause

`seerr/rootfs/etc/nginx/servers/ingress.conf:49` (and the JS-bundle variant on line 51) rewrote root-relative links to the ingress entry **without a trailing slash**:

```nginx
sub_filter 'href="/"' 'href="$app"';
sub_filter 'href:"/"' 'href:"$app"';
```

`$app` is `bashio::addon.ingress_entry`, i.e. `/api/hassio_ingress/<token>` — no trailing slash. Home Assistant registers its ingress view as

```python
url = "/api/hassio_ingress/{token}/{path:.*}"
```

(`homeassistant/components/hassio/ingress.py`), so a URL that stops at the token matches no route at all and aiohttp answers Home Assistant's own plain-text 404 — `Content-Type: text/plain`, `X-Content-Type-Options: nosniff`, body `404: Not Found`, exactly what the reporter captured in #2975. The request never reaches this add-on, which is why nothing appears in the add-on log.

Seerr's **Discover** sidebar entry is `href="/"`, so it was the one link that hit this: every other nav item has a real path and was rewritten correctly. That matches the report exactly — the failing URL was `/api/hassio_ingress/<token>` with nothing after the token, and port 5055 (which bypasses ingress) was never affected.

## The change

Append the slash on the two rewrites that produce a bare `$app`, so the link becomes `/api/hassio_ingress/<token>/`, which does match the route. This is what the other ingress-wrapped add-ons in this repo already do (`autobrr`, `mealie`, `maintainerr`, `birdnet-pipy` all emit `%%ingress_entry%%/`).

The remaining `$app` uses are unaffected: `proxy_redirect ^ $app` prefixes a `Location` that already starts with `/`, and the other `sub_filter`s all append an explicit path (`$app/_next`, `$app/api/v1`, …).

- `seerr/rootfs/etc/nginx/servers/ingress.conf` — the two rewrites, plus a comment recording why the slash matters
- `seerr/config.yaml` — `3.4.1` → `3.4.1.1` (local patch counter; `updater.json`'s `upstream_version` is `3.4.1`, so this appends rather than increments, and no upstream-owned field is touched)
- `seerr/CHANGELOG.md` — entry

## Verification

- Confirmed the 404 comes from Home Assistant, not this add-on: the response headers and `404: Not Found` body in the issue are aiohttp's default, and the route pattern above cannot match a slash-less entry.
- Confirmed no other rewrite in the file emits a bare `$app`, and that `sub_filter 'href="/"'` matches the literal closing quote, so `href="/login"` and friends are untouched.
- **Not verified at runtime**: the sandbox this ran in does not permit starting nginx, so the sub_filter output was reasoned about statically rather than exercised. The CI Docker build validates the image; the behavioural check is one click on **Discover** in the sidebar after the rebuild.

Closes #2975

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Discover links accessed through Home Assistant ingress returning a `404 Not Found` error.
  * Updated routed links to correctly include the required trailing slash.

* **Chores**
  * Updated the Seerr add-on version to `3.4.1.1`.
  * Added a changelog entry documenting the ingress fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->