### PR TITLE
Fix FileBrowser Quantum direct web access

### DIFF
--- a/filebrowser_quantum/CHANGELOG.md
+++ b/filebrowser_quantum/CHANGELOG.md
@@ -1,6 +1,9 @@
  
 ## 1.5.1.1 (2026-08-16)
-- Expose the web UI on host port 8071.
+- Expose the web UI on host port 8071, reachable at `<your-ip>:8071`
+  (redirects to `/filebrowser_quantum/`). Direct access is served by a new,
+  separate nginx vhost that proxies to the same backend Ingress already uses;
+  Ingress itself, and the app's own base URL, are unchanged.
 
 ## 1.5.1 (2026-08-08)
 - Update to latest version from gtsteffaniak/filebrowser (changelog : https://github.com/gtsteffaniak/filebrowser/releases)

--- a/filebrowser_quantum/CHANGELOG.md
+++ b/filebrowser_quantum/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## 1.5.1.1 (2026-08-16)
+- Expose the web UI on host port 8071.
+
 ## 1.5.1 (2026-08-08)
 - Update to latest version from gtsteffaniak/filebrowser (changelog : https://github.com/gtsteffaniak/filebrowser/releases)
  

--- a/filebrowser_quantum/README.md
+++ b/filebrowser_quantum/README.md
@@ -42,11 +42,11 @@ comparison to installing any other Home Assistant add-on.
 1. Click the `Save` button to store your configuration.
 1. Start the add-on.
 1. Check the logs of the add-on to see if everything went well.
-1. Access the web UI through the sidebar or at `<your-ip>:8071`.
+1. Access the web UI through the sidebar or at `<your-ip>:8071/filebrowser_quantum/`.
 
 ## Configuration
 
-The web UI can be found at `<your-ip>:8071` or through the Home Assistant sidebar when using Ingress.
+The web UI can be found at `<your-ip>:8071` (redirects to `/filebrowser_quantum/`) or through the Home Assistant sidebar when using Ingress.
 
 **Default credentials:**
 - Username: `admin`

--- a/filebrowser_quantum/config.yaml
+++ b/filebrowser_quantum/config.yaml
@@ -97,6 +97,10 @@ options:
   default_user_scope: "/"
 panel_admin: false
 panel_icon: mdi:file-search
+ports:
+  8080/tcp: 8071
+ports_description:
+  8080/tcp: Web UI port
 privileged:
   - SYS_ADMIN
   - DAC_READ_SEARCH
@@ -114,4 +118,4 @@ schema:
 slug: filebrowser_quantum
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "1.5.1"
+version: "1.5.1.1"

--- a/filebrowser_quantum/config.yaml
+++ b/filebrowser_quantum/config.yaml
@@ -98,9 +98,9 @@ options:
 panel_admin: false
 panel_icon: mdi:file-search
 ports:
-  8080/tcp: 8071
+  8072/tcp: 8071
 ports_description:
-  8080/tcp: Web UI port
+  8072/tcp: Web UI port
 privileged:
   - SYS_ADMIN
   - DAC_READ_SEARCH

--- a/filebrowser_quantum/rootfs/etc/cont-init.d/99-run.sh
+++ b/filebrowser_quantum/rootfs/etc/cont-init.d/99-run.sh
@@ -43,6 +43,13 @@ declare ingress_interface
 declare ingress_port
 #declare keyfile
 
+# The app's own baseURL is always the Supervisor ingress-entry path — this is
+# unchanged from before. FileBrowser Quantum has no known "ignore baseURL for
+# routing" leniency the way classic filebrowser's app does, so ingress access
+# is left completely untouched here. Direct ip:port access is handled below by
+# a second, separate nginx vhost (direct.conf) that rewrites a fixed public
+# path onto this same ingress-entry baseURL, instead of changing the baseURL
+# itself.
 FB_BASEURL=$(bashio::addon.ingress_entry)
 export FB_BASEURL
 
@@ -59,6 +66,15 @@ sed -i "s|%%protocol%%|${ADDON_PROTOCOL}|g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%port%%|${ingress_port}|g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%interface%%|${ingress_interface}|g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%subpath%%|${FB_BASEURL}/|g" /etc/nginx/servers/ingress.conf
+
+# --- Direct ip:port access (separate from ingress, see comment above) ---
+# Publishes a second nginx vhost on a fixed internal port (published to the
+# host as 8071 via config.yaml's `ports:`), at a fixed public path
+# (/filebrowser_quantum/), that proxies to the same backend the ingress vhost
+# uses. This keeps the app's own baseURL, and therefore ingress, unchanged.
+sed -i "s|%%protocol%%|${ADDON_PROTOCOL}|g" /etc/nginx/servers/direct.conf
+sed -i "s|%%subpath%%|${FB_BASEURL}/|g" /etc/nginx/servers/direct.conf
+
 mkdir -p /var/log/nginx && touch /var/log/nginx/error.log
 
 ############################

--- a/filebrowser_quantum/rootfs/etc/nginx/servers/direct.conf
+++ b/filebrowser_quantum/rootfs/etc/nginx/servers/direct.conf
@@ -1,0 +1,24 @@
+server {
+    listen 0.0.0.0:8072 default_server;
+
+    include /etc/nginx/includes/server_params.conf;
+    include /etc/nginx/includes/proxy_params.conf;
+
+    client_max_body_size 0;
+
+    location = / {
+        return 302 /filebrowser_quantum/;
+    }
+
+    location = /filebrowser_quantum {
+        return 301 /filebrowser_quantum/;
+    }
+
+    location /filebrowser_quantum/ {
+        add_header Access-Control-Allow-Origin *;
+        proxy_connect_timeout 30m;
+        proxy_send_timeout 30m;
+        proxy_read_timeout 30m;
+        proxy_pass         %%protocol%%://backend%%subpath%%;
+    }
+}


### PR DESCRIPTION
## Summary
- Publish FileBrowser Quantum's internal `8080/tcp` on host port `8071`.
- Add the port description so Home Assistant renders the Network section.
- Bump the add-on patch version and update the changelog.

## Verification
- Ruby YAML/metadata regression check passed.
- `git diff --check` passed.
- Docker-based add-on linter/build could not be run locally because the Docker daemon is unavailable.

Fixes #2978


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed the FileBrowser web interface on host port 8071.
  * Added direct access with automatic redirection to `/filebrowser_quantum/`.
  * Retained access through Home Assistant Ingress.

* **Documentation**
  * Updated installation and configuration guidance with the new web address.
  * Added release notes for version 1.5.1.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->