### PR TITLE
fix(immich): URI-encode DB credentials so passwords with special characters work

### DIFF
--- a/immich/CHANGELOG.md
+++ b/immich/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## 3.1.0.1 (2026-08-17)
+- Fix `password authentication failed for user` when `DB_PASSWORD` contains special characters. Passwords are now URI-encoded before being used in the psql connection string, and SQL-escaped before being used in `CREATE`/`ALTER USER` statements
+ 
 ## 3.1.0 (2026-08-01)
 - Update to latest version from immich-app/immich (changelog : https://github.com/immich-app/immich/releases)
  

--- a/immich/config.yaml
+++ b/immich/config.yaml
@@ -141,6 +141,6 @@ slug: immich
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "3.1.0"
+version: "3.1.0.1"
 video: true
 webui: http://[HOST]:[PORT:8080]

--- a/immich/rootfs/etc/cont-init.d/99-run.sh
+++ b/immich/rootfs/etc/cont-init.d/99-run.sh
@@ -98,10 +98,11 @@ setup_root_user() {
     fi
 
     # Check if the root user exists.
-    if ! psql "postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOSTNAME}:${DB_PORT}" -tAc "SELECT 1 FROM pg_roles WHERE rolname='root'" | grep -q 1; then
+    if ! psql "postgres://${DB_USERNAME_URI}:${DB_PASSWORD_URI}@${DB_HOSTNAME}:${DB_PORT}" -tAc "SELECT 1 FROM pg_roles WHERE rolname='root'" | grep -q 1; then
         bashio::log.info "Root user does not exist. Creating root user with DB_ROOT_PASSWORD..."
-        psql "postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOSTNAME}:${DB_PORT}" << EOF
-CREATE ROLE root WITH LOGIN SUPERUSER CREATEDB CREATEROLE PASSWORD '${DB_ROOT_PASSWORD}';
+        local root_password_sql="${DB_ROOT_PASSWORD//\'/\'\'}"
+        psql "postgres://${DB_USERNAME_URI}:${DB_PASSWORD_URI}@${DB_HOSTNAME}:${DB_PORT}" << EOF
+CREATE ROLE root WITH LOGIN SUPERUSER CREATEDB CREATEROLE PASSWORD '${root_password_sql}';
 EOF
     else
         bashio::log.info "Root user exists with a non-default password. No migration needed."
@@ -113,10 +114,10 @@ setup_database() {
     bashio::log.info "Setting up external PostgreSQL database..."
 
     # Create the database if it does not exist
-    if ! psql "postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOSTNAME}:${DB_PORT}/postgres" -tAc \
+    if ! psql "postgres://${DB_USERNAME_URI}:${DB_PASSWORD_URI}@${DB_HOSTNAME}:${DB_PORT}/postgres" -tAc \
         "SELECT 1 FROM pg_database WHERE datname='${DB_DATABASE_NAME}';" | grep -q 1; then
         bashio::log.info "Database does not exist. Creating it now..."
-        psql "postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOSTNAME}:${DB_PORT}" << EOF
+        psql "postgres://${DB_USERNAME_URI}:${DB_PASSWORD_URI}@${DB_HOSTNAME}:${DB_PORT}" << EOF
 CREATE DATABASE ${DB_DATABASE_NAME};
 EOF
     else
@@ -124,20 +125,21 @@ EOF
     fi
 
     # Ensure the user exists and update its password
-    psql "postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOSTNAME}:${DB_PORT}" << EOF
+    local db_password_sql="${DB_PASSWORD//\'/\'\'}"
+    psql "postgres://${DB_USERNAME_URI}:${DB_PASSWORD_URI}@${DB_HOSTNAME}:${DB_PORT}" << EOF
 DO \$\$
 BEGIN
     IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${DB_USERNAME}') THEN
-        CREATE USER ${DB_USERNAME} WITH ENCRYPTED PASSWORD '${DB_PASSWORD}';
+        CREATE USER ${DB_USERNAME} WITH ENCRYPTED PASSWORD '${db_password_sql}';
     ELSE
-        ALTER USER ${DB_USERNAME} WITH ENCRYPTED PASSWORD '${DB_PASSWORD}';
+        ALTER USER ${DB_USERNAME} WITH ENCRYPTED PASSWORD '${db_password_sql}';
     END IF;
 END
 \$\$;
 EOF
 
     # Ensure the user has full privileges on the database
-    psql "postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOSTNAME}:${DB_PORT}" << EOF
+    psql "postgres://${DB_USERNAME_URI}:${DB_PASSWORD_URI}@${DB_HOSTNAME}:${DB_PORT}" << EOF
 GRANT ALL PRIVILEGES ON DATABASE ${DB_DATABASE_NAME} TO ${DB_USERNAME};
 EOF
 
@@ -147,7 +149,7 @@ EOF
 # Function to check if the vectors (pgvecto.rs) extension is available on the server
 check_vector_extension() {
     echo "Checking if 'vectors' extension is available for database '${DB_DATABASE_NAME}'..."
-    RESULT=$(psql "postgres://$DB_USERNAME:$DB_PASSWORD@$DB_HOSTNAME:$DB_PORT/${DB_DATABASE_NAME}" -tAc "SELECT 1 FROM pg_available_extensions WHERE name = 'vectors';")
+    RESULT=$(psql "postgres://$DB_USERNAME_URI:$DB_PASSWORD_URI@$DB_HOSTNAME:$DB_PORT/${DB_DATABASE_NAME}" -tAc "SELECT 1 FROM pg_available_extensions WHERE name = 'vectors';")
     if [[ "$RESULT" == "1" ]]; then
         echo "✅ 'vectors' extension is available."
         return 0
@@ -163,7 +165,7 @@ check_vector_extension() {
 # itself on first startup; checking pg_extension would false-warn on every fresh install.
 check_vchord_extension() {
     echo "Checking if 'vchord' extension is available for database '${DB_DATABASE_NAME}'..."
-    RESULT=$(psql "postgres://$DB_USERNAME:$DB_PASSWORD@$DB_HOSTNAME:$DB_PORT/${DB_DATABASE_NAME}" -tAc "SELECT 1 FROM pg_available_extensions WHERE name = 'vchord';")
+    RESULT=$(psql "postgres://$DB_USERNAME_URI:$DB_PASSWORD_URI@$DB_HOSTNAME:$DB_PORT/${DB_DATABASE_NAME}" -tAc "SELECT 1 FROM pg_available_extensions WHERE name = 'vchord';")
     if [[ "$RESULT" == "1" ]]; then
         echo "✅ 'vchord' extension is available."
         return 0
@@ -186,6 +188,14 @@ export DB_DATABASE_NAME="$(bashio::config 'DB_DATABASE_NAME')"
 export DB_PORT="$(bashio::config 'DB_PORT')"
 export JWT_SECRET="$(bashio::config 'JWT_SECRET')"
 export DB_HOSTNAME="$(bashio::config 'DB_HOSTNAME')"
+
+# libpq percent-decodes the userinfo part of a postgres:// URI, so credentials
+# containing reserved characters (% @ / : ? #) are misread and every psql call
+# below fails with "password authentication failed". Encode them once here and
+# use the encoded copies in URIs only - the app itself still gets the raw value
+# through export_db_env. Same approach as the postgres_15/postgres_17 addons.
+export DB_USERNAME_URI="$(jq -rn --arg x "$DB_USERNAME" '$x|@uri')"
+export DB_PASSWORD_URI="$(jq -rn --arg x "$DB_PASSWORD" '$x|@uri')"
 
 if bashio::config.true 'VIPS_NOVECTOR'; then
     export VIPS_NOVECTOR="1"


### PR DESCRIPTION
## Root cause

`immich/rootfs/etc/cont-init.d/99-run.sh` builds every database connection as a
`postgres://` URI with the raw credentials interpolated straight in — lines 101,
103, 116, 119, 127, 140, 150 and 166 of the pre-change file, all of the form:

```bash
psql "postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOSTNAME}:${DB_PORT}"
```

libpq **percent-decodes the userinfo part of a URI**. So a `DB_PASSWORD`
containing `%` never reaches the server intact: `secret%def` is decoded to
`secret\xDEf` before the authentication request is sent, and Postgres answers
`FATAL: password authentication failed for user "postgres"` — which is exactly
what #1614 reports. The reporter later confirmed the failing password contained
`!` and `%`, and that switching to a password without special characters made it
work. `@`, `/`, `?` and `#` break the URI in the same way (`/` and `@` by
terminating the userinfo section early, so the password is not even sent).

The connection worked fine from a normal client, which is why this looked like a
Postgres-side problem — it is not. It is a wrapper bug in this add-on.

The `postgres_15` and `postgres_17` add-ons in this repo already handle this
(`postgres_15/rootfs/etc/cont-init.d/99-run.sh:156`); `immich` is the only
add-on left that interpolates raw credentials into a URI.

## The change

- Encode the username and password once with `jq`'s `@uri`, into
  `DB_USERNAME_URI` / `DB_PASSWORD_URI`, and use those **only inside the
  `postgres://` URIs**. Same idiom as `postgres_15`/`postgres_17`.
- The raw password is deliberately left untouched everywhere else: it is what
  `export_db_env` hands to Immich itself, and what `CREATE USER` / `ALTER USER`
  must store.
- While in the same statements: single quotes in `DB_PASSWORD` and
  `DB_ROOT_PASSWORD` are now doubled before being embedded in the SQL string
  literals, so a password containing `'` no longer produces a syntax error
  instead of a working role.

`DB_HOSTNAME` is intentionally not encoded — it is a hostname/IP, and
`check_db_hostname()` may still rewrite it after this point, which continues to
work since the URIs read it at call time.

## Verification

- `shellcheck -s bash immich/rootfs/etc/cont-init.d/99-run.sh` — clean.
- Encoding confirmed directly: `jq -rR '@uri'` on `p@ss%dew!o'rd#x/y` yields
  `p%40ss%25dew%21o%27rd%23x%2Fy`, which is what libpq needs in order to decode
  back to the original password.
- **Not verified against a live Postgres server** — this sweep has no Home
  Assistant instance or database to connect to. The reasoning above is from the
  libpq URI parsing rules and the repo's own precedent, not from a reproduced
  connection.

Version bumped `3.1.0` → `3.1.0.1` (local patch counter appended;
`updater.json`'s `upstream_version` is `3.1.0`, untouched).

Closes #1614

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database setup when `DB_PASSWORD` contains special characters.
  * Improved PostgreSQL connection handling by safely encoding credentials.
  * Ensured user creation and database configuration correctly escape password values.

* **Chores**
  * Updated the add-on version to 3.1.0.1.
  * Documented the password-handling fix in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->