### PR TITLE
fix(claude_desktop): install the complete Codex package so tool calls work

### DIFF
--- a/claude_desktop/CHANGELOG.md
+++ b/claude_desktop/CHANGELOG.md
@@ -1,3 +1,49 @@
+## 07308545.2 (19-08-2026)
+- Fix Codex CLI being installed incomplete, which silently broke every Codex tool call. Since
+  codex-cli 0.147.0 the CLI does not execute shell commands or file reads itself; it delegates
+  them to a companion `codex-code-mode-host` binary that it looks up next to its own executable.
+  `81-codex_cli.sh` downloaded the `codex-<target>.tar.gz` release asset, which contains only the
+  `codex` executable, so that companion binary was never installed. Measured on the running add-on
+  (codex-cli 0.147.0, `/data/codex/bin` holding only `.version`, the launcher and `codex-real`):
+  `codex exec` starts, authenticates and answers, but every tool call fails with
+  `failed to spawn code-mode host /data/codex/bin/codex-code-mode-host: No such file or directory`
+  and the run still exits 0 — so Codex answered from the prompt text alone and the failure looked
+  like success. `--disable code_mode` does not avoid it.
+  - The installer now downloads the `codex-package-<target>.tar.gz` release asset, which is the
+    complete package tree upstream's own installer uses, and installs all of it: the entrypoint as
+    `/data/codex/bin/codex-real`, `codex-code-mode-host` beside it, and `codex-package.json`,
+    `codex-resources/` (bundled bubblewrap and zsh) and `codex-path/` (bundled ripgrep) in
+    `/data/codex`. Cherry-picking the two binaries out of that tree also works today, but it is
+    the same mistake at a smaller scale: the next helper upstream adds would break in exactly this
+    way again. The installed tree grows from ~246 MB to ~300 MB, and `/data/codex` is now
+    explicitly add-on-owned in its entirety: the package tree below it is replaced as a unit on
+    every upgrade, so nothing should be kept there by hand. Codex's own state stays in `~/.codex`
+    and is never touched.
+  - A replacement that is interrupted partway no longer leaves a Codex that looks installed but
+    mixes two releases. The stamp is removed before the first file is replaced, so a stamp-less
+    prefix identifies exactly that case; the entrypoint is then removed as well, the boot reports
+    Codex as unavailable instead of silently misbehaving, and the next start reinstalls in full.
+  - That layout is load-bearing, so the install prefix was chosen to satisfy it rather than
+    changed. Codex canonicalises its own executable path, requires the parent directory to be
+    named `bin`, and reads the manifest and helper directories from that directory's parent — the
+    existing `/data/codex/bin` prefix already matches, and the executable's file name is not part
+    of the contract, so `codex-real` and the subscription-only `codex` launcher wrapping it are
+    both unchanged, as is the `/usr/local/bin/codex` symlink and the MCP registration.
+  - Existing installs repair themselves. The "already installed, skip the download" test now also
+    requires the code-mode host and the package manifest to be present, so an add-on that already
+    has a working `codex-real` and no helpers reinstalls on the next start instead of staying
+    quietly broken.
+  - `claude-tools-doctor.sh` now reports whether the package layout is complete, because the
+    failure mode this fixes is invisible in `codex --version`, in the version stamp and in the
+    exit code.
+- Known limitation, unchanged by this release and not caused by it: Codex's own Linux sandbox
+  cannot start in this container. Running both the system `bwrap` 0.8.0 and the bundled one
+  directly with `--dev-bind / / --unshare-net /bin/true` fails identically with
+  `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`, so it is a container capability
+  limitation rather than a packaging one. With the shipped `codex_sandbox_mode: workspace-write`
+  default, tool calls therefore still fail with that bwrap error; `danger-full-access` is the only
+  mode that currently executes commands, and the container is already the security boundary.
+
 ## 07308545.1 (17-08-2026)
 - Minor bugs fixed
  

--- a/claude_desktop/CHANGELOG.md
+++ b/claude_desktop/CHANGELOG.md
@@ -10,15 +10,17 @@
   and the run still exits 0 — so Codex answered from the prompt text alone and the failure looked
   like success. `--disable code_mode` does not avoid it.
   - The installer now downloads the `codex-package-<target>.tar.gz` release asset, which is the
-    complete package tree upstream's own installer uses, and installs all of it: the entrypoint as
+    complete package tree upstream's own installer uses, and installs all of it. Not a list of
+    known file names: whatever the archive contains is moved into place by position, so a helper
+    added by a future release arrives beside the entrypoint on its own instead of being extracted
+    and then dropped — cherry-picking today's two binaries works today, but it is the same mistake
+    at a smaller scale. For release 0.148.0 that means the entrypoint as
     `/data/codex/bin/codex-real`, `codex-code-mode-host` beside it, and `codex-package.json`,
     `codex-resources/` (bundled bubblewrap and zsh) and `codex-path/` (bundled ripgrep) in
-    `/data/codex`. Cherry-picking the two binaries out of that tree also works today, but it is
-    the same mistake at a smaller scale: the next helper upstream adds would break in exactly this
-    way again. The installed tree grows from ~246 MB to ~300 MB, and `/data/codex` is now
+    `/data/codex`. The installed tree grows from ~246 MB to ~300 MB, and `/data/codex` is now
     explicitly add-on-owned in its entirety: the package tree below it is replaced as a unit on
