### PR TITLE
docs(filebrowser_quantum): add-on is Ingress-only, stop advertising port 8071

### DIFF
--- a/filebrowser_quantum/CHANGELOG.md
+++ b/filebrowser_quantum/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## 1.5.1.1 (2026-08-17)
+- Documentation: the add-on is Ingress-only and does not publish port 8071, so the README no longer advertises direct access at `<your-ip>:8071`
+ 
 ## 1.5.1 (2026-08-08)
 - Update to latest version from gtsteffaniak/filebrowser (changelog : https://github.com/gtsteffaniak/filebrowser/releases)
  

--- a/filebrowser_quantum/README.md
+++ b/filebrowser_quantum/README.md
@@ -42,11 +42,11 @@ comparison to installing any other Home Assistant add-on.
 1. Click the `Save` button to store your configuration.
 1. Start the add-on.
 1. Check the logs of the add-on to see if everything went well.
-1. Access the web UI through the sidebar or at `<your-ip>:8071`.
+1. Access the web UI through the Home Assistant sidebar.
 
 ## Configuration
 
-The web UI can be found at `<your-ip>:8071` or through the Home Assistant sidebar when using Ingress.
+The web UI is reached through the Home Assistant sidebar (Ingress). This add-on does not publish a port on your network, so it has no **Network** section in its configuration page and is not reachable at `<your-ip>:8071`.
 
 **Default credentials:**
 - Username: `admin`
@@ -69,7 +69,7 @@ The web UI can be found at `<your-ip>:8071` or through the Home Assistant sideba
 ## Setup
 
 1. Start the add-on and wait for it to initialize.
-1. Access the web interface through the Home Assistant sidebar or at `<your-ip>:8071`.
+1. Access the web interface through the Home Assistant sidebar.
 1. Log in using the default credentials:
    - Username: `admin`
    - Password: `admin`

--- a/filebrowser_quantum/config.yaml
+++ b/filebrowser_quantum/config.yaml
@@ -114,4 +114,4 @@ schema:
 slug: filebrowser_quantum
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "1.5.1"
+version: "1.5.1.1"


### PR DESCRIPTION
## Root cause

`filebrowser_quantum/config.yaml` declares `ingress_port: 8071` (line 82) but has
**no `ports:` key**. Those two things are unrelated:

- `ingress_port` is the port the Supervisor's ingress proxy connects to on the
  add-on's *private* container IP. It is never published to the host.
- `ports:` is what publishes a port to your network — and it is also the only
  thing that makes Home Assistant render the **Network** card on the add-on's
  configuration page.

So there is no Network section because there is nothing to configure, and
`http://<ha-ip>:8071` has never worked for this add-on. The README text was
carried over from the sibling `filebrowser` add-on, which *does* declare
`ports: {8080/tcp: 8071}` (`filebrowser/config.yaml`) — the Quantum variant
never got that key.

The user's own log confirms the add-on is healthy and ingress-only:

```
Running at : http://0.0.0.0:8080/api/hassio_ingress/<token>/
```

## The change

Documentation only — `filebrowser_quantum/README.md` lines 45, 49 and 72 no
longer advertise `<your-ip>:8071`, and the Configuration section now states
explicitly that the add-on is Ingress-only and therefore has no Network section.

## Why not just add `ports:` instead

That is the other possible fix, and it is deliberately **not** what this PR
does, because it is not a one-line change here:

1. `rootfs/etc/cont-init.d/99-run.sh:107-108` sets FileBrowser's
   `server.baseURL` to the ingress entry (`/api/hassio_ingress/<token>/`), and
   `rootfs/etc/nginx/servers/ingress.conf:14` re-adds that prefix on the way to
   the backend. FileBrowser only serves under that base URL, so publishing
   either 8080 or 8071 as-is gives a page whose asset links resolve to a
   doubled prefix. Making direct access work needs an extra nginx server block
   (or a second FileBrowser base URL), not just a `ports:` entry.
2. This add-on ships `auth_method: noauth` and `default_user_scope: /` as
   defaults. Publishing a port with those defaults would expose the whole
   filesystem, read/write, unauthenticated, to anything on the LAN. That is a
   call for @alexbelgium to make, not something to slip in with a docs fix.

Happy to follow up with the nginx work if direct access is wanted.

## Also noticed (not changed)

The README's options table lists `auth_method` default `password`, but
`config.yaml:96` sets `noauth`; the "Default credentials: admin/admin" section
does not apply while `noauth` is active. Left alone as out of scope for this
issue.

## Verification

No code paths changed, so there is nothing to run beyond CI's lint and Docker
build. The claim being fixed — that `ports:` is absent — is checkable by reading
`filebrowser_quantum/config.yaml`.

Version bumped `1.5.1` → `1.5.1.1` (local patch counter appended;
`updater.json`'s `upstream_version` is `1.5.1`, untouched).

Closes #2978

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the web interface is available only through the Home Assistant sidebar and Ingress.
  * Removed outdated instructions for direct access through port 8071.
  * Documented that the add-on does not publish a network port or include network configuration.

* **Chores**
  * Updated the add-on version to 1.5.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->