### PR TITLE
fix(filebrowser_quantum): repair direct access on port 8071

### DIFF
--- a/filebrowser_quantum/CHANGELOG.md
+++ b/filebrowser_quantum/CHANGELOG.md
@@ -1,4 +1,11 @@
  
+## 1.5.1.2 (2026-08-19)
+- Fix direct access on port 8071, which was broken in 1.5.1.1: the root
+  redirect pointed at the container-internal port 8072 instead of the
+  published one, and the page it led to referenced assets under a path the
+  add-on did not serve, so every asset returned 404. Requests are now passed
+  through unchanged and only the bare root is redirected.
+
 ## 1.5.1.1 (2026-08-16)
 - Expose the web UI on host port 8071, reachable at `<your-ip>:8071`
   (redirects to `/filebrowser_quantum/`). Direct access is served by a new,

--- a/filebrowser_quantum/CHANGELOG.md
+++ b/filebrowser_quantum/CHANGELOG.md
@@ -4,7 +4,8 @@
   redirect pointed at the container-internal port 8072 instead of the
   published one, and the page it led to referenced assets under a path the
   add-on did not serve, so every asset returned 404. Requests are now passed
-  through unchanged and only the bare root is redirected.
+  through unchanged, with the bare root and the two previously documented
+  `/filebrowser_quantum` URLs redirected to the app's configured base path.
 
 ## 1.5.1.1 (2026-08-16)
 - Expose the web UI on host port 8071, reachable at `<your-ip>:8071`

--- a/filebrowser_quantum/README.md
+++ b/filebrowser_quantum/README.md
@@ -46,7 +46,7 @@ comparison to installing any other Home Assistant add-on.
 
 ## Configuration
 
-The web UI can be found at `<your-ip>:8071` or through the Home Assistant sidebar when using Ingress. Direct access redirects to the add-on's internal base path, so the address bar will show a longer URL than the one you typed.
+The web UI can be found at `<your-ip>:8071` or through the Home Assistant sidebar when using Ingress. Direct access redirects to the add-on's configured base path, so the address bar will show a longer URL than the one you typed.
 
 **Default credentials:**
 - Username: `admin`

--- a/filebrowser_quantum/README.md
+++ b/filebrowser_quantum/README.md
@@ -42,11 +42,11 @@ comparison to installing any other Home Assistant add-on.
 1. Click the `Save` button to store your configuration.
 1. Start the add-on.
 1. Check the logs of the add-on to see if everything went well.
-1. Access the web UI through the sidebar or at `<your-ip>:8071/filebrowser_quantum/`.
+1. Access the web UI through the sidebar or at `<your-ip>:8071`.
 
 ## Configuration
 
-The web UI can be found at `<your-ip>:8071` (redirects to `/filebrowser_quantum/`) or through the Home Assistant sidebar when using Ingress.
+The web UI can be found at `<your-ip>:8071` or through the Home Assistant sidebar when using Ingress. Direct access redirects to the add-on's internal base path, so the address bar will show a longer URL than the one you typed.
 
 **Default credentials:**
 - Username: `admin`

--- a/filebrowser_quantum/config.yaml
+++ b/filebrowser_quantum/config.yaml
@@ -118,4 +118,4 @@ schema:
 slug: filebrowser_quantum
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "1.5.1.1"
+version: "1.5.1.2"

--- a/filebrowser_quantum/rootfs/etc/cont-init.d/99-run.sh
+++ b/filebrowser_quantum/rootfs/etc/cont-init.d/99-run.sh
@@ -43,13 +43,9 @@ declare ingress_interface
 declare ingress_port
 #declare keyfile
 
-# The app's own baseURL is always the Supervisor ingress-entry path — this is
-# unchanged from before. FileBrowser Quantum has no known "ignore baseURL for
-# routing" leniency the way classic filebrowser's app does, so ingress access
-# is left completely untouched here. Direct ip:port access is handled below by
-# a second, separate nginx vhost (direct.conf) that rewrites a fixed public
-# path onto this same ingress-entry baseURL, instead of changing the baseURL
-# itself.
+# The app's own baseURL is the Supervisor ingress-entry path, unchanged from
+# before: FileBrowser emits that prefix as absolute links in its HTML and JS,
+# so it is also the path direct ip:port access has to use (see direct.conf).
 FB_BASEURL=$(bashio::addon.ingress_entry)
 export FB_BASEURL
 