-    every upgrade, so nothing should be kept there by hand. Codex's own state stays in `~/.codex`
-    and is never touched.
+    every upgrade — files an older release left behind are removed with it — so nothing should be
+    kept there by hand. Codex's own state stays in `~/.codex` and is never touched.
   - An incomplete install is no longer advertised. `82-claude_tools.sh` registers the Codex MCP
     server whenever the launcher at `/data/codex/bin/codex` is executable and re-checks nothing
     else, and both the launcher and the package tree persist in `/data` independently of each

--- a/claude_desktop/CHANGELOG.md
+++ b/claude_desktop/CHANGELOG.md
@@ -18,9 +18,11 @@
     `/data/codex/bin/codex-real`, `codex-code-mode-host` beside it, and `codex-package.json`,
     `codex-resources/` (bundled bubblewrap and zsh) and `codex-path/` (bundled ripgrep) in
     `/data/codex`. The installed tree grows from ~246 MB to ~300 MB, and `/data/codex` is now
-    explicitly add-on-owned in its entirety: the package tree below it is replaced as a unit on
-    every upgrade — files an older release left behind are removed with it — so nothing should be
-    kept there by hand. Codex's own state stays in `~/.codex` and is never touched.
+    explicitly add-on-owned in its entirety: every path the new release ships replaces the
+    installed copy of that path outright rather than merging into it, so nothing should be kept
+    there by hand. A path upstream stops shipping altogether is not pruned — it is left behind as
+    dead weight that the new entrypoint no longer looks for. Codex's own state stays in
+    `~/.codex` and is never touched.
   - An incomplete install is no longer advertised. `82-claude_tools.sh` registers the Codex MCP
     server whenever the launcher at `/data/codex/bin/codex` is executable and re-checks nothing
     else, and both the launcher and the package tree persist in `/data` independently of each
@@ -31,8 +33,9 @@
     prefix is exactly the tree that may mix two releases. This covers the cases that reach the
     launcher without a fresh install: a boot that cannot reach the release metadata and finds a
     pre-existing incomplete install, and a launcher left behind by an interrupted replacement.
-    Nothing is deleted beyond the launcher — the executable, the package tree and the ChatGPT
-    sign-in stay, so a later boot completes the install without another download or another login.
+    Nothing under `/data/codex` is deleted beyond that launcher — the executable, the package
+    tree and the ChatGPT sign-in stay, so a later boot completes the install without another
+    download or another login.
   - That layout is load-bearing, so the install prefix was chosen to satisfy it rather than
     changed. Codex canonicalises its own executable path, requires the parent directory to be
     named `bin`, and reads the manifest and helper directories from that directory's parent — the

--- a/claude_desktop/CHANGELOG.md
+++ b/claude_desktop/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 07308545.2 (19-08-2026)
-- Fix Codex CLI being installed incomplete, which silently broke every Codex tool call. Since
+## 07308545.3 (19-08-2026)
+- Fix an incompletely installed Codex CLI, which silently broke every Codex tool call. Since
   codex-cli 0.147.0 the CLI does not execute shell commands or file reads itself; it delegates
   them to a companion `codex-code-mode-host` binary that it looks up next to its own executable.
   `81-codex_cli.sh` downloaded the `codex-<target>.tar.gz` release asset, which contains only the
@@ -19,10 +19,18 @@
     explicitly add-on-owned in its entirety: the package tree below it is replaced as a unit on
     every upgrade, so nothing should be kept there by hand. Codex's own state stays in `~/.codex`
     and is never touched.
-  - A replacement that is interrupted partway no longer leaves a Codex that looks installed but
-    mixes two releases. The stamp is removed before the first file is replaced, so a stamp-less
-    prefix identifies exactly that case; the entrypoint is then removed as well, the boot reports
-    Codex as unavailable instead of silently misbehaving, and the next start reinstalls in full.
+  - An incomplete install is no longer advertised. `82-claude_tools.sh` registers the Codex MCP
+    server whenever the launcher at `/data/codex/bin/codex` is executable and re-checks nothing
+    else, and both the launcher and the package tree persist in `/data` independently of each
+    other. The launcher is therefore now written only for an install that has its executable, its
+    code-mode host, its package manifest and its version stamp, and is removed together with the
+    `/usr/local/bin/codex` symlink otherwise. The stamp is part of that test because it is deleted
+    before the first file of a replacement is moved and written after the last, so a stamp-less
+    prefix is exactly the tree that may mix two releases. This covers the cases that reach the
+    launcher without a fresh install: a boot that cannot reach the release metadata and finds a
+    pre-existing incomplete install, and a launcher left behind by an interrupted replacement.
+    Nothing is deleted beyond the launcher — the executable, the package tree and the ChatGPT
+    sign-in stay, so a later boot completes the install without another download or another login.
   - That layout is load-bearing, so the install prefix was chosen to satisfy it rather than
     changed. Codex canonicalises its own executable path, requires the parent directory to be
     named `bin`, and reads the manifest and helper directories from that directory's parent — the

