### PR TITLE
fix(komga): keep the reader inside the ingress panel

### DIFF
--- a/komga/CHANGELOG.md
+++ b/komga/CHANGELOG.md
@@ -1,4 +1,7 @@
- 
+## 1.26.3.1 (19-08-2026)
+
+- Fix : tapping `Read` in the Home Assistant companion app opened the reader in an external browser, which carries no ingress session cookie, so Home Assistant answered `401 Unauthorized` before Komga was reached ([#2994](https://github.com/alexbelgium/hassio-addons/issues/2994)). Komga opens the reader with `window.open(url, '_blank')` ; nginx now injects a script that turns that popup into a navigation of the ingress panel itself. Only http(s) urls below Komga's own base path are affected, so the OAuth2 login popup and links out of Komga keep their own window
+
 ## 1.26.3 (2026-08-13)
 - Update to latest version from gotson/komga (changelog : https://github.com/gotson/komga/releases)
 ## 1.26.1.4 (12-08-2026)

--- a/komga/config.yaml
+++ b/komga/config.yaml
@@ -101,4 +101,4 @@ schema:
 slug: komga
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/komga
-version: "1.26.3"
+version: "1.26.3.1"

--- a/komga/rootfs/etc/nginx/servers/ingress.conf
+++ b/komga/rootfs/etc/nginx/servers/ingress.conf
@@ -60,6 +60,23 @@ server {
         # Only the json/xml document types are added here, so book pages are
         # never scanned.
         sub_filter "http://127.0.0.1:25600/komga" "%%ingress_entry%%/komga";
+
+        # Komga opens the reader with window.open(url, '_blank'). In the
+        # Home Assistant companion apps the ingress panel is a webview, which
+        # hands such a popup to an external browser : that browser carries no
+        # ingress session cookie, so Home Assistant answers 401 before Komga is
+        # even reached. Turn that popup into a navigation of the panel itself,
+        # but only for the exact call shape Komga uses (name _blank, no feature
+        # string) and only for http(s) urls below window.resourceBaseUrl, so
+        # that the OAuth2 login popup (window.open(url, 'oauth2Login',
+        # '<features>')), blob urls and links out of Komga keep their own
+        # window. Anchored on the single page app mount point : both Komga ui
+        # shells carry it once, and only a book served as text/html rather than
+        # the xhtml the epub spec mandates could collide with it -- the same
+        # exposure the /komga filter above already has, and Komga sends
+        # script-src 'none' on that endpoint.
+        sub_filter "<div id=\"app\">" "<script>(function(){var o=window.open;window.open=function(u,n,f){try{if(u&&n==='_blank'&&!f){var t=new URL(u,location.href);if((t.protocol==='http:'||t.protocol==='https:')&&t.origin===location.origin&&t.pathname.indexOf(window.resourceBaseUrl||'/')===0){location.assign(t.href);return window}}}catch(e){}return o.apply(window,arguments)}})();</script><div id=\"app\">";
+
         sub_filter_types application/json application/webpub+json
                          application/divina+json application/opds+json
                          application/atom+xml;

--- a/komga/rootfs/etc/nginx/servers/ingress.conf
+++ b/komga/rootfs/etc/nginx/servers/ingress.conf
@@ -61,21 +61,23 @@ server {
         # never scanned.
         sub_filter "http://127.0.0.1:25600/komga" "%%ingress_entry%%/komga";
 
-        # Komga opens the reader with window.open(url, '_blank'). In the
-        # Home Assistant companion apps the ingress panel is a webview, which
-        # hands such a popup to an external browser : that browser carries no
-        # ingress session cookie, so Home Assistant answers 401 before Komga is
-        # even reached. Turn that popup into a navigation of the panel itself,
-        # but only for the exact call shape Komga uses (name _blank, no feature
-        # string) and only for http(s) urls below window.resourceBaseUrl, so
-        # that the OAuth2 login popup (window.open(url, 'oauth2Login',
-        # '<features>')), blob urls and links out of Komga keep their own
-        # window. Anchored on the single page app mount point : both Komga ui
-        # shells carry it once, and only a book served as text/html rather than
-        # the xhtml the epub spec mandates could collide with it -- the same
-        # exposure the /komga filter above already has, and Komga sends
-        # script-src 'none' on that endpoint.
-        sub_filter "<div id=\"app\">" "<script>(function(){var o=window.open;window.open=function(u,n,f){try{if(u&&n==='_blank'&&!f){var t=new URL(u,location.href);if((t.protocol==='http:'||t.protocol==='https:')&&t.origin===location.origin&&t.pathname.indexOf(window.resourceBaseUrl||'/')===0){location.assign(t.href);return window}}}catch(e){}return o.apply(window,arguments)}})();</script><div id=\"app\">";
+        # Komga opens the reader with window.open(url, '_blank'). In the Home
+        # Assistant companion apps the ingress panel is a webview, which hands
+        # such a popup to an external browser : that browser carries no ingress
+        # session cookie, so Home Assistant answers 401 before Komga is even
+        # reached. Turn that popup into a navigation of the panel itself, but
+        # only for the call shape Komga uses (name _blank, no feature string)
+        # and only for http(s) urls below window.resourceBaseUrl. That leaves
+        # the OAuth2 login popup (window.open(url, 'oauth2Login', '<features>'),
+        # which needs its own window), blob urls and links out of Komga alone,
+        # and if Komga ever stopped setting resourceBaseUrl the popup is left
+        # untouched rather than widened to the whole Home Assistant origin,
+        # which ingress shares. Anchored on the single page app mount point :
+        # both Komga ui shells carry it once, and only a book served as
+        # text/html rather than the xhtml the epub spec mandates could collide
+        # with it -- the same exposure the /komga filter above already has, and
+        # Komga sends script-src 'none' on that endpoint.
+        sub_filter "<div id=\"app\">" "<script>(function(){var o=window.open;window.open=function(u,n,f){try{var b=window.resourceBaseUrl;if(u&&n==='_blank'&&!f&&b){if(b.slice(-1)!=='/')b+='/';var t=new URL(u,location.href);if((t.protocol==='http:'||t.protocol==='https:')&&t.origin===location.origin&&t.pathname.indexOf(b)===0){location.assign(t.href);return window}}}catch(e){}return o.apply(window,arguments)}})();</script><div id=\"app\">";
 
         sub_filter_types application/json application/webpub+json
                          application/divina+json application/opds+json


### PR DESCRIPTION
Fixes #2994

## What breaks

Tapping **Read** in the Komga panel from the Home Assistant companion app opens the
reader in an external browser, which answers `401 Unauthorized`.

The cause is not the ingress rewriting, it is the call shape. Komga's UI opens the
reader with a popup — `next-ui/src/composables/book/useBookActions.ts:169` and `:179`,
`next-ui/src/components/book/card/BookCard.vue:155`,
`next-ui/src/composables/book/useBooks.ts:104`, all of the form:

```js
window.open(bookReaderUrl(...), '_blank')
```

The companion apps render the ingress panel in a webview and hand a `_blank` popup to
an external browser. That browser carries no `ingress_session` cookie, so Home
Assistant rejects the request before Komga is ever reached — which is why the add-on
log in the issue shows only `200`s: the failing request never arrives at the add-on.

Upstream exposes no setting for opening the reader in the same tab (grepped `next-ui`
for `newtab` / `sameTab` / `openIn` — nothing), so the fix has to live in the nginx
layer that already rewrites this HTML.

## What changed

One `sub_filter` in `komga/rootfs/etc/nginx/servers/ingress.conf`, injecting a script
into the UI shell that turns Komga's own popups into a navigation of the panel itself:

* only when the call shape is exactly Komga's (`name === '_blank'`, no feature string),
  so the OAuth2 login popup — `window.open(url, 'oauth2Login', '<features>')`,
  `komga-webui/src/views/LoginView.vue:265`, whose flow depends on `window.opener`,
  `window.name` and `window.close()` — keeps its own window;
* only for `http:`/`https:` URLs, same origin, under `window.resourceBaseUrl`, so
  `blob:` previews, `about:blank`, and links out of Komga (GitHub, docs) are untouched;
* navigating to the already-parsed `URL.href`, not the raw argument, so the validated
  value is the value navigated to.

Anchored on `<div id="app">`, which both Komga UI shells carry exactly once and which
is not URL-shaped, so it does not overlap the two existing filters.

## Verified

* nginx `-t` passes, and with a stub upstream serving a copy of the Komga shell the
  script is injected exactly once, immediately before `<div id="app">`, with
  `window.resourceBaseUrl` still correctly rewritten to the ingress path.
* The injected JS was exercised against 15 inputs. Navigates in place: the divina and
  epub reader URLs, their relative form, and an empty feature string. Falls through to
  the native popup: the OAuth2 call, an external `https://github.com/...` link, a
  `blob:` URL on the HA origin, `about:blank`, a `javascript:` URL, a same-origin HA
  path outside Komga (`/lovelace/0`), a call with no name argument, one with an empty
  name, one with `noopener` features, and an `undefined` URL. A `toString()` that
  changes between coercions navigates to the first, validated value.
* `validate.sh komga --vs-master` clean — no lint findings added.

## Not verified

* The actual companion-app reproduction. There is no dockerd here and the webview
  cannot be simulated; the trigger rests on the reporter's own observation that the
  link opens in an external browser. CI is the only gate on the image build.
* Behaviour on a webview without `URL`. Construction would throw, the `catch` falls
  back to the native popup, and the 401 would return — a silent no-op, not a break.

## Behaviour change and risk

On desktop browsers the reader now replaces the panel instead of opening a new tab.
Browser back returns to the library, and the reader's own close button already routed
back to the book page (`DivinaReader.vue:814`, `EpubReader.vue:920`) rather than
calling `window.close()`. Only ingress traffic is affected — direct access on port
25600 bypasses nginx entirely.

Residual, from the Codex review: because `sub_filter` selects on Content-Type, a book
served as `text/html` instead of the `application/xhtml+xml` the EPUB spec mandates and
containing the literal `<div id="app">` would get the script inserted. That is the same
exposure the pre-existing `/komga` filter already carries, and Komga sends
`script-src 'none'` on the epub resource endpoint, so the script could not run. If
upstream ever renames the mount element the filter simply stops matching: Komga still
loads, the 401 returns.

## Rollback

Delete the `sub_filter "<div id=\"app\">" ...` line and its comment block in
`komga/rootfs/etc/nginx/servers/ingress.conf`. Nothing else in the diff depends on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Reader popups for eligible internal Komga links now open within the current panel instead of launching a separate window.
  - External links, OAuth2 login popups, blob URLs, and links with additional features continue to open as before.

- **Bug Fixes**
  - Fixed navigation behavior for Komga reader popups when accessed through the ingress connection.

- **Chores**
  - Updated the Komga add-on to version 1.26.3.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->