@@ -67,11 +63,10 @@ sed -i "s|%%port%%|${ingress_port}|g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%interface%%|${ingress_interface}|g" /etc/nginx/servers/ingress.conf
 sed -i "s|%%subpath%%|${FB_BASEURL}/|g" /etc/nginx/servers/ingress.conf
 
-# --- Direct ip:port access (separate from ingress, see comment above) ---
-# Publishes a second nginx vhost on a fixed internal port (published to the
-# host as 8071 via config.yaml's `ports:`), at a fixed public path
-# (/filebrowser_quantum/), that proxies to the same backend the ingress vhost
-# uses. This keeps the app's own baseURL, and therefore ingress, unchanged.
+# --- Direct ip:port access (separate vhost, ingress untouched) ---
+# Listens on 8072, published to the host as 8071 by config.yaml's `ports:`.
+# Requests are passed through unchanged; only the bare root is redirected to
+# the app's baseURL, which is what its own links already point at.
 sed -i "s|%%protocol%%|${ADDON_PROTOCOL}|g" /etc/nginx/servers/direct.conf
 sed -i "s|%%subpath%%|${FB_BASEURL}/|g" /etc/nginx/servers/direct.conf
 

--- a/filebrowser_quantum/rootfs/etc/cont-init.d/99-run.sh
+++ b/filebrowser_quantum/rootfs/etc/cont-init.d/99-run.sh
@@ -65,8 +65,9 @@ sed -i "s|%%subpath%%|${FB_BASEURL}/|g" /etc/nginx/servers/ingress.conf
 
 # --- Direct ip:port access (separate vhost, ingress untouched) ---
 # Listens on 8072, published to the host as 8071 by config.yaml's `ports:`.
-# Requests are passed through unchanged; only the bare root is redirected to
-# the app's baseURL, which is what its own links already point at.
+# Requests are passed through unchanged; the bare root and the two legacy
+# /filebrowser_quantum paths are redirected to the app's baseURL, which is what
+# its own links already point at.
 sed -i "s|%%protocol%%|${ADDON_PROTOCOL}|g" /etc/nginx/servers/direct.conf
 sed -i "s|%%subpath%%|${FB_BASEURL}/|g" /etc/nginx/servers/direct.conf
 

