### PR TITLE
fix(scrutiny_fa_original): keep real /init as PID 1 so s6 supervision starts

### DIFF
--- a/scrutiny_fa_original/CHANGELOG.md
+++ b/scrutiny_fa_original/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## v0.9.3.1 (2026-08-18)
+- Fix startup crash: `collector-once` failed with `s6-svwait: fatal: unable to subscribe to events for /run/service/scrutiny` because the add-on entrypoint never started real s6 supervision. Keep the upstream image's own `/init` as PID 1, same as `scrutiny_original` (#2991) and `scrutiny`/`scrutiny_fa` (#2878).
+ 
 ## v0.9.3 (2026-08-13)
 - Update to latest version from analogj/scrutiny (changelog : https://github.com/analogj/scrutiny/releases)
  

--- a/scrutiny_fa_original/Dockerfile
+++ b/scrutiny_fa_original/Dockerfile
@@ -33,7 +33,8 @@ ENV S6_CMD_WAIT_FOR_SERVICES=1 \
 
 # Add rootfs
 COPY rootfs/ /
-RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \;
+RUN find . -type f \( -name "*.sh" -o -name "run" -o -name "finish" \) -print -exec chmod +x {} \; && \
+    if [ -d /command ]; then ln -sf /command/* /usr/bin/; fi
 
 # Uses /bin for compatibility purposes
 # hadolint ignore=DL4005
@@ -61,19 +62,35 @@ RUN chmod 744 /ha_autoapps.sh && /ha_autoapps.sh "$PACKAGES" && rm /ha_autoapps.
 # 4 Entrypoint #
 ################
 
-# Add entrypoint
+# Keep the repository initialization hook, but return after it has prepared the
+# cont-init scripts. Upstream s6 remains responsible for supervising services.
 ENV S6_STAGE2_HOOK=/ha_entrypoint.sh
 COPY ha_entrypoint.sh /ha_entrypoint.sh
-RUN chmod 777 /ha_entrypoint.sh
+RUN chmod 0755 /ha_entrypoint.sh && \
+    awk '!inserted && $0 == "if $PID1; then" { \
+        print "if ! $PID1; then"; \
+        print "  echo \"Initialization hook complete\""; \
+        print "  exit 0"; \
+        print "fi"; \
+        inserted=1 \
+    } { print }' /ha_entrypoint.sh > /ha_entrypoint.sh.tmp && \
+    mv /ha_entrypoint.sh.tmp /ha_entrypoint.sh && \
+    chmod 0755 /ha_entrypoint.sh
 
 # Install bashio
 COPY bashio-standalone.sh /usr/local/lib/bashio-standalone.sh
 RUN chmod 0755 /usr/local/lib/bashio-standalone.sh
 
+RUN test -x /init && \
+    test -x /ha_entrypoint.sh && \
+    bash -n /ha_entrypoint.sh && \
+    grep -q 'Initialization hook complete' /ha_entrypoint.sh
+
 RUN sed -i "1a if ! bashio::require.unprotected; then bashio::addon.stop; fi" /etc/cont-init.d/90-run.sh
 
-ENTRYPOINT [ "/usr/bin/env" ]
-CMD [ "/ha_entrypoint.sh" ]
+# Scrutiny's image already includes s6-overlay and defines all services under
+# /etc/services.d. Keep /init as PID 1 so service readiness and s6-svc calls work.
+ENTRYPOINT [ "/init" ]
 
 ############
 # 5 Labels #

--- a/scrutiny_fa_original/config.yaml
+++ b/scrutiny_fa_original/config.yaml
@@ -45,4 +45,4 @@ schema:
 slug: scrutiny_fa_original
 udev: true
 url: https://github.com/analogj/scrutiny
-version: "v0.9.3"
+version: "v0.9.3.1"


### PR DESCRIPTION
## Summary

Applies the same startup fix as #2991 to `scrutiny_fa_original`, the fourth Scrutiny variant.
Without it this add-on fails to start with:
```
waiting for scrutiny service to start
s6-svwait: fatal: unable to subscribe to events for /run/service/scrutiny: No such file or directory
WARNING: /etc/services.d/collector-once/run exited (code 111), restarting (#2/5) in 5s...
```

`scrutiny_fa_original` builds from the same `ghcr.io/analogj/scrutiny:latest-omnibus` image as
`scrutiny_original` and has a **byte-identical `rootfs/` tree** (confirmed with `diff -rq`), so it
has the same bug for the same reason. Related to #2989, which reported it against
`scrutiny_original`.

## Root cause

Two interacting halves, both verified rather than assumed:

1. The Dockerfile made `/ha_entrypoint.sh` itself PID 1 (`ENTRYPOINT ["/usr/bin/env"]` /
   `CMD ["/ha_entrypoint.sh"]`). When it is PID 1 it does not run real s6 supervision — it execs
   each `/etc/services.d/*/run` directly in a manual retry loop, so `s6-svscan`/`s6-rc` never run
   and `/run/service/*` never exists. `collector-once`'s `s6-svwait` therefore fails.
2. Before starting each service, `ha_entrypoint.sh:334` **rewrites that script's shebang** to
   bashio (`sed -i "1s|^.*|#!$shebang|"`), and bashio sets `errexit`/`errtrace`/`nounset`/
   `pipefail`. Upstream's `collector-once/run` is written for plain
   `#!/command/with-contenv bash` and expects failures to be non-fatal — so under the rewritten
   shebang the first failing command kills the script outright.

The upstream image content was checked directly by pulling it via the GHCR registry API and
extracting the layers (no dockerd available here). It ships s6-overlay 3.1.6.2 and four services
(`collector-once`, `cron`, `influxdb`, `scrutiny`), with s6-supervision-dependent calls at
`collector-once/run` lines 6, 11 and 23, plus `cron/finish`.

## Fix

Identical mechanism to #2991 and to `scrutiny`/`scrutiny_fa` on master:

1. Patch `/ha_entrypoint.sh` at build time (awk) so that when invoked as the `S6_STAGE2_HOOK`
   (i.e. not PID 1) it still runs `/etc/cont-init.d/*`, then exits 0 before reaching its own
   services.d supervision loop.
2. `ENTRYPOINT [ "/init" ]` — s6-overlay's own init from the upstream image — so real
   `s6-rc-compile`/`s6-rc-init`/`s6-rc -u change` runs and creates `/run/service/*`.
3. `if [ -d /command ]; then ln -sf /command/* /usr/bin/; fi` in the install stage. Required
   because with `/init` as PID 1, ha_entrypoint's PID1 branch — which creates that symlink at
   runtime and rewrites service shebangs — no longer runs, while this add-on's own
   `rootfs/etc/services.d/nginx/run` and `finish` use `#!/usr/bin/with-contenv bashio`. This was a
   P1 finding from #2991's review that applies here identically.
4. A build-time smoke test asserting `/init` and the patched hook are present and syntactically
   valid.

The FA-specific `RUN sed -i "1a if ! bashio::require.unprotected; then bashio::addon.stop; fi"
/etc/cont-init.d/90-run.sh` line is kept unchanged and still applies — `90-run.sh` runs via
cont-init.d regardless of which process is PID 1.

### Why not just `sed` out the `s6-svwait` line?

That one-liner was tried first for the sibling add-ons (`a575f6e121`, shipped as v1.67.0-2) and
removed again in `bbaa0900a4`. It is not sufficient: `collector-once/run` calls
`s6-svc -D /run/service/collector-once` twice more (lines 6 and 23), which fail identically once
`/run/service/*` does not exist. Under the bashio `errexit` described above, deleting only the
`s6-svwait` line just moves the crash later — the collector runs once, then aborts at line 23 with
the same code 111 and the same 5×-restart loop on every boot.
[#2879](https://github.com/alexbelgium/hassio-addons/issues/2879) was filed against the release
that shipped that one-liner, showing the `nounset` half of the same root cause.

## Validation

- `validate.sh scrutiny_fa_original --vs-master`: shellcheck clean, hadolint clean, no new lint
  findings, CHANGELOG updated, version bumped.
- Resulting Dockerfile diffed against `scrutiny_original`'s fixed version — the entrypoint block
  is identical except for the FA-only `require.unprotected` line, which keeps its relative
  position.
- Independent Codex CLI code review of this diff — no correctness defect found.
- The awk anchor was verified against the real template: `.templates/ha_entrypoint.sh` contains
  `if $PID1; then` twice (lines 329 and 374); the `!inserted` guard matches only the first, which
  is the intended insertion point immediately after the cont-init loop.

## Not verified

- Docker build — CI is the only gate (no dockerd locally).
- Actual boot of the rebuilt add-on. The failure mode is well understood from #2989's log and the
  fix is mechanically identical to one already shipping in two sibling add-ons, but no live
  container has been observed here.

## Rollback

Two self-contained hunks in `scrutiny_fa_original/Dockerfile` (the `/command` symlink in the
install stage, and the "4 Entrypoint" block). Reverting the commit restores the previous
`ENTRYPOINT`/`CMD` — no other files depend on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a startup crash affecting one-time collector runs.
  * Improved container initialization and supervision for more reliable add-on startup.

* **Documentation**
  * Added release notes for version 0.9.3.1.

* **Chores**
  * Updated the add-on version to 0.9.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->