--- a/claude_desktop/README.md
+++ b/claude_desktop/README.md
@@ -209,14 +209,25 @@ registers `codex mcp-server` in both Claude Code and Claude Desktop. A Claude
 session can therefore delegate a task to ChatGPT Codex and read its result back
 through MCP.
 
-Codex is not baked into the image because its Linux binary is large and the
-feature is off by default. At each startup, the add-on resolves the latest
-stable upstream release. It downloads the architecture-specific binary into
-persistent `/data/codex/bin` only when the installed release is missing or
-outdated, verifies the GitHub-published SHA-256 digest before extraction or
-execution, validates the staged binary with `--version`, and replaces the
-existing binary atomically. If release metadata or the download is unavailable,
-startup continues and a previously working installation is retained.
+Codex is not baked into the image because its Linux distribution is large and
+the feature is off by default. At each startup, the add-on resolves the latest
+stable upstream release. It downloads the architecture-specific package into
+persistent `/data/codex` only when the installed release is missing, incomplete
+or outdated, verifies the GitHub-published SHA-256 digest before extraction or
+execution, and validates the staged package with `--version` before it replaces
+the installed one. The complete upstream package is installed, not just the
+`codex` executable: Codex delegates every shell and file-read tool call to a
+companion `codex-code-mode-host` binary that it looks up next to itself, so an
+executable installed on its own can answer but can never run anything. If
+release metadata or the download is unavailable, startup continues and a
+previously working installation is retained.
+
+`/data/codex` belongs to the add-on: everything below it — `bin/`,
+`codex-package.json`, `codex-resources/` and `codex-path/` — is replaced as a
+unit whenever a new release is installed, so it is not a place to keep files by
+hand. Codex's own state (`auth.json`, `config.toml`) lives in `~/.codex` and is
+never touched by an install. The installed package is roughly 300 MB, and an
+upgrade briefly needs room for the archive and both releases at once.
 
 ### Signing in with a ChatGPT subscription
 

--- a/claude_desktop/config.yaml
+++ b/claude_desktop/config.yaml
@@ -136,5 +136,5 @@ schema:
 slug: claude_desktop
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "07308545.2"
+version: "07308545.3"
 video: true

--- a/claude_desktop/config.yaml
+++ b/claude_desktop/config.yaml
@@ -136,5 +136,5 @@ schema:
 slug: claude_desktop
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "07308545.1"
+version: "07308545.2"
 video: true

--- a/claude_desktop/rootfs/etc/cont-init.d/81-codex_cli.sh
+++ b/claude_desktop/rootfs/etc/cont-init.d/81-codex_cli.sh
@@ -10,10 +10,20 @@ set -o pipefail
 # The install prefix is /data/codex, NOT $HOME/.codex/bin: /data is persistent regardless of the
 # configurable data_location, and the managed MCP merge treats commands under $HOME as
 # user-installed. Codex state (auth.json, config.toml) remains in the runtime user's home.
+#
+# Codex is distributed as a package tree, not as a lone executable: since 0.147.0 every shell and
+# file-read tool call is executed by a companion binary, codex-code-mode-host, that Codex looks up
+# next to itself. Upstream publishes that tree as the codex-package-<target> release asset, and the
+# whole tree is installed here. Its layout is load-bearing and must not be flattened: Codex
+# canonicalises its own executable path, requires the parent directory to be named `bin`, and then
+# reads codex-package.json, codex-resources/ and codex-path/ from that directory's parent. The
+# executable's file name is not part of that contract, which is why codex-real keeps its name.
 CODEX_ROOT="/data/codex"
 CODEX_PREFIX="${CODEX_ROOT}/bin"
 CODEX_BIN="${CODEX_PREFIX}/codex"
 CODEX_REAL="${CODEX_PREFIX}/codex-real"
+CODEX_HOST="${CODEX_PREFIX}/codex-code-mode-host"
+CODEX_MANIFEST="${CODEX_ROOT}/codex-package.json"
 CODEX_STAMP="${CODEX_PREFIX}/.version"
 CODEX_LINK="/usr/local/bin/codex"
 CODEX_RELEASE_API="https://api.github.com/repos/openai/codex/releases/latest"
@@ -26,6 +36,32 @@ fi
 
 run_as_runtime_user() {
     s6-setuidgid abc env HOME="$RUNTIME_HOME" CODEX_HOME="$RUNTIME_HOME/.codex" "$@"
+}
+
+# Move a verified package tree from staging into the install prefix. Called only from an `if`
+# condition, where `set -e` does not apply, so every step reports failure explicitly.
+#
+# The long, failure-prone part of an install — the download and its digest check — is already done
+# by the time this runs; what is left is same-filesystem renames of an already validated tree. They
+# are not one atomic operation, so the version stamp is removed first: any interruption leaves a
+# stamp-less prefix, which the next boot treats as "not installed" and replaces wholesale. The
+# entrypoint is moved last, so a prefix whose codex-real is the new release is a prefix whose
+# helper binaries are the new release too.
+install_codex_package() {
+    local staged="$1"
+    local optional
+    rm -f -- "$CODEX_STAMP" || return 1
+    rm -rf -- "${CODEX_ROOT}/codex-resources" "${CODEX_ROOT}/codex-path" || return 1
+    # codex-resources/ and codex-path/ hold optional helpers (bubblewrap, zsh, ripgrep) that Codex
+    # falls back to system copies for, so a target that ships without them still installs.
+    for optional in codex-resources codex-path; do
+        if [ -d "${staged}/${optional}" ]; then
+            mv -f -- "${staged}/${optional}" "${CODEX_ROOT}/${optional}" || return 1
+        fi
+    done
+    mv -f -- "${staged}/codex-package.json" "$CODEX_MANIFEST" || return 1
+    mv -f -- "${staged}/bin/codex-code-mode-host" "$CODEX_HOST" || return 1
+    mv -f -- "${staged}/bin/codex" "$CODEX_REAL" || return 1
 }
 
 if ! bashio::config.true 'install_codex_cli'; then
