### PR TITLE
ci: pin EndBug/add-and-commit to v11.0.0 (floating v11 tag no longer loads)

### DIFF
--- a/.github/workflows/daily_README.yaml
+++ b/.github/workflows/daily_README.yaml
@@ -228,7 +228,7 @@ jobs:
           echo "... done"
 
       - name: Commit if needed
-        uses: EndBug/add-and-commit@v11
+        uses: EndBug/add-and-commit@v11.0.0
         with:
           message: "GitHub bot : README updated"
           default_author: github_actions

--- a/.github/workflows/helper_stats_graphs.yaml
+++ b/.github/workflows/helper_stats_graphs.yaml
@@ -237,7 +237,7 @@ jobs:
           # Get stars evolution
           wget -S -O .github/starsevol.svg "https://api.star-history.com/svg?repos=alexbelgium/hassio-addons&type=Date" || true
       - name: Commit if needed
-        uses: EndBug/add-and-commit@v11
+        uses: EndBug/add-and-commit@v11.0.0
         with:
           message: "GitHub bot : graphs updated"
           default_author: github_actions

--- a/.github/workflows/on_issues.yml
+++ b/.github/workflows/on_issues.yml
@@ -59,7 +59,7 @@ jobs:
         # Remove issues list
         rm issueslist
     - name: Commit if needed
-      uses: EndBug/add-and-commit@v11
+      uses: EndBug/add-and-commit@v11.0.0
       with:
         message: "Github bot : issues linked to readme"
         default_author: github_actions

--- a/.github/workflows/onpush_builder.yaml
+++ b/.github/workflows/onpush_builder.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: Commit sanitize changes
         id: sanitize_commit
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        uses: EndBug/add-and-commit@v11
+        uses: EndBug/add-and-commit@v11.0.0
         with:
           commit: -u
           message: "GitHub bot: sanitize (spaces + LF endings) & chmod [nobuild]"
@@ -410,7 +410,7 @@ jobs:
           done
 
       - name: Commit changelog changes
-        uses: EndBug/add-and-commit@v11
+        uses: EndBug/add-and-commit@v11.0.0
         with:
           commit: -u
           message: "GitHub bot: changelog [nobuild]"

--- a/.github/workflows/weekly_crlftolf.yaml
+++ b/.github/workflows/weekly_crlftolf.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: erclu/check-crlf@v1
 
       - name: Commit if needed
-        uses: EndBug/add-and-commit@v11
+        uses: EndBug/add-and-commit@v11.0.0
         with:
           message: "Github bot : CRLF corrected"
           default_author: github_actions
@@ -50,7 +50,7 @@ jobs:
             dos2unix -k "$f"
           done
       - name: Commit if needed
-        uses: EndBug/add-and-commit@v11
+        uses: EndBug/add-and-commit@v11.0.0
         with:
           message: "Github bot : CRLF corrected"
           default_author: github_actions

--- a/.github/workflows/weekly_reduceimagesize.yml
+++ b/.github/workflows/weekly_reduceimagesize.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Commit if needed
         if: steps.calibre.outputs.markdown != ''
-        uses: EndBug/add-and-commit@v11
+        uses: EndBug/add-and-commit@v11.0.0
         with:
           message: "Github bot : image compressed"
           default_author: github_actions

--- a/.github/workflows/weekly_stats.yaml
+++ b/.github/workflows/weekly_stats.yaml
@@ -109,7 +109,7 @@ jobs:
           #TOTAL3="$(awk '{SUM+=$2}END{print SUM}' Stats)"
 
       - name: Commit if needed
-        uses: EndBug/add-and-commit@v11
+        uses: EndBug/add-and-commit@v11.0.0
         with:
           default_author: github_actions
           message : "Github bot : stats updated"


### PR DESCRIPTION
Every push to `master` has failed to build since 05:15 UTC today, and the failure has nothing to do with the add-on that happened to be merged at that moment. `prebuild-sanitize` dies before running a step:

```
EndBug/add-and-commit/v11/action.yml (Line: 25, Col: 18): Unrecognized named-value: 'github'.
Located at position 1 within expression: github.workspace
Failed to load EndBug/add-and-commit/v11/action.yml
```

## What happened

Upstream released `v11.1.0` at 2026-08-18 22:44 UTC and moved the floating `v11` tag to it. That release put a literal `${{ github.workspace }}` in the *description* of the `cwd` input:

```yaml
  cwd:
    description: The directory where your repository is located (…). In with:, use ${{ github.workspace }} — $GITHUB_WORKSPACE is not expanded.
```

Action metadata descriptions are still parsed as expressions, and the `github` context does not exist at that point, so the action fails to load entirely. `v11.0.0` — what `v11` resolved to when Dependabot bumped us in #2985 — does not contain that line.

Confirmed by fetching `action.yml` at each ref: the string is present at `v11.1.0` and at `v11` today, absent at `v11.0.0` and `v10`. The last green builder run was 2026-08-18 19:36, i.e. before the upstream release; the first push after it failed.

## The change

`EndBug/add-and-commit@v11` → `@v11.0.0`, in all 9 places across 7 workflows. That keeps the major version Dependabot moved us to and steps off the moving tag, so a future upstream fix arrives as a Dependabot PR rather than mid-flight.

Affected workflows: `onpush_builder.yaml` (×2), `weekly_crlftolf.yaml` (×2), `daily_README.yaml`, `helper_stats_graphs.yaml`, `weekly_stats.yaml`, `weekly_reduceimagesize.yml`, `on_issues.yml`.

## Collateral to clean up after this merges

The builder's `revert-on-failure` job did its job and reverted the seerr merge (#2993) that was in flight when the action broke — `1b1436b61a`. That add-on fix is unrelated and correct; it is reapplied in a separate PR, which should merge **after** this one so the builder can actually run.

## Verified / not verified

- **Verified**: all 7 workflow files still parse as YAML; the ref-by-ref comparison of upstream `action.yml` above.
- **Not verified**: that `v11.0.0` behaves identically to `v10` at runtime beyond loading — it was in use for the four green builder runs between #2985 and the upstream release, which is the evidence available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated repository maintenance workflows to use the latest pinned release of the commit action.
  * Improved consistency across README, statistics, issue, image, formatting, and build automation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->