--- a/filebrowser_quantum/rootfs/etc/nginx/servers/direct.conf
+++ b/filebrowser_quantum/rootfs/etc/nginx/servers/direct.conf
@@ -6,19 +6,35 @@ server {
 
     client_max_body_size 0;
 
+    # nginx listens on 8072 inside the container but is published to the host
+    # as 8071. An absolute redirect would be built from $server_port and send
+    # the browser to :8072, which is not published and therefore unreachable.
+    absolute_redirect off;
+
+    # FileBrowser serves under its baseURL (the Supervisor ingress entry) and
+    # emits that prefix as absolute links in its HTML/JS, so the browser must
+    # use that same path here. Send the bare root to it; everything else is
+    # passed through untouched, which keeps asset, API and websocket URLs
+    # working without any response rewriting.
     location = / {
-        return 302 /filebrowser_quantum/;
+        return 302 %%subpath%%;
     }
 
+    # 1.5.1.1 briefly documented /filebrowser_quantum/ as the direct URL. The
+    # app never served that path itself, so send those bookmarks on instead of
+    # letting them fall through to a 404.
     location = /filebrowser_quantum {
-        return 301 /filebrowser_quantum/;
+        return 302 %%subpath%%;
     }
 
-    location /filebrowser_quantum/ {
-        add_header Access-Control-Allow-Origin *;
+    location = /filebrowser_quantum/ {
+        return 302 %%subpath%%;
+    }
+
+    location / {
         proxy_connect_timeout 30m;
         proxy_send_timeout 30m;
         proxy_read_timeout 30m;
-        proxy_pass         %%protocol%%://backend%%subpath%%;
+        proxy_pass         %%protocol%%://backend;
     }
 }

--- a/filebrowser_quantum/rootfs/etc/nginx/servers/direct.conf
+++ b/filebrowser_quantum/rootfs/etc/nginx/servers/direct.conf
@@ -13,9 +13,9 @@ server {
 
     # FileBrowser serves under its baseURL (the Supervisor ingress entry) and
     # emits that prefix as absolute links in its HTML/JS, so the browser must
-    # use that same path here. Send the bare root to it; everything else is
-    # passed through untouched, which keeps asset, API and websocket URLs
-    # working without any response rewriting.
+    # use that same path here. The bare root and the two legacy paths below
+    # redirect to it; every other request is proxied through untouched, which
+    # keeps asset, API and websocket URLs working without response rewriting.
     location = / {
         return 302 %%subpath%%;
     }


### PR DESCRIPTION
Follow-up to #2979 (merged as 1.5.1.1), which published port 8071 but left direct access still broken. Both remaining failures were measured against a running instance, not inferred.

## What was broken

**1. The root redirect pointed at an unpublished port.** nginx listens on 8072 inside the container and is published to the host as 8071, but the redirect was absolute, so nginx built it from `$server_port`:

```
GET http://<ip>:8071/
→ 302  Location: http://<ip>:8072/filebrowser_quantum/
```

8072 is not published, so the browser landed on an unreachable address. This is what the user reported.

**2. The page it led to referenced assets the add-on did not serve.** FileBrowser serves under its `baseURL` (the Supervisor ingress entry) and emits that prefix as absolute links, so the HTML at `/filebrowser_quantum/` pointed at `/api/hassio_ingress/<hash>/public/static/...` — a path the vhost had no route for:

```
GET /api/hassio_ingress/<hash>/public/static/favicon.svg   → 404
GET /filebrowser_quantum/public/static/favicon.svg         → 200
```

The page loaded and every asset on it failed. The previous design translated request paths but could not translate the URLs the app emits in responses.

## The fix

Stop translating paths. The direct vhost now passes requests through unchanged and redirects only the bare root to the app's own `baseURL` — the path its links already point at — so asset, API and websocket URLs work with no response rewriting:

- `absolute_redirect off` so the `Location` stays relative and keeps the browser on 8071.
- `location = /` → 302 to the app's base path; `location /` → `proxy_pass` with no URI part, passing the request URI through byte-for-byte.
- `/filebrowser_quantum` and `/filebrowser_quantum/` redirect too, so bookmarks made from 1.5.1.1's README keep working.
- Dropped the `Access-Control-Allow-Origin: *` the old direct vhost had copied from the ingress vhost. This is a LAN-facing port on an add-on whose shipped defaults are `auth_method: noauth` and `default_user_scope: /`; wildcard CORS there would let any page the user visits read their filesystem cross-origin. The ingress vhost is untouched.

`ingress.conf`, the app's `server.baseURL` and the `FB_BASEURL` wiring are unchanged from master — only `direct.conf` and its two `sed` lines differ.

## Verification

**Verified** — both vhosts rendered exactly as `99-run.sh` renders them, then run under local nginx 1.22.1 against a stub backend that echoes the path it received. The shipped 1.5.1.1 config reproduces the bug (`Location: http://192.168.178.23:18073/…`, nginx's own listen port rather than the browser's), and this branch's config gives:

| Request | Result |
|---|---|
| `/` | `302 Location: /api/hassio_ingress/<hash>/` (relative) |
| `/filebrowser_quantum`, `/filebrowser_quantum/` | same relative 302 |
| `/api/hassio_ingress/<hash>/files/x?q=1` | backend receives that path unchanged, query string intact |

**Verified** — the shared `includes/proxy_params.conf` already carries what this depends on: `proxy_http_version 1.1`, `Upgrade`/`Connection` for websocket upgrades, and `Host $http_host` (which preserves `:8071` in anything the backend generates).

**Not verified** — the Docker build (no dockerd available locally; CI is the gate), and the end-to-end browser flow on a real Supervisor, since that needs this branch built and installed. The local nginx run covers the routing logic but not FileBrowser's actual responses.

**Reviewed** — Codex (gpt-5.6-sol) reviewed this and the two prior attempts; it killed an earlier version that would have broken Ingress, and predicted failure 2 above before it was measured.

## Risk and rollback

Blast radius is one file plus two `sed` lines. Reverting `direct.conf` to master restores 1.5.1.1 behavior; deleting the file and the `ports:` key returns to ingress-only.

Refs #2978


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected direct access on port 8071 to route requests through the configured application base path.
  * Added redirects for the root path and legacy FileBrowser paths.
  * Improved handling of assets and other requests during direct access.

* **Documentation**
  * Clarified direct-access redirect behavior and base-path configuration.

* **Chores**
  * Updated the add-on version to 1.5.1.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->