@@ -44,7 +80,7 @@ case "$(uname -m)" in
         ;;
 esac
 
-CODEX_ASSET="codex-${CODEX_TARGET}.tar.gz"
+CODEX_ASSET="codex-package-${CODEX_TARGET}.tar.gz"
 mkdir -p "$CODEX_PREFIX"
 
 # Migrate the PR's earlier direct-binary layout to the enforced wrapper layout without another
@@ -118,6 +154,9 @@ fi
 if [ -z "$release_info" ]; then
     if [ -x "$CODEX_REAL" ] && run_as_runtime_user "$CODEX_REAL" --version > /dev/null 2>&1; then
         bashio::log.warning "Unable to resolve the latest verified Codex release; keeping the existing install"
+        if [ ! -x "$CODEX_HOST" ]; then
+            bashio::log.warning "The existing Codex install has no code-mode host; its tool calls will fail until a boot can reach the release metadata"
+        fi
     else
         bashio::log.warning "Unable to resolve the latest verified Codex release; Codex is unavailable this boot"
         exit 0
@@ -125,31 +164,50 @@ if [ -z "$release_info" ]; then
 else
     IFS=$'\t' read -r CODEX_WANTED CODEX_SHA256 CODEX_URL <<< "$release_info"
 
+    # An install is complete only if the code-mode host and the package manifest are there too:
+    # every install made before this add-on switched to the package asset has a working codex-real
+    # and no helpers, and repairs itself here rather than needing a fresh /data. Running the binary
+    # also rejects one built for another architecture, which a restored backup could leave behind.
     if [ -x "$CODEX_REAL" ] \
+        && [ -x "$CODEX_HOST" ] \
+        && [ -f "$CODEX_MANIFEST" ] \
         && [ "$(cat "$CODEX_STAMP" 2> /dev/null || true)" = "$CODEX_WANTED" ] \
         && run_as_runtime_user "$CODEX_REAL" --version > /dev/null 2>&1; then
         bashio::log.info "Codex CLI ${CODEX_WANTED} already installed (latest stable)"
     else
         bashio::log.info "Installing latest stable Codex CLI ${CODEX_WANTED} (${CODEX_TARGET}); this is a large one-time download"
         archive="${codex_tmp}/${CODEX_ASSET}"
-        extracted="${codex_tmp}/codex-${CODEX_TARGET}"
+        staged="${codex_tmp}/package"
 
-        # Fail open for add-on startup but fail closed for the candidate binary: its official
+        # Fail open for add-on startup but fail closed for the candidate release: its official
         # release digest must match before extraction or execution, and replacement happens only
-        # after the staged binary successfully runs.
-        if curl -fsSL --retry 3 --retry-delay 2 --connect-timeout 10 --max-time 600 \
-            -o "$archive" "$CODEX_URL" \
+        # after the staged tree is complete and its entrypoint successfully runs. The candidate is
+        # exercised in staging with its own codex-package.json and helper directories in place, so
+        # the layout Codex will resolve at runtime is the layout that was validated.
+        if mkdir -p "$staged" \
+            && chmod 0755 "$staged" \
+            && curl -fsSL --retry 3 --retry-delay 2 --connect-timeout 10 --max-time 600 \
+                -o "$archive" "$CODEX_URL" \
             && printf '%s  %s\n' "$CODEX_SHA256" "$archive" | sha256sum -c - > /dev/null \
-            && tar -xzf "$archive" -C "$codex_tmp" \
-            && [ -f "$extracted" ] \
-            && chmod 0755 "$extracted" \
-            && run_as_runtime_user "$extracted" --version > /dev/null 2>&1 \
-            && mv -f "$extracted" "$CODEX_REAL"; then
+            && tar -xzf "$archive" -C "$staged" \
+            && [ -f "${staged}/codex-package.json" ] \
+            && [ -f "${staged}/bin/codex" ] \
+            && [ -f "${staged}/bin/codex-code-mode-host" ] \
+            && chmod 0755 "${staged}/bin/codex" "${staged}/bin/codex-code-mode-host" \
+            && run_as_runtime_user "${staged}/bin/codex" --version > /dev/null 2>&1 \
+            && install_codex_package "$staged"; then
             printf '%s' "$CODEX_WANTED" > "$CODEX_STAMP"
             bashio::log.info "Codex CLI installed: $("$CODEX_REAL" --version 2> /dev/null || echo unknown)"
-        elif [ -x "$CODEX_REAL" ]; then
+        elif [ -x "$CODEX_REAL" ] && [ -f "$CODEX_STAMP" ]; then
             bashio::log.warning "Verified Codex ${CODEX_WANTED} installation failed; keeping the existing install"
         else
