### PR TITLE
Portainer Agent: use alpine-sts upstream image

### DIFF
--- a/portainer_agent/CHANGELOG.md
+++ b/portainer_agent/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2025.12.8 (2026-08-23)
+
+- Fix: Use `portainer/agent:alpine-sts` to match the STS release channel configured in `updater.json`
+
 ## 2025.12.7 (2026-08-23)
 
 - Fix: Docker reported the addon as `unhealthy` in Portainer. The healthcheck script could never run because its shebang required the s6-overlay environment, which this addon's entrypoint does not set up (https://github.com/alexbelgium/hassio-addons/issues/3002)

--- a/portainer_agent/CHANGELOG.md
+++ b/portainer_agent/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 2025.12.8 (2026-08-23)
+## 2.44.0 (2026-08-23)
 
 - Fix: Use `portainer/agent:alpine-sts` to match the STS release channel configured in `updater.json`
+- Fix: Align add-on versioning with Portainer STS releases
 
 ## 2025.12.7 (2026-08-23)
 

--- a/portainer_agent/Dockerfile
+++ b/portainer_agent/Dockerfile
@@ -18,7 +18,7 @@
 ARG BUILD_FROM
 
 # Get agent
-FROM portainer/agent:alpine as original_agent
+FROM portainer/agent:alpine-sts as original_agent
 ENV PORTAINER_AGENT_ARGS=""
 
 # Build using base

--- a/portainer_agent/config.yaml
+++ b/portainer_agent/config.yaml
@@ -41,4 +41,4 @@ schema:
 slug: portainer_agent
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "2025.12.8"
+version: "2.44.0"

--- a/portainer_agent/config.yaml
+++ b/portainer_agent/config.yaml
@@ -41,4 +41,4 @@ schema:
 slug: portainer_agent
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "2025.12.7"
+version: "2025.12.8"

--- a/portainer_agent/updater.json
+++ b/portainer_agent/updater.json
@@ -1,6 +1,6 @@
 {
-  "github_tagfilter": "alpine",
-  "last_update": "24-12-2025",
+  "github_tagfilter": "sts",
+  "last_update": "23-08-2026",
   "repository": "alexbelgium/hassio-addons",
   "slug": "portainer_agent",
   "source": "dockerhub",


### PR DESCRIPTION
## Summary

Fix the Portainer Agent add-on to use the STS upstream image declared in `updater.json`.

## Problem

The add-on currently tracks the STS release channel in `updater.json`:

```json
"upstream_version": "alpine-sts"
```

However, the Dockerfile actually builds the agent from:

```dockerfile
FROM portainer/agent:alpine as original_agent
```

These tags currently point to different Portainer Agent versions:

* `portainer/agent:alpine` → **2.39.6**
* `portainer/agent:alpine-sts` → **2.44.0**

As a result, the add-on reports Portainer Agent **2.39.6** even though it is configured to track the STS channel. This can also cause a version mismatch warning when connecting it to a Portainer Server running the current STS release.

## Changes

* Change the upstream image from `portainer/agent:alpine` to `portainer/agent:alpine-sts`.
* Update the add-on changelog.
* Bump the add-on version.

This makes the Dockerfile consistent with the existing `updater.json` configuration and ensures the packaged agent follows the intended Portainer STS release channel.

## Verification

After rebuilding the add-on, Portainer reports the agent as **2.44.0**, matching the current `alpine-sts` upstream image.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Portainer Agent add-on to version 2.44.0.
  * Aligned the add-on with the STS release channel for improved release compatibility.
  * Updated release tracking to follow STS-tagged releases.

* **Documentation**
  * Updated the changelog with version 2.44.0 details and STS versioning information.

* **Maintenance**
  * Refreshed the add-on update metadata date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->