### PR TITLE
fix(scrutiny_original): keep real /init as PID 1 so s6 supervision starts

### DIFF
--- a/scrutiny_original/CHANGELOG.md
+++ b/scrutiny_original/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## v0.9.3.1 (2026-08-18)
+- Fix startup crash: `collector-once` failed with `s6-svwait: fatal: unable to subscribe to events for /run/service/scrutiny` because the add-on entrypoint never started real s6 supervision. Keep the upstream image's own `/init` as PID 1 (same fix already shipped for `scrutiny`/`scrutiny_fa` in #2878). Closes #2989.
+ 
 ## v0.9.3 (2026-08-13)
 - Update to latest version from analogj/scrutiny (changelog : https://github.com/analogj/scrutiny/releases)
  

--- a/scrutiny_original/Dockerfile
+++ b/scrutiny_original/Dockerfile
@@ -33,7 +33,8 @@ ENV S6_CMD_WAIT_FOR_SERVICES=1 \
 
 # Add rootfs
 COPY rootfs/ /
-RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \; && \
+    if [ -d /command ]; then ln -sf /command/* /usr/bin/; fi
 
 # Uses /bin for compatibility purposes
 # hadolint ignore=DL4005

--- a/scrutiny_original/Dockerfile
+++ b/scrutiny_original/Dockerfile
@@ -61,17 +61,33 @@ RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.
 # 4 Entrypoint #
 ################
 
-# Add entrypoint
+# Keep the repository initialization hook, but return after it has prepared the
+# cont-init scripts. Upstream s6 remains responsible for supervising services.
 ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
 COPY ha_entrypoint.sh /ha_entrypoint.sh
-RUN chmod 777 /ha_entrypoint.sh
+RUN chmod 0755 /ha_entrypoint.sh && \
+    awk '!inserted && $0 == "if $PID1; then" { \
+        print "if ! $PID1; then"; \
+        print "  echo \"Initialization hook complete\""; \
+        print "  exit 0"; \
+        print "fi"; \
+        inserted=1 \
+    } { print }' /ha_entrypoint.sh > /ha_entrypoint.sh.tmp && \
+    mv /ha_entrypoint.sh.tmp /ha_entrypoint.sh && \
+    chmod 0755 /ha_entrypoint.sh
 
 # Install bashio
 COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
 RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
 
-ENTRYPOINT [ "/usr/bin/env" ]
-CMD [ "/ha_entrypoint.sh" ]
+RUN test -x /init && \
+    test -x /ha_entrypoint.sh && \
+    bash -n /ha_entrypoint.sh && \
+    grep -q 'Initialization hook complete' /ha_entrypoint.sh
+
+# Scrutiny's image already includes s6-overlay and defines all services under
+# /etc/services.d. Keep /init as PID 1 so service readiness and s6-svc calls work.
+ENTRYPOINT [ "/init" ]
 
 ############
 # 5 Labels #

--- a/scrutiny_original/config.yaml
+++ b/scrutiny_original/config.yaml
@@ -113,4 +113,4 @@ schema:
 slug: scrutiny_original
 udev: true
 url: https://github.com/analogj/scrutiny
-version: "v0.9.3"
+version: "v0.9.3.1"


### PR DESCRIPTION
## Summary

`scrutiny_original` fails to start with:
```
waiting for scrutiny service to start
s6-svwait: fatal: unable to subscribe to events for /run/service/scrutiny: No such file or directory
WARNING: /etc/services.d/collector-once/run exited (code 111), restarting (#2/5) in 5s...
```
This is the same bug fixed for the sibling add-ons `scrutiny`/`scrutiny_fa` in #2878, but it was
never applied to `scrutiny_original`. Closes #2989.

## Root cause

Verified by pulling the actual upstream image (`ghcr.io/analogj/scrutiny:latest-omnibus`, per
`scrutiny_original/build.json`) via the GHCR registry API and extracting its layers — no dockerd
in this environment, so this was done with `curl` + a registry bearer token, not `docker pull`.

- `/etc/services.d/collector-once/run` inside that image is byte-identical to the script that
  caused #2877: it does `s6-svwait -u /run/service/scrutiny` before starting the collector.
- The image bundles `s6-overlay-3.1.6.2` — same version as the already-fixed `scrutiny` image.
- `scrutiny_original`'s own `rootfs/etc/cont-init.d/` has the identical filename set
  (`01-configuration.sh`, `32-nginx_ingress.sh`, `90-run.sh`) as `scrutiny`, confirming shared
  lineage/conventions.

`scrutiny_original`'s Dockerfile made `/ha_entrypoint.sh` itself PID 1
(`ENTRYPOINT ["/usr/bin/env"]` / `CMD ["/ha_entrypoint.sh"]`). Per `.templates/ha_entrypoint.sh`,
when it *is* PID 1 it does not run real s6 supervision — it just execs each
`/etc/services.d/*/run` directly in a manual background retry loop. `s6-svscan`/`s6-rc` never
run, so `/run/service/*` is never created, and `collector-once`'s `s6-svwait` fails.

There is a second half to this, and it is why a narrower fix does not work. Before starting each
service, `ha_entrypoint.sh:334` **rewrites that script's shebang** to bashio
(`sed -i "1s|^.*|#!$shebang|"`), and bashio sets `errexit`, `errtrace`, `nounset` and `pipefail`.
Upstream's `collector-once/run` is written for plain `#!/command/with-contenv bash` and relies on
failures being non-fatal. Under the rewritten shebang, the *first* failing command kills it.

The reporter's log proves this: after the `s6-svwait` line fails, the next line is the exit-111
warning — **not** the `scrutiny api not ready` messages that the following `until curl ... /api/health`
loop would have printed had the script continued. It aborted at that line.

## Fix

Mirrors the already-merged fix for `scrutiny`/`scrutiny_fa` (same repo, `scrutiny/Dockerfile`
on master) — reused verbatim, not reinvented:

1. Patch `/ha_entrypoint.sh` at build time (awk) so that when it's invoked as the
   `S6_STAGE2_HOOK` (i.e. NOT PID 1 — called *by* the real `/init`) it still runs
   `/etc/cont-init.d/*` as before, but then exits 0 immediately, before reaching its own
   manual `/etc/services.d/*/run` supervision loop.
2. `ENTRYPOINT [ "/init" ]` instead of `ENTRYPOINT ["/usr/bin/env"]` + `CMD [...]`. `/init` is
   s6-overlay's own init baked into the upstream image; it calls the (patched) hook first, then
   proceeds to its own `s6-rc-compile`/`s6-rc-init`/`s6-rc -u change`, which creates
   `/run/service/*` for real.
3. A small build-time smoke test confirming `/init` and the patched hook are present and sane.

**Not ported:** `scrutiny/Dockerfile`'s current fix also carries a large InfluxDB "pre-2.9
migration" preflight script, specific to the Starosdev fork's InfluxDB 2.9 bump in v1.67.
`scrutiny_original` tracks a different upstream (`analogj/scrutiny`) with its own plain
`influxd run` service and no evidence of that migration need (confirmed via the same image
pull). Importing that would be unrelated scope creep for this bug.

### Why not just `sed` out the `s6-svwait` line?

That one-liner was tried first for the sibling add-ons (commit `a575f6e121`, shipped as
v1.67.0-2) and then removed again in `bbaa0900a4`. It is not sufficient, for the `errexit`
reason above: `collector-once/run` calls `s6-svc -D /run/service/collector-once` twice more
(lines 6 and 23), and those fail identically once `/run/service/*` does not exist. Deleting only
the `s6-svwait` line moves the crash later — the collector runs once, then aborts at line 23 with
the same code 111 and the same 5×-restart loop on every boot.

[#2879](https://github.com/alexbelgium/hassio-addons/issues/2879) ("scrutiny still broken") was
filed against the release that shipped that one-liner, showing the `nounset` half of the same
root cause (`COLLECTOR_ZFS_CRON_SCHEDULE: unbound variable`). Keeping `/init` as PID 1 fixes the
whole class: upstream scripts keep their own `#!/command/with-contenv bash` shebang and run under
real supervision, instead of being rewritten to run under bashio's `errexit`/`nounset`.

## Validation

- `validate.sh scrutiny_original --vs-master`: shellcheck clean, hadolint clean, no new lint
  findings, CHANGELOG updated, version bumped.
- Root cause confirmed against the actual upstream image content, not just by analogy.
- Three independent Codex CLI passes: plan review before implementing, code review of the final
  diff, and an explicit "is the simpler one-line `sed` enough?" challenge. No correctness defect
  found in the diff.
- An earlier revision of this description flagged an open question about `/etc/cont-init.d/*`
  running twice (once via the hook, once via s6-overlay's native `legacy-cont-init` stage), since
  `01-configuration.sh` does non-idempotent `sed -i "1a export ..."` inserts. **That is resolved
  and is a non-issue:** `run_one_script` ends with `sed -i '1a exit 0'` (`ha_entrypoint.sh:319`),
  which neuters each cont-init script immediately after running it, so the `legacy-cont-init`
  re-run is a no-op.

## Not verified

- Docker build (CI is the only gate available; both `aarch64` and `amd64` pass).
- Actual boot of the rebuilt add-on / that `collector-once` completes end-to-end. No dockerd is
  available in this environment, so the running container has not been observed. The failure mode
  is well understood from the log in #2989, but the fix itself is confirmed only by build + code
  review, not by a live boot.

## Rollback

Single self-contained hunk in `scrutiny_original/Dockerfile`'s "4 Entrypoint" section. Revert
just that section (or the whole commit) to go back to the previous `ENTRYPOINT`/`CMD` — no other
files depend on this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a startup crash affecting one-time collection runs.
  * Improved container initialization so required services start and remain supervised correctly.
  * Added startup validation to help prevent invalid configurations.

* **Chores**
  * Updated the add-on to version 0.9.3.1.
  * Documented the startup reliability fix in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->