+            # The stamp is removed before the first file is replaced, so a missing stamp next to an
+            # existing codex-real means the replacement itself was interrupted and the prefix may
+            # now mix two releases. Never expose that: drop the entrypoint so this boot reports
+            # Codex as unavailable — the failure this whole change fixes was a Codex that looked
+            # installed and answered normally while being unable to do anything — and let the next
+            # boot reinstall from scratch.
+            rm -f -- "$CODEX_REAL"
             bashio::log.warning "Verified Codex ${CODEX_WANTED} installation failed; Codex is unavailable this boot"
         fi
     fi

--- a/claude_desktop/rootfs/etc/cont-init.d/81-codex_cli.sh
+++ b/claude_desktop/rootfs/etc/cont-init.d/81-codex_cli.sh
@@ -38,6 +38,18 @@ run_as_runtime_user() {
     s6-setuidgid abc env HOME="$RUNTIME_HOME" CODEX_HOME="$RUNTIME_HOME/.codex" "$@"
 }
 
+# What "installed" means, in one place. A Codex that is missing its code-mode host, its package
+# manifest or its version stamp still starts, authenticates and answers — it simply cannot run a
+# single tool call — so presence of the executable alone is not a usable install. The stamp counts
+# because it is removed before the first file of a replacement is moved and written after the last,
+# so its absence next to an executable means the tree may mix two releases.
+codex_install_is_complete() {
+    [ -x "$CODEX_REAL" ] \
+        && [ -x "$CODEX_HOST" ] \
+        && [ -f "$CODEX_MANIFEST" ] \
+        && [ -f "$CODEX_STAMP" ]
+}
+
 # Move a verified package tree from staging into the install prefix. Called only from an `if`
 # condition, where `set -e` does not apply, so every step reports failure explicitly.
 #
@@ -152,14 +164,10 @@ PY
 fi
 
 if [ -z "$release_info" ]; then
-    if [ -x "$CODEX_REAL" ] && run_as_runtime_user "$CODEX_REAL" --version > /dev/null 2>&1; then
+    if codex_install_is_complete && run_as_runtime_user "$CODEX_REAL" --version > /dev/null 2>&1; then
         bashio::log.warning "Unable to resolve the latest verified Codex release; keeping the existing install"
-        if [ ! -x "$CODEX_HOST" ]; then
-            bashio::log.warning "The existing Codex install has no code-mode host; its tool calls will fail until a boot can reach the release metadata"
-        fi
     else
-        bashio::log.warning "Unable to resolve the latest verified Codex release; Codex is unavailable this boot"
-        exit 0
+        bashio::log.warning "Unable to resolve the latest verified Codex release; the installed Codex is missing or incomplete and stays unavailable until a boot can reach the release metadata"
     fi
 else
     IFS=$'\t' read -r CODEX_WANTED CODEX_SHA256 CODEX_URL <<< "$release_info"
@@ -168,9 +176,7 @@ else
     # every install made before this add-on switched to the package asset has a working codex-real
     # and no helpers, and repairs itself here rather than needing a fresh /data. Running the binary
     # also rejects one built for another architecture, which a restored backup could leave behind.
-    if [ -x "$CODEX_REAL" ] \
-        && [ -x "$CODEX_HOST" ] \
-        && [ -f "$CODEX_MANIFEST" ] \
+    if codex_install_is_complete \
         && [ "$(cat "$CODEX_STAMP" 2> /dev/null || true)" = "$CODEX_WANTED" ] \
         && run_as_runtime_user "$CODEX_REAL" --version > /dev/null 2>&1; then
         bashio::log.info "Codex CLI ${CODEX_WANTED} already installed (latest stable)"
@@ -198,22 +204,24 @@ else
             && install_codex_package "$staged"; then
             printf '%s' "$CODEX_WANTED" > "$CODEX_STAMP"
             bashio::log.info "Codex CLI installed: $("$CODEX_REAL" --version 2> /dev/null || echo unknown)"
-        elif [ -x "$CODEX_REAL" ] && [ -f "$CODEX_STAMP" ]; then
+        elif codex_install_is_complete; then
             bashio::log.warning "Verified Codex ${CODEX_WANTED} installation failed; keeping the existing install"
         else
-            # The stamp is removed before the first file is replaced, so a missing stamp next to an
-            # existing codex-real means the replacement itself was interrupted and the prefix may
-            # now mix two releases. Never expose that: drop the entrypoint so this boot reports
-            # Codex as unavailable — the failure this whole change fixes was a Codex that looked
-            # installed and answered normally while being unable to do anything — and let the next
-            # boot reinstall from scratch.
-            rm -f -- "$CODEX_REAL"
             bashio::log.warning "Verified Codex ${CODEX_WANTED} installation failed; Codex is unavailable this boot"
         fi
     fi
 fi
 
