### PR TITLE
fix(seerr): stop rewriting the root link inside the JS bundle (#2975)

### DIFF
--- a/seerr/CHANGELOG.md
+++ b/seerr/CHANGELOG.md
@@ -1,4 +1,8 @@
  
+## 3.4.1.2 (2026-08-18)
+
+- Fixed **Discover** in the sidebar still failing through ingress after 3.4.1.1 (#2975). The trailing slash added in 3.4.1.1 was also applied to the copy of the link inside Seerr's JavaScript bundle, and Next.js' client-side router strips a trailing slash before navigating: it then sent the click to a URL Home Assistant does not route, so it either landed on the same `404: Not Found` or threw `Invariant: attempted to hard navigate to the same URL` and did nothing at all. The bundle is no longer rewritten, so **Discover** routes inside the app exactly like **Requests**, **Issues** and **Settings** already did. The server-rendered link keeps its trailing slash. Only ingress was affected; the directly published port 5055 always worked.
+
 ## 3.4.1.1 (2026-08-16)
 
 - Fixed `404: Not Found` when clicking **Discover** in the sidebar through ingress (#2975). Seerr's Discover link points at `/`, which nginx rewrote to the ingress entry without a trailing slash; Home Assistant only routes ingress on `/api/hassio_ingress/<token>/…`, so the request was rejected by Home Assistant before reaching the add-on. Only ingress was affected; the directly published port 5055 always worked.

--- a/seerr/config.yaml
+++ b/seerr/config.yaml
@@ -96,4 +96,4 @@ schema:
 slug: seerr
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/seerr
-version: "3.4.1.1"
+version: "3.4.1.2"

--- a/seerr/rootfs/etc/nginx/servers/ingress.conf
+++ b/seerr/rootfs/etc/nginx/servers/ingress.conf
@@ -43,8 +43,10 @@ server {
 
         sub_filter_once off;
 
-        # Do not rewrite every response type blindly.
-        sub_filter_types text/html application/javascript text/javascript application/json;
+        # Do not rewrite every response type blindly. text/html is implicit and
+        # must not be listed - nginx pre-seeds it and warns "duplicate MIME type"
+        # on every config load if it appears here as well.
+        sub_filter_types application/javascript text/javascript application/json;
 
         # Seerr's "Discover" sidebar entry, the header logo and the 404 and
         # error pages are all <Link href="/">. The server-rendered anchor has to

--- a/seerr/rootfs/etc/nginx/servers/ingress.conf
+++ b/seerr/rootfs/etc/nginx/servers/ingress.conf
@@ -46,14 +46,35 @@ server {
         # Do not rewrite every response type blindly.
         sub_filter_types text/html application/javascript text/javascript application/json;
 
-        # The trailing slash is required: Home Assistant routes ingress on
-        # "/api/hassio_ingress/{token}/{path:.*}", so the bare entry without it
-        # matches no route and Home Assistant answers its own plain-text
-        # "404: Not Found" before the request ever reaches this add-on. Seerr's
-        # Discover link is href="/", so without the slash every click on it 404s.
+        # Seerr's "Discover" sidebar entry, the header logo and the 404 and
+        # error pages are all <Link href="/">. The server-rendered anchor has to
+        # carry the ingress prefix *with* a trailing slash: Home Assistant routes
+        # ingress on "/api/hassio_ingress/{token}/{path:.*}", so a slash-less
+        # entry matches no route and Home Assistant answers its own plain-text
+        # "404: Not Found" before the request ever reaches this add-on (#2975).
         sub_filter 'href="/"' 'href="$app/"';
         sub_filter 'href="/login"' 'href="$app/login"';
-        sub_filter 'href:"/"' 'href:"$app/"';
+
+        # A matching rule for 'href:"/"' - the form those same links take once
+        # compiled into the JS bundle - used to sit here. It is gone on purpose
+        # and must not come back: it fed the ingress prefix into Next.js' own
+        # route table, and next/link resolves a pushed href through
+        # normalizePathTrailingSlash(), which drops a trailing slash while
+        # `trailingSlash` is false (Seerr sets no override). Next therefore hard
+        # navigated to the slash-less URL and recreated the same 404; on the root
+        # page it instead threw "Invariant: attempted to hard navigate to the
+        # same URL" and the click did nothing. That is the state PR #2976 left
+        # #2975 in. Left alone the href stays "/", which removeTrailingSlash()
+        # preserves, so the router matches its own "/" route and transitions
+        # in-app - the path every other sidebar entry ("/requests", "/issues",
+        # "/users", "/settings") already takes. Prefixing belongs in the rendered
+        # anchor, never in the router's route table.
+        #
+        # Note that none of these rules are response-type scoped - sub_filter_types
+        # includes JavaScript - so the anchor rule above avoids the bundle only
+        # because the compiled output spells the prop 'href:"/"' and not
+        # 'href="/"'. These are textual substitutions over someone else's minified
+        # output: recheck them whenever Seerr or Next.js is upgraded.
         sub_filter '\/_next' '%%ingress_entry_escaped%%\/_next';
         sub_filter '/_next' '$app/_next';
         sub_filter '/api/v1' '$app/api/v1';


### PR DESCRIPTION
Follow-up to #2976, which did not fix #2975.

## Why 3.4.1.1 did not work

#2976 appended a trailing slash to both root-link rewrites:

```nginx
sub_filter 'href="/"' 'href="$app/"';   # server-rendered HTML
sub_filter 'href:"/"' 'href:"$app/"';   # the same link inside the JS bundle
```

The HTML half is correct and is doing its job — the reporter's DOM now shows
`<a href="/api/hassio_ingress/<token>/">`, slash included.

The JS half cannot work, with or without the slash. `sub_filter_types` includes
`application/javascript`, so that rule rewrites Seerr's sidebar route table inside the
bundle, and the Link's runtime `href` becomes the ingress path. Next.js then normalises
it before navigating:

- `addBasePath()` (`packages/next/src/client/add-base-path.ts`) wraps every result in
  `normalizePathTrailingSlash()`, and `Router.change()` calls it on `as`
  (`shared/lib/router/router.ts:1358`), as does `prepareUrlAs()`.
- `normalizePathTrailingSlash()` returns `removeTrailingSlash(pathname)` whenever
  `trailingSlash` is false — Seerr sets no `next.config` override, so that is the case here.

So the slash #2976 added is stripped again client-side, and because
`/api/hassio_ingress/<token>` is not in the client pages manifest, `Router.change()` falls
through to `handleHardNavigation({url: as})` and sets `window.location.href` to the
slash-less URL — the exact 404 the slash was meant to prevent. When the user is already on
the root page that URL equals `router.asPath`, so `handleHardNavigation` throws instead
(`router.ts:648`) and the click does nothing:

```
Error: Invariant: attempted to hard navigate to the same URL
  /api/hassio_ingress/<token> https://host/api/hassio_ingress/<token>/
    at Y.getRouteInfo
    at async Y.change
```

Both branches are in the reporter's console.

The corroborating detail: **Discover is the only sidebar entry rewritten inside the
bundle, and the only one reported broken.** Seerr's route table
(`src/components/Layout/Sidebar/index.tsx`) gives Discover `href: '/'` and everything else
a real path — `/discover/movies`, `/discover/tv`, `/requests`, `/blocklist`, `/issues`,
`/users`, `/settings`. None of those are rewritten, all of them match the client pages
manifest, all of them route in-app, and none of them 404.

## The change

Drop the JS-bundle rule. The link stays `/`, the router matches its own `/` route and
transitions client-side, exactly like every other sidebar entry. The HTML rule keeps its
trailing slash — it still matters for a click landing before hydration and for
open-in-new-tab.

These rules were copied from Seerr's own
[reverse-proxy doc](https://github.com/seerr-team/seerr/blob/develop/docs/extending-seerr/reverse-proxy.mdx),
where upstream labels the subfolder block an unsupported workaround. Upstream's slash-less
`href="/$app"` works there only because their `location ^~ /seerr` also matches the
slash-less path; Home Assistant routes ingress on `/api/hassio_ingress/{token}/{path:.*}`
and does not.

- `seerr/rootfs/etc/nginx/servers/ingress.conf` — remove the rule, and record why it must
  not come back
- `seerr/config.yaml` — `3.4.1.1` → `3.4.1.2`
- `seerr/CHANGELOG.md` — entry

Second commit, from Copilot's review and unrelated to the bug: `text/html` is dropped from
`sub_filter_types`. nginx pre-seeds that type, so listing it logs
`[warn] duplicate MIME type "text/html"` on every config load. Reproduced against nginx
1.22.1 locally — warning present when listed, absent when not, and an HTML response is
substituted either way.

## Verified / not verified

**Verified** by reading the pinned upstream source (Seerr v3.4.1 pins `next@16.2.6`):
`normalizePathTrailingSlash` strips the slash when `trailingSlash` is false;
`addBasePath` calls it; `Router.change` calls `addBasePath` on `as`;
`handleHardNavigation` throws on a self-navigation; and `removeTrailingSlash` preserves
`/` itself, which is what makes the unrewritten link resolve to Next's own `/` route. The
reporter's two console messages are the two branches this predicts, and the set of broken
links matches the set of rewritten links exactly. GitHub code search puts `href="/"` in
exactly three Seerr sources — `Sidebar/index.tsx`, `pages/404.tsx`, `pages/_error.tsx` —
all of them `<Link>`s that want the plain route, so nothing needed the removed rule.

An independent review by Codex (GPT-5.6) agreed with the diagnosis and the fix, and its
caveats are folded in above: sufficiency cannot be *proven* without inspecting the built
bundle, and the URL-drift claim was too broad as first written.

**Checked**: `validate.sh seerr --vs-master` adds no new lint findings. Pre-existing
shellcheck errors in `services.d/*/finish` are untouched.

**Not verified at runtime**: no dockerd in the environment this was written in, so nginx
was never started and the filtered output was not exercised. The behavioural check is one
click on **Discover** after the rebuild — it should render Discover with no navigation and
no console error.

## Known limitation, deliberately not addressed here

Next.js pushes root-relative URLs, so after an in-app navigation the browser URL sits
outside the ingress prefix (`https://host/requests`). This change does not introduce that
drift and should not worsen it — every sidebar entry already behaves this way, and the
in-session navigation that follows keeps working because `/_next`, `/api/v1`, `/images/`
and the other asset roots are rewritten to absolute ingress-prefixed paths. But the drift
is a real defect, not a harmless one: reloading after it loses Seerr, the visible URL is
not shareable, and back/forward can cross between prefixed and unprefixed history entries.

Fixing it properly means giving Next a stable `basePath`, which the rotating ingress token
rules out, or injecting JavaScript that wraps `history.pushState` — nginx cannot reach a
`pushState` call, since it never touches the server. Both are much larger and more fragile
than the reported bug warrants, so this PR fixes the 404 and leaves the drift documented.

The reporter's console also shows `sw.js` failing to register (404 on `/sw.js`). Left
alone on purpose: a service worker scoped to a rotating ingress token is more likely to
serve stale content than to help, and a failed registration is inert.

## Rollback

Single hunk — restoring `sub_filter 'href:"/"' 'href:"$app/"';` returns to 3.4.1.1
behaviour.

Closes #2975

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation to the Discover sidebar link when using an ingress path.
  * Preserved correct trailing-slash behavior for server-rendered links while preventing incorrect rewriting of JavaScript navigation paths.

* **Chores**
  * Updated the Seerr add-on version to 3.4.1.2.
  * Added release notes documenting the ingress navigation fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->