### PR TITLE
fix(calibre-web): trust the addon ip so ingress login works on 0.6.27

### DIFF
--- a/calibre_web/CHANGELOG.md
+++ b/calibre_web/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## 0.6.27.1 (2026-08-23)
+- Fix: Ingress login was rejected since 0.6.27, which only accepts the reverse proxy auth header from trusted source addresses. The addon now adds its own ip to that list (https://github.com/alexbelgium/hassio-addons/issues/3003)
+
 ## 0.6.27 (2026-08-13)
 - Update to latest version from linuxserver/docker-calibre-web (changelog : https://github.com/linuxserver/docker-calibre-web/releases)
 

--- a/calibre_web/config.yaml
+++ b/calibre_web/config.yaml
@@ -116,5 +116,5 @@ schema:
 slug: calibre-web
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/calibre_web
-version: "0.6.27"
+version: "0.6.27.1"
 video: true

--- a/calibre_web/rootfs/etc/cont-init.d/80-configuration.sh
+++ b/calibre_web/rootfs/etc/cont-init.d/80-configuration.sh
@@ -18,6 +18,22 @@ if [ ! -f /config/app.db ]; then
     bashio::log.warning "First boot : disabling Ingress until addon restart"
 else
     sqlite3 /config/app.db 'update settings set config_reverse_proxy_login_header_name="X-WebAuth-User",config_allow_reverse_proxy_header_login=1'
+
+    # Calibre-web 0.6.27 only accepts the ingress auth header from a trusted source address, and
+    # defaults that list to "127.0.0.1,::1". Nginx binds its upstream socket to the addon ip
+    # (proxy_bind $server_addr in ingress.conf) and calibre-web listens dual-stack, so it sees
+    # ::ffff:<addon ip> and drops the header. Both the plain and the ipv4-mapped forms are listed
+    # because an ipv4 entry never matches an ipv6-mapped address on the calibre-web side.
+    # The column only exists once calibre-web 0.6.27+ has migrated app.db, so a failure here is
+    # not fatal : the next start applies it.
+    addon_ip=$(bashio::addon.ip_address)
+    trusted_ips="127.0.0.1,::1,::ffff:127.0.0.1"
+    if bashio::var.has_value "${addon_ip}"; then
+        trusted_ips="${trusted_ips},${addon_ip},::ffff:${addon_ip}"
+    fi
+    if ! sqlite3 /config/app.db "update settings set config_reverse_proxy_trusted_ips='${trusted_ips}'" 2> /dev/null; then
+        bashio::log.warning "Could not set the ingress trusted ip list, it will be applied at next start"
+    fi
 fi
 
 bashio::log.info "Default username:password is admin:admin123"

--- a/calibre_web/rootfs/etc/cont-init.d/80-configuration.sh
+++ b/calibre_web/rootfs/etc/cont-init.d/80-configuration.sh
@@ -31,9 +31,13 @@ else
     if bashio::var.has_value "${addon_ip}"; then
         trusted_ips="${trusted_ips},${addon_ip},::ffff:${addon_ip}"
     fi
-    if ! sqlite3 /config/app.db "update settings set config_reverse_proxy_trusted_ips='${trusted_ips}'" 2> /dev/null; then
-        bashio::log.warning "Could not set the ingress trusted ip list, it will be applied at next start"
-    fi
+    trusted_ips_error=$(sqlite3 /config/app.db "update settings set config_reverse_proxy_trusted_ips='${trusted_ips}'" 2>&1) || {
+        if echo "${trusted_ips_error}" | grep -q "no such column"; then
+            bashio::log.warning "Could not set the ingress trusted ip list, it will be applied at next start"
+        else
+            bashio::log.warning "Could not set the ingress trusted ip list: ${trusted_ips_error}"
+        fi
+    }
 fi
 
 bashio::log.info "Default username:password is admin:admin123"


### PR DESCRIPTION
## Root cause

Calibre-web **0.6.27** added a trusted-source check in front of the reverse
proxy auth header. `cps/reverseproxy.py` now calls `is_trusted_proxy_source()`
(`cps/reverse_proxy_auth.py`) and strips `X-WebAuth-User` unless the connecting
address is listed in `config_reverse_proxy_trusted_ips`, which defaults to
`127.0.0.1,::1` (`cps/config_sql.py:160`).

Our ingress nginx binds its upstream socket to the add-on's own address:

`calibre_web/rootfs/etc/nginx/servers/ingress.conf:13`

```nginx
proxy_bind              $server_addr;
proxy_pass              http://127.0.0.1:8083;
```

`$server_addr` is the hassio-network address nginx listens on, so calibre-web
sees the request coming from the add-on's own IP, and because it listens
dual-stack it sees it in IPv4-mapped form — exactly what the reporter's log
shows:

```text
WARN {reverseproxy.py:80} Discarded reverse proxy auth header 'X-WebAuth-User'
from untrusted source IP-address: ::ffff:172.30.33.10
```

`calibre_web/rootfs/etc/cont-init.d/80-configuration.sh:20` sets
`config_reverse_proxy_login_header_name` and
`config_allow_reverse_proxy_header_login`, but nothing sets the new trusted-IP
list, so ingress auto-login stops working on every install after the 0.6.27
bump.

Note that an IPv4 entry can never match an IPv4-mapped IPv6 address:
`is_trusted_proxy_source()` compares with `ipaddress`, and
`ipaddress._BaseNetwork.__contains__` returns `False` whenever the address
versions differ. Both forms therefore have to be listed.

## The change

`80-configuration.sh` now writes the trusted list next to the two settings it
already applies:

```bash
addon_ip=$(bashio::addon.ip_address)
trusted_ips="127.0.0.1,::1,::ffff:127.0.0.1"
if bashio::var.has_value "${addon_ip}"; then
    trusted_ips="${trusted_ips},${addon_ip},::ffff:${addon_ip}"
fi
if ! sqlite3 /config/app.db "update settings set config_reverse_proxy_trusted_ips='${trusted_ips}'" 2> /dev/null; then
    bashio::log.warning "Could not set the ingress trusted ip list, it will be applied at next start"
fi
```

`bashio::addon.ip_address` is the same call `32-nginx.sh:49` already uses for
the nginx `listen` directive, so it is by construction the address
`proxy_bind $server_addr` will use. Only that one address is trusted rather
than the whole `172.30.32.0/23` supervisor subnet, so another add-on cannot
present `X-WebAuth-User` and be logged in as admin.

The statement is deliberately allowed to fail: `config_reverse_proxy_trusted_ips`
only exists once calibre-web 0.6.27+ has migrated `app.db`, and cont-init runs
*before* calibre-web. On the first start after upgrading from 0.6.26 the column
is still missing; without the tolerated failure the `set -e` at the top of the
script would abort init and the add-on would not start at all. The next start
applies it — the same "restart once" behaviour the script already has for the
first-boot case just above.

Also bumps `version` `0.6.27` → `0.6.27.1` (local patch counter appended;
`updater.json`'s `upstream_version` is `0.6.27` and is untouched).

## Verification

- `shellcheck -s bash` is clean on the changed script.
- The value this produces for the reporter's install is
  `127.0.0.1,::1,::ffff:127.0.0.1,172.30.33.10,::ffff:172.30.33.10`, which
  contains `::ffff:172.30.33.10` — the exact value they confirmed fixes the
  login by hand (their `::ffff:ac1e:210a` is the same address written in hex).
  The change applies it automatically instead of requiring a manual sqlite edit.
- Not run against a live add-on — no Home Assistant instance was available in
  this run. The CI Docker build is what validates the build itself.

Closes #3003

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Ingress login rejections by allowing authentication requests from the add-on’s own network address.
  * Improved reporting for trusted-address configuration errors while keeping non-critical failures from interrupting startup.
  * Existing installations will apply the updated trusted-address settings automatically when required.

* **Maintenance**
  * Updated the add-on version to 0.6.27.1 and documented the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->