-if [ ! -x "$CODEX_REAL" ]; then
+# The launcher is the add-on's single "Codex is usable" signal: 82-claude_tools.sh registers the
+# Codex MCP server when it is executable and re-checks nothing else. Write it only for a complete
+# install, and remove it — together with the PATH symlink — for an incomplete one. Both the launcher
+# and the package tree live in /data and survive restarts independently, so a launcher left from an
+# earlier boot would otherwise outlive the install it was written for and advertise a Codex whose
+# every tool call fails. The executable, the package tree and the ChatGPT sign-in are all left in
+# place: a later boot completes the install without another download or another login.
+if ! codex_install_is_complete; then
+    rm -f -- "$CODEX_BIN" "$CODEX_LINK"
+    bashio::log.warning "Codex is not completely installed; not registering it this boot"
     exit 0
 fi
 

--- a/claude_desktop/rootfs/etc/cont-init.d/81-codex_cli.sh
+++ b/claude_desktop/rootfs/etc/cont-init.d/81-codex_cli.sh
@@ -53,6 +53,12 @@ codex_install_is_complete() {
 # Move a verified package tree from staging into the install prefix. Called only from an `if`
 # condition, where `set -e` does not apply, so every step reports failure explicitly.
 #
+# Whatever the package ships is installed, rather than the file names this add-on happens to know
+# about today: a helper added by a future release has to arrive beside codex-real on its own, or it
+# fails exactly the way the missing code-mode host did. Only paths the archive actually contains are
+# touched — /data/codex also holds this install's staging directory, so the tree below it is never
+# cleared wholesale.
+#
 # The long, failure-prone part of an install — the download and its digest check — is already done
 # by the time this runs; what is left is same-filesystem renames of an already validated tree. They
 # are not one atomic operation, so the version stamp is removed first: any interruption leaves a
@@ -61,18 +67,28 @@ codex_install_is_complete() {
 # helper binaries are the new release too.
 install_codex_package() {
     local staged="$1"
-    local optional
+    local entry name
     rm -f -- "$CODEX_STAMP" || return 1
-    rm -rf -- "${CODEX_ROOT}/codex-resources" "${CODEX_ROOT}/codex-path" || return 1
-    # codex-resources/ and codex-path/ hold optional helpers (bubblewrap, zsh, ripgrep) that Codex
-    # falls back to system copies for, so a target that ships without them still installs.
-    for optional in codex-resources codex-path; do
-        if [ -d "${staged}/${optional}" ]; then
-            mv -f -- "${staged}/${optional}" "${CODEX_ROOT}/${optional}" || return 1
+    # Everything beside bin/ first — the manifest and the helper directories (codex-resources/ and
+    # codex-path/ today, holding bubblewrap, zsh and ripgrep) — then everything the package puts in
+    # bin/ except the entrypoint, then the entrypoint. The existing launcher and version stamp are
+    # never matched: the launcher is skipped by name and the stamp is a dot file.
+    for entry in "${staged}"/*; do
+        name="${entry##*/}"
+        if [ ! -e "$entry" ] || [ "$name" = "bin" ]; then
+            continue
         fi
+        rm -rf -- "${CODEX_ROOT:?}/${name}" || return 1
+        mv -f -- "$entry" "${CODEX_ROOT}/${name}" || return 1
     done
-    mv -f -- "${staged}/codex-package.json" "$CODEX_MANIFEST" || return 1
-    mv -f -- "${staged}/bin/codex-code-mode-host" "$CODEX_HOST" || return 1
+    for entry in "${staged}"/bin/*; do
+        name="${entry##*/}"
+        if [ ! -e "$entry" ] || [ "$name" = "codex" ]; then
+            continue
+        fi
+        rm -rf -- "${CODEX_PREFIX:?}/${name}" || return 1
+        mv -f -- "$entry" "${CODEX_PREFIX}/${name}" || return 1
+    done
     mv -f -- "${staged}/bin/codex" "$CODEX_REAL" || return 1
 }
 

--- a/claude_desktop/rootfs/usr/local/bin/claude-tools-doctor.sh
+++ b/claude_desktop/rootfs/usr/local/bin/claude-tools-doctor.sh
@@ -186,7 +186,9 @@ if bashio::config.true 'install_codex_cli'; then
         # Codex runs every shell and file-read tool call through this companion binary. When it is
         # absent the CLI still starts, authenticates and answers, but each tool call fails and the
         # run still exits 0 — so report it explicitly rather than leaving it to be inferred.
-        if [ -x /data/codex/bin/codex-code-mode-host ] && [ -f /data/codex/codex-package.json ]; then
+        if [ -x /data/codex/bin/codex-code-mode-host ] \
+            && [ -f /data/codex/codex-package.json ] \
+            && [ -f /data/codex/bin/.version ]; then
             printf '%-30s %s\n' "package layout" "complete"
         else
             printf '%-30s %s\n' "package layout" "INCOMPLETE - tool calls will fail; restart the add-on to reinstall"

--- a/claude_desktop/rootfs/usr/local/bin/claude-tools-doctor.sh
+++ b/claude_desktop/rootfs/usr/local/bin/claude-tools-doctor.sh
@@ -183,6 +183,14 @@ if bashio::config.true 'install_codex_cli'; then
     if [ -x "$codex_bin" ]; then
         printf '%-30s %s\n' "installed" "$("$codex_bin" --version 2> /dev/null || echo 'FAILED TO RUN')"
         printf '%-30s %s\n' "installed version stamp" "$(cat /data/codex/bin/.version 2> /dev/null || echo 'MISSING')"
