### PR TITLE
fix(calibre-web): trust the supervisor range for the ingress auth header

### DIFF
--- a/calibre_web/CHANGELOG.md
+++ b/calibre_web/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## 0.6.27.2 (2026-08-23)
+- Fix: trust the whole supervisor network range for the ingress auth header instead of the addon's own address, which changes across restarts. The list is only written when that range is missing, so an entry added in the calibre-web admin page is no longer erased on every start (https://github.com/alexbelgium/hassio-addons/pull/3010)
+
 ## 0.6.27.1 (2026-08-23)
 - Fix: Ingress login was rejected since 0.6.27, which only accepts the reverse proxy auth header from trusted source addresses. The addon now adds its own ip to that list (https://github.com/alexbelgium/hassio-addons/issues/3003)
 

--- a/calibre_web/config.yaml
+++ b/calibre_web/config.yaml
@@ -116,5 +116,5 @@ schema:
 slug: calibre-web
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/calibre_web
-version: "0.6.27.1"
+version: "0.6.27.2"
 video: true

--- a/calibre_web/rootfs/etc/cont-init.d/80-configuration.sh
+++ b/calibre_web/rootfs/etc/cont-init.d/80-configuration.sh
@@ -24,10 +24,13 @@ else
     # supervisor network (proxy_bind $server_addr in ingress.conf) and calibre-web listens
     # dual-stack, so it sees ::ffff:<addon ip> and drops the header. The supervisor range is
     # listed in both forms because an ipv4 entry never matches an ipv4-mapped address.
-    # Written only when the range is missing, so a list edited since is left alone.
+    # Prepended to whatever is already there, and only when the mapped form is missing : that form
+    # is the one ingress needs and the one nobody types by hand, so it doubles as the marker that
+    # this already ran. Anything the user added is kept, the statement runs at most once, and the
+    # duplicates it can leave behind are entries calibre-web skips or already trusts.
     # The column only exists once calibre-web 0.6.27+ has migrated app.db and cont-init runs
     # before calibre-web, so a failure here is not fatal : the next start applies it.
-    trusted_ips_error=$(sqlite3 /config/app.db "update settings set config_reverse_proxy_trusted_ips='127.0.0.1,::1,::ffff:127.0.0.1,172.30.32.0/23,::ffff:172.30.32.0/119' where coalesce(config_reverse_proxy_trusted_ips,'') not like '%172.30.32.0/23%'" 2>&1) ||
+    trusted_ips_error=$(sqlite3 /config/app.db "update settings set config_reverse_proxy_trusted_ips='127.0.0.1,::1,::ffff:127.0.0.1,172.30.32.0/23,::ffff:172.30.32.0/119,'||coalesce(config_reverse_proxy_trusted_ips,'') where coalesce(config_reverse_proxy_trusted_ips,'') not like '%::ffff:172.30.32.0/119%'" 2>&1) ||
         bashio::log.warning "Could not set the ingress trusted ip list, it will be applied at next start (${trusted_ips_error})"
 fi
 

--- a/calibre_web/rootfs/etc/cont-init.d/80-configuration.sh
+++ b/calibre_web/rootfs/etc/cont-init.d/80-configuration.sh
@@ -19,25 +19,16 @@ if [ ! -f /config/app.db ]; then
 else
     sqlite3 /config/app.db 'update settings set config_reverse_proxy_login_header_name="X-WebAuth-User",config_allow_reverse_proxy_header_login=1'
 
-    # Calibre-web 0.6.27 only accepts the ingress auth header from a trusted source address, and
-    # defaults that list to "127.0.0.1,::1". Nginx binds its upstream socket to the addon ip
-    # (proxy_bind $server_addr in ingress.conf) and calibre-web listens dual-stack, so it sees
-    # ::ffff:<addon ip> and drops the header. Both the plain and the ipv4-mapped forms are listed
-    # because an ipv4 entry never matches an ipv6-mapped address on the calibre-web side.
-    # The column only exists once calibre-web 0.6.27+ has migrated app.db, so a failure here is
-    # not fatal : the next start applies it.
-    addon_ip=$(bashio::addon.ip_address)
-    trusted_ips="127.0.0.1,::1,::ffff:127.0.0.1"
-    if bashio::var.has_value "${addon_ip}"; then
-        trusted_ips="${trusted_ips},${addon_ip},::ffff:${addon_ip}"
-    fi
-    trusted_ips_error=$(sqlite3 /config/app.db "update settings set config_reverse_proxy_trusted_ips='${trusted_ips}'" 2>&1) || {
-        if echo "${trusted_ips_error}" | grep -q "no such column"; then
-            bashio::log.warning "Could not set the ingress trusted ip list, it will be applied at next start"
-        else
-            bashio::log.warning "Could not set the ingress trusted ip list: ${trusted_ips_error}"
-        fi
-    }
+    # Calibre-web 0.6.27 only accepts that header from a trusted source address, and defaults the
+    # list to "127.0.0.1,::1". Ingress reaches calibre-web from the addon's own address on the
+    # supervisor network (proxy_bind $server_addr in ingress.conf) and calibre-web listens
+    # dual-stack, so it sees ::ffff:<addon ip> and drops the header. The supervisor range is
+    # listed in both forms because an ipv4 entry never matches an ipv4-mapped address.
+    # Written only when the range is missing, so a list edited since is left alone.
+    # The column only exists once calibre-web 0.6.27+ has migrated app.db and cont-init runs
+    # before calibre-web, so a failure here is not fatal : the next start applies it.
+    trusted_ips_error=$(sqlite3 /config/app.db "update settings set config_reverse_proxy_trusted_ips='127.0.0.1,::1,::ffff:127.0.0.1,172.30.32.0/23,::ffff:172.30.32.0/119' where coalesce(config_reverse_proxy_trusted_ips,'') not like '%172.30.32.0/23%'" 2>&1) ||
+        bashio::log.warning "Could not set the ingress trusted ip list, it will be applied at next start (${trusted_ips_error})"
 fi
 
 bashio::log.info "Default username:password is admin:admin123"


### PR DESCRIPTION
Reimplements #3004 from the code as it stood before it, in one statement.
Supersedes #3009, which is closed.

## Why the rewrite

#3004 derived the add-on's own address and wrote it unconditionally on every start.
That address changes across restarts, so the value had to be rewritten each boot —
which erased anything the user had added to the same field from the calibre-web admin
page (Codex and Copilot both flagged this on the merged PR). Preserving their entries
then required a merge pass plus a record of what had been injected, because a preserved
stale address stays trusted once Supervisor hands it to another add-on.

Trusting the whole `172.30.32.0/23` range removes the reason for all of it. The range
covers whichever address the add-on is given, so the value is constant and can be
written once, and the merge machinery is not needed at all.

## The change

Net **-6 lines** against master. The entire diff to the script is one statement appended
to the two settings it already writes:

```bash
trusted_ips_error=$(sqlite3 /config/app.db "update settings set config_reverse_proxy_trusted_ips='127.0.0.1,::1,::ffff:127.0.0.1,172.30.32.0/23,::ffff:172.30.32.0/119,'||coalesce(config_reverse_proxy_trusted_ips,'') where coalesce(config_reverse_proxy_trusted_ips,'') not like '%::ffff:172.30.32.0/119%'" 2>&1) ||
    bashio::log.warning "Could not set the ingress trusted ip list, it will be applied at next start (${trusted_ips_error})"
```

Both forms of the range are listed because calibre-web listens dual-stack and an IPv4
entry never matches an IPv4-mapped address; `/119` is the mapped equivalent of `/23`
(`::ffff:ac1e:2000/119`).

Two details in that statement carry the review from the first revision:

The `WHERE` tests the **mapped** form, not the IPv4 one. Someone who reads that the
supervisor network is the source may add `172.30.32.0/23` by hand, and ingress still
fails because of the dual-stack listen — a guard on the IPv4 range would then skip
forever. The mapped form is the one ingress needs and the one nobody types by hand, so
it doubles as the marker that this already ran.

The list is **prepended** to the existing value, not assigned over it, so an entry an
administrator had already added survives the first start. No branch is needed for the
empty and NULL cases: the trailing comma leaves an empty entry, and calibre-web's
`parse_trusted_proxy_networks()` skips empty entries.

Together this runs at most once per install, and the duplicates it can leave behind are
entries calibre-web skips or addresses inside the range now trusted anyway.

## The trade-off, stated plainly

Any add-on on the supervisor network can now send `X-WebAuth-User` to port 8083 and be
logged in as that user. #3004 avoided this by trusting a single address. That protection
is deliberately given up here in exchange for the simplicity, as the maintainer's call.

## Verified

Ten cases run against real sqlite databases under `set -e`, all passing:

| case | result |
|---|---|
| fresh 0.6.27 default `127.0.0.1,::1` | required list prepended |
| IPv4 range present, mapped form absent | list applied (the guard finding) |
| user entry `192.168.1.5` present | survives the first run |
| upgrade from 0.6.27.1 (#3004's per-address list) | list applied, so those installs are fixed |
| manual `::ffff:ac1e:210a` workaround from #3003 | list applied, entry kept |
| run again on the script's own output | idempotent, not rewritten |
| user entry added after our write | left alone |
| `NULL` / empty value | written, trailing empty entry skipped by upstream |
| pre-migration `app.db`, column absent | warning with the sqlite error, non-fatal |

`set -e` never aborted. Separately checked against a transcription of `cps/reverse_proxy_auth.py` from 0.6.27
that every value this can produce parses with nothing ignored, that `::ffff:172.30.33.10`
is trusted, and that `::ffff:192.168.1.99` is not.

`shellcheck -s bash` clean; `validate.sh calibre_web --vs-master` reports no new findings
(the `services.d/nginx/finish` parse errors are pre-existing execline).

## Not verified

Not run against a live add-on — calibre-web is not installed on the machine this was
written on. The Docker build is CI's gate as usual.

## Rollback

One hunk in `calibre_web/rootfs/etc/cont-init.d/80-configuration.sh`. Reverting this
commit restores #3004's behaviour exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ingress authentication by trusting the complete supervisor network range.
  * Preserved administrator-added trusted network entries during startup.
  * Prevented trusted network settings from being overwritten when already configured.

* **Chores**
  * Updated the add-on version to 0.6.27.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->