+        # Codex runs every shell and file-read tool call through this companion binary. When it is
+        # absent the CLI still starts, authenticates and answers, but each tool call fails and the
+        # run still exits 0 — so report it explicitly rather than leaving it to be inferred.
+        if [ -x /data/codex/bin/codex-code-mode-host ] && [ -f /data/codex/codex-package.json ]; then
+            printf '%-30s %s\n' "package layout" "complete"
+        else
+            printf '%-30s %s\n' "package layout" "INCOMPLETE - tool calls will fail; restart the add-on to reinstall"
+        fi
         printf '%-30s %s\n' "release policy" "latest stable, SHA-256 verified"
         printf '%-30s %s\n' "authentication policy" "ChatGPT subscription only"
 


### PR DESCRIPTION
## The bug

Since codex-cli 0.147.0 the Codex CLI does not run shell commands or read files itself. It
delegates every such tool call to a companion binary, `codex-code-mode-host`, that it looks up
next to its own executable. The add-on's installer, `81-codex_cli.sh`, downloads the
`codex-<target>.tar.gz` release asset, which contains nothing but the `codex` executable, so that
companion binary was never installed.

Measured on the running add-on (codex-cli 0.147.0; `/data/codex/bin` held only `.version`, the
launcher and `codex-real`, 246 MB): `codex exec` starts, authenticates and answers, but every tool
call fails with

```
failed to spawn code-mode host /data/codex/bin/codex-code-mode-host: No such file or directory (os error 2)
```

and the run still exits 0. Codex therefore answered from the prompt text alone while looking like
it had succeeded. `--disable code_mode` does not avoid it, and `--disable code_mode_host` only
changes the message to "code-mode host is disabled".

## The fix

Download `codex-package-<target>.tar.gz` — the complete package tree that upstream's own
`scripts/install/install.sh` installs — instead of the bare executable, and install all of it into
the existing `/data/codex` prefix: the entrypoint as `bin/codex-real`, `codex-code-mode-host`
beside it, and `codex-package.json`, `codex-resources/` (bundled bubblewrap and zsh) and
`codex-path/` (bundled ripgrep) in `/data/codex`.

Cherry-picking just the two binaries out of that tree also works today (I tested it), but it is
the same mistake at a smaller scale: the next helper upstream adds would break in exactly this
way again.

The prefix did not have to move. Reading `codex-rs/install-context/src/lib.rs` at `rust-v0.148.0`:
Codex canonicalises its own executable path, requires the parent directory to be named `bin`, and
then reads `codex-package.json`, `codex-resources/` and `codex-path/` from that directory's
parent. `/data/codex/bin` already satisfies that, and the executable's *file name* is not part of
the contract — so `codex-real`, the subscription-only `codex` launcher that wraps it, the
`/usr/local/bin/codex` symlink and the MCP registration are all unchanged.

Two further changes:

- **Self-healing.** The "already installed, skip the download" test now also requires
  `codex-code-mode-host` and `codex-package.json`. Every install made before this PR has a working
  `codex-real` and no helpers, so it repairs itself on the next start rather than needing a fresh
  `/data`. Running the binary as part of that test also rejects one built for another architecture.
- **No silent half-installs.** The version stamp is deleted before the first file is replaced and
  written only after the last. If the replacement is interrupted, the stamp-less prefix identifies
  that case, the entrypoint is removed too, the boot honestly reports Codex as unavailable, and the
  next start reinstalls in full — rather than leaving a Codex that mixes two releases and, once
  again, looks fine while misbehaving.

`claude-tools-doctor.sh` now reports whether the package layout is complete, because this failure
mode is invisible in `codex --version`, in the version stamp and in the exit code.

## Verified

- **Root cause and layout contract** — read from the pinned upstream source at `rust-v0.148.0`, not
  inferred. The x86_64 package tarball has no top-level directory: `bin/codex`,
  `bin/codex-code-mode-host`, `codex-package.json`, `codex-path/rg`, `codex-resources/bwrap`,
  `codex-resources/zsh/bin/zsh`. Both `codex-package-x86_64-unknown-linux-musl.tar.gz` and
  `codex-package-aarch64-unknown-linux-musl.tar.gz` are published with a GitHub SHA-256 digest, so
  the installer's existing digest gate still applies unchanged.
- **The install routine** — ran the new `install_codex_package` standalone against a real extracted
  package and a simulated pre-PR broken install (`codex-real` + stamp, no helpers). Result:
  `bin/codex-real`, `bin/codex-code-mode-host`, `codex-package.json`, `codex-path/rg`,
  `codex-resources/*`, with the stamp written last.
- **End to end** — ran a real `codex exec` from that exact installed tree. It executed
  `/bin/bash -lc 'cat /proc/sys/kernel/random/boot_id'` and returned the host's true boot id. Before
  the fix the same request produced the spawn error above. It did **not** switch to the bundled
  zsh; shell calls still go through `/bin/bash -lc`.
- **Interrupted install** — forced a `mv` to fail. The stamp was already gone, so the prefix is left
  stamp-less and the next boot reinstalls in full.
- `shellcheck`, `bash -n`, and `.claude/skills/hassio-addon-workflow/scripts/validate.sh
  claude_desktop --vs-master`: clean, no new findings versus master.
- Reviewed independently by Codex (gpt-5.6-sol) at plan and at diff stage. Its "install the whole
  package, not two files" recommendation is what shipped; its "make a failed replacement visible
  rather than silently mixed" objection produced the entrypoint-removal hunk.

## Not verified

- **The Docker build.** dockerd does not run in this environment; CI is the only gate.
- **aarch64.** This host is x86_64. The aarch64 path is the same code with a different target
  string, and I confirmed the aarch64 package asset exists with a digest, but no aarch64 install was
  executed.
- **A real add-on boot.** The installer was exercised by running the shipped script itself under
  stubbed bashio/s6 with its paths redirected into a scratch tree, not by booting the rebuilt
  add-on. s6 ordering, the real `/data` and the interaction with `82-claude_tools.sh` are exercised
  only on first start after this version is installed.
- The disk figures (~246 MB before, ~300 MB after) are measured from the extracted trees, not from
  a `/data` on a rebuilt add-on.

## Known separate limitation, not addressed here

Codex's own Linux sandbox cannot start in this container, and this is **not** caused by the
packaging bug. Running both the system `bwrap` 0.8.0 and the package's bundled `bwrap` directly as
`bwrap --dev-bind / / --unshare-net /bin/true` fails identically:

```
bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted
```

So it is a container capability limitation. Shipping the bundled bwrap changes nothing there.

Worth flagging separately, because I measured it while testing this fix and it outlives this PR:
with the **shipped default** `codex_sandbox_mode: workspace-write`, a tool call still fails with
that bwrap error even after this fix. I asked Codex to `cat /proc/sys/kernel/random/boot_id` under
`workspace-write` and got the bwrap error back instead of the value; under `danger-full-access` the
same request returned the correct id. `danger-full-access` is currently the only mode in which
Codex can execute anything in this container. Changing a shipped default is a maintainer decision,
so this PR does not touch it.


## Follow-up commit: advertise Codex only when its package tree is complete

Three bot reviewers converged on the same real gap, and all three claims reproduced against the
shipped script (bashio/s6 stubbed, `/data/codex` and `/usr/local/bin/codex` redirected into a
scratch tree, release API pointed at an unreachable endpoint):

`82-claude_tools.sh` registers the Codex MCP server whenever `/data/codex/bin/codex` is executable
and re-checks nothing else, while the launcher and the package tree persist in `/data`
independently of each other. So the launcher could sit next to an install that cannot run a single
tool call, reached three ways:

1. A boot that cannot fetch release metadata and keeps a pre-existing install that has `codex-real`
   but no code-mode host or manifest — every install predating this PR. Reproduced: the launcher
   and symlink were created.
2. The same boot finding a stamp-less tree left by an interrupted replacement (old `codex-real`,
   new host and manifest already moved in). Reproduced: logged `keeping the existing install`.
3. A launcher surviving from an earlier boot after the install was dropped. Reproduced: the script
   logged `Codex is unavailable this boot` and left a launcher that exits 127.

Fixed with one gate rather than three patches. Completeness is defined once — executable,
code-mode host, package manifest, and version stamp — and the launcher is written only when it
holds; otherwise the launcher and the `/usr/local/bin/codex` symlink are removed and the boot logs
`Codex is not completely installed; not registering it this boot`. The stamp belongs in that test
because it is deleted before the first file of a replacement is moved and written after the last,
so a stamp-less prefix is exactly the tree that may mix two releases. `claude-tools-doctor.sh`
checks the stamp for the same reason.

Consequently the failure path no longer deletes `codex-real`: with the launcher gone it is
harmless, and keeping it lets a later boot finish without another 112 MB download or another
ChatGPT sign-in.

Verified after the change: all four scenarios above re-run — the three broken ones now end with the
launcher absent, and a complete install during a metadata outage still registers. Separately, a
full end-to-end run of the shipped script against the live GitHub release upgraded a simulated
legacy install in 13.9 s and produced `bin/codex-real`, `bin/codex-code-mode-host`,
`codex-package.json`, `codex-path/rg`, `codex-resources/*`, the stamp `0.148.0`, the launcher, the
symlink and the managed `config.toml`; the launcher reports `codex-cli 0.148.0`.

## Rollback

The whole change is one commit touching one add-on. `git revert` it, or revert the riskiest hunk
alone — the asset switch — by restoring `CODEX_ASSET="codex-${CODEX_TARGET}.tar.gz"` and the old
single-file extract/validate/move chain in `81-codex_cli.sh`. On the next start the installer will
see a stamp that no longer matches and reinstall the bare executable, returning to today's
behaviour. Nothing outside `/data/codex` is touched, and `~/.codex` — where the ChatGPT sign-in
lives — is never written by the installer, so no rollback path costs the user a re-login.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Codex installations now include all required components and bundled resources.
  - Incomplete or outdated installations are automatically repaired during startup.
  - Updates are validated before replacement, preserving the previous working installation when needed.
  - Existing Codex state and integration paths remain unchanged.

- **Bug Fixes**
  - Fixed packaging issues that could cause Codex tool calls to fail.

- **Diagnostics**
  - Added checks to report whether the Codex installation is complete.

- **Documentation**
  - Updated installation guidance, validation details, upgrade storage requirements, and known Linux sandbox limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->