### PR TITLE
feat(free_games_claimer): update upstream remaster to 1.6

### DIFF
--- a/free_games_claimer/CHANGELOG.md
+++ b/free_games_claimer/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 2.1.0 (2026-08-24)
+
+- Updated the pinned upstream from Free Games Claimer Remaster 1.1 to 1.6,
+  which adds the Ubisoft giveaway, Fab, AliExpress and Epic mobile stores,
+  fixed daily scheduler times, the `VNC_URL` notification link override, and a
+  fix for the `--accept-lang` flag that made every store's browser detectable
+  as automated.
+- Mirrored upstream's Chromium hardening: `xdg-open` is neutralised and an
+  `AutoLaunchProtocolsFromOrigins` policy is installed, so app-scheme links
+  cannot open a blocking dialog in the VNC session.
+- Disabled upstream's release-update notification by default. It tells the user
+  to run `docker compose pull`, while the add-on is updated through the Home
+  Assistant add-on store. Set `NOTIFY_UPDATES=true` in `config.env` to receive
+  it anyway.
+- The default store selection is unchanged: existing installations keep
+  claiming from Epic, Prime Gaming and GOG until `STORES` is edited.
+
 ## 2.0.1 (2026-07-17)
 
 - Aligned the pull-request build context with the production builder by copying

--- a/free_games_claimer/CHANGELOG.md
+++ b/free_games_claimer/CHANGELOG.md
@@ -17,7 +17,9 @@
 - Replaced the pinned upstream commit with `ARG BUILD_UPSTREAM`, which names an
   upstream release tag, and re-enabled the repository updater for this add-on.
   Upstream releases are now picked up automatically instead of requiring a
-  manual commit pin; upstream's development tags are excluded.
+  manual commit pin. Upstream's development tags are excluded: `lastversion`
+  reports the `v1.7d` development tag as release `1.7`, for which no source
+  archive exists, so an unfiltered update would have broken the build.
 
 ## 2.0.1 (2026-07-17)
 

--- a/free_games_claimer/CHANGELOG.md
+++ b/free_games_claimer/CHANGELOG.md
@@ -12,6 +12,8 @@
   to run `docker compose pull`, while the add-on is updated through the Home
   Assistant add-on store. Set `NOTIFY_UPDATES=true` in `config.env` to receive
   it anyway.
+- Reworded the add-on description so the store list reads as partial rather
+  than exhaustive; the full list is in the README.
 - The default store selection is unchanged: existing installations keep
   claiming from Epic, Prime Gaming and GOG until `STORES` is edited.
 - Replaced the pinned upstream commit with `ARG BUILD_UPSTREAM`, which names an

--- a/free_games_claimer/CHANGELOG.md
+++ b/free_games_claimer/CHANGELOG.md
@@ -14,6 +14,10 @@
   it anyway.
 - The default store selection is unchanged: existing installations keep
   claiming from Epic, Prime Gaming and GOG until `STORES` is edited.
+- Replaced the pinned upstream commit with `ARG BUILD_UPSTREAM`, which names an
+  upstream release tag, and re-enabled the repository updater for this add-on.
+  Upstream releases are now picked up automatically instead of requiring a
+  manual commit pin; upstream's development tags are excluded.
 
 ## 2.0.1 (2026-07-17)
 

--- a/free_games_claimer/Dockerfile
+++ b/free_games_claimer/Dockerfile
@@ -17,7 +17,7 @@ ARG BUILD_REF
 ARG BUILD_REPOSITORY
 ARG BUILD_VERSION
 ARG UPSTREAM_REPOSITORY="P-Adamiec/Free-Games-Claimer-Remaster"
-ARG UPSTREAM_REF="cca4992354215cef8807b748575af797606627f4"
+ARG UPSTREAM_REF="1e2b38f945b9371641c64a62cff1d5fb65df96c0"
 
 ENV S6_CMD_WAIT_FOR_SERVICES="1" \
     S6_CMD_WAIT_FOR_SERVICES_MAXTIME="0" \
@@ -87,6 +87,11 @@ RUN apt-get update \
     else \
         apt-get install -y --no-install-recommends chromium; \
     fi \
+    && printf '#!/bin/sh\nexit 0\n' > /usr/bin/xdg-open \
+    && chmod +x /usr/bin/xdg-open \
+    && mkdir -p /etc/opt/chrome/policies/managed /etc/chromium/policies/managed \
+    && printf '%s\n' '{"AutoLaunchProtocolsFromOrigins":[{"protocol":"aliexpress","allowed_origins":["*"]},{"protocol":"aliexpresshd","allowed_origins":["*"]},{"protocol":"aecmd","allowed_origins":["*"]},{"protocol":"alibaba","allowed_origins":["*"]},{"protocol":"alipay","allowed_origins":["*"]},{"protocol":"alipays","allowed_origins":["*"]},{"protocol":"tmall","allowed_origins":["*"]},{"protocol":"taobao","allowed_origins":["*"]},{"protocol":"market","allowed_origins":["*"]},{"protocol":"intent","allowed_origins":["*"]}]}' \
+       | tee /etc/opt/chrome/policies/managed/fgc-autolaunch.json /etc/chromium/policies/managed/fgc-autolaunch.json > /dev/null \
     && ln -sf /usr/share/novnc/vnc_auto.html /usr/share/novnc/index.html \
     && ln -sf /usr/bin/python3 /usr/bin/python \
     && apt-get purge -y gnupg \

--- a/free_games_claimer/Dockerfile
+++ b/free_games_claimer/Dockerfile
@@ -97,10 +97,12 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* /var/cache/* /var/tmp/* /tmp/* /usr/share/doc/*
 
 # Install the upstream release named by BUILD_UPSTREAM. The repository updater
-# bumps that value together with the add-on version, so the image contents
-# still cannot change without a version bump. Upstream tags its releases
-# "v1.6", but the tag name is downloaded without the prefix as well so that an
-# unattended update does not fail the build if upstream ever drops it.
+# bumps that value together with the add-on version. A release tag is a mutable
+# reference: rebuilding the same BUILD_UPSTREAM installs whatever the tag points
+# at today, which is the accepted cost of tracking upstream automatically.
+# Upstream tags its releases "v1.6", but the tag name is downloaded without the
+# prefix as well so that an unattended update does not fail the build if
+# upstream ever drops it.
 WORKDIR /fgc
 RUN (curl --proto "=https" --tlsv1.2 -fsSL \
         "https://github.com/${UPSTREAM_REPOSITORY}/archive/v${BUILD_UPSTREAM}.tar.gz" \

--- a/free_games_claimer/Dockerfile
+++ b/free_games_claimer/Dockerfile
@@ -17,7 +17,7 @@ ARG BUILD_REF
 ARG BUILD_REPOSITORY
 ARG BUILD_VERSION
 ARG UPSTREAM_REPOSITORY="P-Adamiec/Free-Games-Claimer-Remaster"
-ARG UPSTREAM_REF="1e2b38f945b9371641c64a62cff1d5fb65df96c0"
+ARG BUILD_UPSTREAM="1.6"
 
 ENV S6_CMD_WAIT_FOR_SERVICES="1" \
     S6_CMD_WAIT_FOR_SERVICES_MAXTIME="0" \
@@ -27,10 +27,7 @@ ENV S6_CMD_WAIT_FOR_SERVICES="1" \
     WIDTH="1280" \
     HEIGHT="720" \
     DEPTH="24" \
-    SHOW="1" \
-    COMMIT="${UPSTREAM_REF}" \
-    BRANCH="main" \
-    NOW="${BUILD_DATE}"
+    SHOW="1"
 
 # Install the dependencies used by Free Games Claimer Remaster. The upstream
 # Dockerfile supports both amd64 (Google Chrome) and arm64 (Chromium), so the
@@ -99,12 +96,12 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/* /var/tmp/* /tmp/* /usr/share/doc/*
 
-# Install a deterministic snapshot of the replacement upstream. Updating the
-# upstream reference is intentionally explicit so image contents cannot change
-# without an add-on version bump.
+# Install the upstream release named by BUILD_UPSTREAM. The repository updater
+# bumps that value together with the add-on version, so the image contents
+# still cannot change without a version bump.
 WORKDIR /fgc
 RUN curl --proto "=https" --tlsv1.2 -fsSL \
-        "https://github.com/${UPSTREAM_REPOSITORY}/archive/${UPSTREAM_REF}.tar.gz" \
+        "https://github.com/${UPSTREAM_REPOSITORY}/archive/v${BUILD_UPSTREAM}.tar.gz" \
         -o /tmp/free-games-claimer-remaster.tar.gz \
     && tar -xzf /tmp/free-games-claimer-remaster.tar.gz --strip-components=1 -C /fgc \
     && python3 -m pip install --no-cache-dir --break-system-packages -r requirements.txt \
@@ -160,4 +157,4 @@ LABEL \
     org.opencontainers.image.created="${BUILD_DATE}" \
     org.opencontainers.image.revision="${BUILD_REF}" \
     org.opencontainers.image.version="${BUILD_VERSION}" \
-    io.hass.upstream="https://github.com/${UPSTREAM_REPOSITORY}/tree/${UPSTREAM_REF}"
+    io.hass.upstream="https://github.com/${UPSTREAM_REPOSITORY}/releases/tag/v${BUILD_UPSTREAM}"

--- a/free_games_claimer/Dockerfile
+++ b/free_games_claimer/Dockerfile
@@ -164,4 +164,4 @@ LABEL \
     org.opencontainers.image.created="${BUILD_DATE}" \
     org.opencontainers.image.revision="${BUILD_REF}" \
     org.opencontainers.image.version="${BUILD_VERSION}" \
-    io.hass.upstream="https://github.com/${UPSTREAM_REPOSITORY}/releases/tag/v${BUILD_UPSTREAM}"
+    io.hass.upstream="https://github.com/${UPSTREAM_REPOSITORY}/releases"

--- a/free_games_claimer/Dockerfile
+++ b/free_games_claimer/Dockerfile
@@ -98,11 +98,16 @@ RUN apt-get update \
 
 # Install the upstream release named by BUILD_UPSTREAM. The repository updater
 # bumps that value together with the add-on version, so the image contents
-# still cannot change without a version bump.
+# still cannot change without a version bump. Upstream tags its releases
+# "v1.6", but the tag name is downloaded without the prefix as well so that an
+# unattended update does not fail the build if upstream ever drops it.
 WORKDIR /fgc
-RUN curl --proto "=https" --tlsv1.2 -fsSL \
+RUN (curl --proto "=https" --tlsv1.2 -fsSL \
         "https://github.com/${UPSTREAM_REPOSITORY}/archive/v${BUILD_UPSTREAM}.tar.gz" \
         -o /tmp/free-games-claimer-remaster.tar.gz \
+        || curl --proto "=https" --tlsv1.2 -fsSL \
+            "https://github.com/${UPSTREAM_REPOSITORY}/archive/${BUILD_UPSTREAM}.tar.gz" \
+            -o /tmp/free-games-claimer-remaster.tar.gz) \
     && tar -xzf /tmp/free-games-claimer-remaster.tar.gz --strip-components=1 -C /fgc \
     && python3 -m pip install --no-cache-dir --break-system-packages -r requirements.txt \
     && dos2unix ./*.sh \

--- a/free_games_claimer/README.md
+++ b/free_games_claimer/README.md
@@ -142,16 +142,23 @@ normally uses port `7080`.
 
 ## Upstream update policy
 
-The image is built from an explicit upstream commit in the Dockerfile. This
-keeps amd64 and aarch64 images reproducible and prevents an upstream branch or
-container tag from changing without an add-on review and version bump.
+The image is built from the upstream release named by `ARG BUILD_UPSTREAM` in
+the Dockerfile, downloaded as the matching `v<version>` source tarball. The
+repository updater tracks upstream releases and bumps that value, the add-on
+version and `CHANGELOG.md` together, so a new upstream release reaches the
+add-on without a manual edit while the image contents still never change
+without a version bump.
 
-The repository updater is intentionally paused for this add-on because the
-add-on uses its own `2.x` version series while the replacement upstream uses a
-`1.x` version series. An automatic replacement would risk a Home Assistant
-version regression and would not safely update the pinned commit. A maintainer
-upstream update must therefore update `UPSTREAM_REF`, `upstream_version`, the
-add-on version, and `CHANGELOG.md` together.
+Upstream's development tags (`v1.7d` and similar) carry no GitHub release and
+are filtered out through `"github_exclude": "d"` in `updater.json`.
+
+The add-on version does not track the upstream version. The add-on uses a `2.x`
+series while upstream is on `1.x`, and Home Assistant only offers an update
+when the new version sorts strictly higher, so the updater increments the
+add-on version (`2.1.0` to `2.1.1`) instead of publishing a lower-sorting
+upstream number. The upstream release actually installed is recorded in
+`upstream_version` in `updater.json`, in the `io.hass.upstream` image label,
+and in the add-on's startup banner.
 
 ## Installation
 

--- a/free_games_claimer/README.md
+++ b/free_games_claimer/README.md
@@ -165,8 +165,8 @@ series while upstream is on `1.x`, and Home Assistant only offers an update
 when the new version sorts strictly higher, so the updater increments the
 add-on version (`2.1.0` to `2.1.1`) instead of publishing a lower-sorting
 upstream number. The upstream release actually installed is recorded in
-`upstream_version` in `updater.json`, in the `io.hass.upstream` image label,
-and in the add-on's startup banner.
+`upstream_version` in `updater.json`, in `CHANGELOG.md`, and in the add-on's
+startup banner.
 
 ## Installation
 

--- a/free_games_claimer/README.md
+++ b/free_games_claimer/README.md
@@ -149,8 +149,10 @@ version and `CHANGELOG.md` together, so a new upstream release reaches the
 add-on without a manual edit while the image contents still never change
 without a version bump.
 
-Upstream's development tags (`v1.7d` and similar) carry no GitHub release and
-are filtered out through `"github_exclude": "d"` in `updater.json`.
+Upstream's development tags (`v1.7d` and similar) are filtered out through
+`"github_exclude": "d"` in `updater.json`. Without it the updater reports the
+`v1.7d` tag as release `1.7`, for which GitHub serves no source archive, and
+the build would fail.
 
 The add-on version does not track the upstream version. The add-on uses a `2.x`
 series while upstream is on `1.x`, and Home Assistant only offers an update

--- a/free_games_claimer/README.md
+++ b/free_games_claimer/README.md
@@ -146,8 +146,14 @@ The image is built from the upstream release named by `ARG BUILD_UPSTREAM` in
 the Dockerfile, downloaded as the matching `v<version>` source tarball. The
 repository updater tracks upstream releases and bumps that value, the add-on
 version and `CHANGELOG.md` together, so a new upstream release reaches the
-add-on without a manual edit while the image contents still never change
-without a version bump.
+add-on without a manual edit.
+
+A release tag is a mutable reference. Rebuilding the same `BUILD_UPSTREAM`
+installs whatever that tag points at, so an upstream tag that is force-moved or
+deleted would change or fail the build without an add-on change. That is the
+accepted cost of automatic tracking, and it is the same trade-off every other
+automatically updated add-on in this repository makes; the previous commit pin
+was immutable but could only be advanced by hand.
 
 Upstream's development tags (`v1.7d` and similar) are filtered out through
 `"github_exclude": "d"` in `updater.json`. Without it the updater reports the

--- a/free_games_claimer/README.md
+++ b/free_games_claimer/README.md
@@ -24,14 +24,19 @@ This add-on is based on
 [Free Games Claimer Remaster](https://github.com/P-Adamiec/Free-Games-Claimer-Remaster).
 It can claim free games from:
 
-- Epic Games Store
+- Epic Games Store, including its weekly free mobile game
+- Fab, Epic's asset marketplace (`fab`)
 - Amazon Prime Gaming
 - GOG
 - Steam
+- Ubisoft giveaways (`ubisoft`)
+- AliExpress daily coin check-in (`aliexpress`)
 - GamerPower-supported stores, when explicitly enabled
 
 For compatibility with previous add-on releases, the default store selection
-remains Epic Games, Prime Gaming, and GOG.
+remains Epic Games, Prime Gaming, and GOG. The other stores are enabled by
+adding them to `STORES`, for example `epic,prime,gog,fab,ubisoft`, and each
+needs its own credentials in `config.env`.
 
 ## Web interface
 
@@ -97,6 +102,11 @@ STEAM_PASSWORD=your-password
 NOTIFY=tgram://bot-token/chat-id
 # DISCORD_WEBHOOK=https://discord.com/api/webhooks/...
 ```
+
+Upstream's release-update notification (`NOTIFY_UPDATES`) is disabled by the
+add-on, because it advises running `docker compose pull` while the add-on is
+actually updated through the Home Assistant add-on store. Setting
+`NOTIFY_UPDATES=true` in `config.env` re-enables it.
 
 Existing variables such as `EG_EMAIL`, `EG_PASSWORD`, `PG_EMAIL`,
 `PG_PASSWORD`, `PG_OTPKEY`, `GOG_EMAIL`, `GOG_PASSWORD`, `SHOW`, `WIDTH`,

--- a/free_games_claimer/config.yaml
+++ b/free_games_claimer/config.yaml
@@ -2,7 +2,7 @@
 arch:
   - aarch64
   - amd64
-description: "Automatically claims free games from Epic Games Store, Amazon Prime Gaming, GOG, Steam, and optional GamerPower-supported stores"
+description: "Claims free games from Epic, Fab, Prime, GOG, Steam, Ubisoft"
 devices:
   - /dev/dri
   - /dev/dri/card0
@@ -96,5 +96,5 @@ schema:
 slug: free_games_claimer
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "2.0.1"
+version: "2.1.0"
 webui: "[PROTO:ssl]://[HOST]:[PORT:6080]"

--- a/free_games_claimer/config.yaml
+++ b/free_games_claimer/config.yaml
@@ -2,7 +2,7 @@
 arch:
   - aarch64
   - amd64
-description: "Claims free games from Epic, Fab, Prime, GOG, Steam, Ubisoft"
+description: "Claims free games from Epic, Prime, GOG, Steam, Ubisoft and more"
 devices:
   - /dev/dri
   - /dev/dri/card0

--- a/free_games_claimer/rootfs/etc/cont-init.d/99-run.sh
+++ b/free_games_claimer/rootfs/etc/cont-init.d/99-run.sh
@@ -36,6 +36,12 @@ set -a
 source "${RUNTIME_CONFIG}"
 set +a
 
+# Upstream checks GitHub for newer releases and then tells the user to run
+# "docker compose pull", which is wrong here: the add-on is updated through the
+# Home Assistant add-on store. Default the check off, but honour an explicit
+# NOTIFY_UPDATES from config.env.
+export NOTIFY_UPDATES="${NOTIFY_UPDATES:-false}"
+
 # The Home Assistant port mapping is intentionally kept at 6080 for a seamless
 # upgrade from the previous add-on, even though the new upstream defaults to 7080.
 if [ -n "${NOVNC_PORT:-}" ] && [ "${NOVNC_PORT}" != "6080" ]; then

--- a/free_games_claimer/rootfs/templates/config.env
+++ b/free_games_claimer/rootfs/templates/config.env
@@ -10,12 +10,17 @@ TIMEOUT=60
 LOGIN_TIMEOUT=180
 VNC_LOGIN_TIMEOUT=180
 NOVNC_PORT=6080
+# Public address used in notification links when behind a reverse proxy.
+# VNC_URL=https://fgc.example.tld
 
-# Keep the previous add-on's default stores. Add steam or gamerpower if wanted.
+# Keep the previous add-on's default stores. The upstream also supports
+# steam, fab, ubisoft, aliexpress and gamerpower; add them here if wanted.
 STORES=epic,prime,gog
 
 # Used only when RUN_ONCE is disabled in the add-on options.
 SCHEDULER_HOURS=12
+# SCHEDULER_TIMEZONE=UTC
+# SCHEDULER_FIXED_TIMES=17:00,21:30
 
 # Common credentials can be used as fallbacks for all stores.
 # EMAIL=
@@ -33,7 +38,27 @@ SCHEDULER_HOURS=12
 # GOG_PASSWORD=
 # STEAM_USERNAME=
 # STEAM_PASSWORD=
+# UBI_EMAIL=
+# UBI_PASSWORD=
+# UBI_OTPKEY=
+# AE_EMAIL=
+# AE_PASSWORD=
+
+# Epic's weekly free mobile game, claimed with the epic store.
+# EG_MOBILE=true
+# EG_MOBILE_PLATFORMS=android,ios
+
+# Fab assets sign in with the Epic account. Accepting the licence agreement is
+# required to claim; set to false to be notified instead of accepting.
+# FAB_ACCEPT_EULA=true
 
 # Notifications (Apprise or Discord)
 # NOTIFY=
 # DISCORD_WEBHOOK=
+# NOTIFY_ALREADY_CLAIMED=false
+# NOTIFY_SKIP_STORES=
+
+# Upstream release notifications are disabled by the add-on: updates are
+# delivered through the Home Assistant add-on store, not by docker compose.
+# Set to true to receive them anyway.
+# NOTIFY_UPDATES=false

--- a/free_games_claimer/updater.json
+++ b/free_games_claimer/updater.json
@@ -1,11 +1,11 @@
 {
   "dockerhub_by_date": false,
   "dockerhub_list_size": 2,
-  "last_update": "17-07-2026",
+  "last_update": "24-08-2026",
   "paused": true,
   "repository": "alexbelgium/hassio-addons",
   "slug": "free_games_claimer",
   "source": "github",
   "upstream_repo": "P-Adamiec/Free-Games-Claimer-Remaster",
-  "upstream_version": "1.1"
+  "upstream_version": "1.6"
 }

--- a/free_games_claimer/updater.json
+++ b/free_games_claimer/updater.json
@@ -1,8 +1,10 @@
 {
   "dockerhub_by_date": false,
   "dockerhub_list_size": 2,
+  "github_exclude": "d",
+  "github_fulltag": false,
   "last_update": "24-08-2026",
-  "paused": true,
+  "paused": false,
   "repository": "alexbelgium/hassio-addons",
   "slug": "free_games_claimer",
   "source": "github",


### PR DESCRIPTION
Closes #2990.

## What changed

`free_games_claimer` tracked upstream [Free-Games-Claimer-Remaster](https://github.com/P-Adamiec/Free-Games-Claimer-Remaster) at release **1.1**. This updates it to **1.6**, the newest release (19-08-2026); the issue asked for 1.5.

What 1.2 → 1.6 brings: the Ubisoft giveaway store, Fab (Epic's asset marketplace), AliExpress daily check-in, Epic's weekly free mobile game, fixed daily scheduler times (`SCHEDULER_FIXED_TIMES`), a `VNC_URL` override for notification links behind a reverse proxy, and a fix for the `--accept-lang=en-US,en;q=0.9` flag that leaked a quality value into `navigator.languages` and made every store's browser trivially detectable as automated.

Beyond the version bump:

- **Mirrored upstream's Chromium hardening into the add-on's own Dockerfile** — a no-op `/usr/bin/xdg-open` plus an `AutoLaunchProtocolsFromOrigins` managed policy for Chrome and Chromium. Without both, app-scheme links (`aliexpress://`, `intent://`, …) pop a modal that blocks the VNC session. The add-on Dockerfile is not upstream's, so these hunks do not arrive with the version bump.
- **Defaulted `NOTIFY_UPDATES` to `false`** in `99-run.sh`. Upstream's new release check notifies the user to run `docker compose pull`, which is wrong here: the add-on is updated through the Home Assistant add-on store. An explicit `NOTIFY_UPDATES=true` in `config.env` still wins, because the default is applied after `config.env` is sourced.
- Refreshed the `config.env` template (new store credentials, scheduler and notification options) and the README store list.
- **Dropped the upstream commit pin so the repository updater can advance the add-on by itself.** `ARG UPSTREAM_REF="1e2b38f…"` becomes `ARG BUILD_UPSTREAM="1.6"` — the idiom the updater rewrites, as in `bazarr` and `enedisgateway2mqtt` — and the build downloads `archive/v${BUILD_UPSTREAM}.tar.gz`. `updater.json` is unpaused, with `github_exclude: "d"` so upstream's development tags (`v1.5d`, `v1.6d`, `v1.7d`, none of which have a GitHub release) can never be selected. `COMMIT`/`BRANCH`/`NOW` are dropped: they existed to show the pinned SHA in the startup banner, which now shows upstream's own version. Details and verification in [this comment](https://github.com/alexbelgium/hassio-addons/pull/3012#issuecomment-5394786309).

**No shipped default changes for existing installs.** `STORES` still defaults to `epic,prime,gog`, so an existing installation keeps claiming from exactly the same three stores until its `config.env` is edited. The template only seeds new installs.

## Verified

- `validate.sh free_games_claimer --vs-master`: `bash -n`, shellcheck, hadolint and the config.yaml check pass, and the diff adds **no new lint findings** (the config.yaml description was shortened under 80 chars, which removes a pre-existing yamllint violation).
- Sourcing the new `config.env` template under `set -euo pipefail; set -a` parses cleanly and yields `STORES=epic,prime,gog NOVNC_PORT=6080 NOTIFY_UPDATES=false`; with `NOTIFY_UPDATES=true` present the user value survives.
- The pinned tarball URL resolves (HTTP 200) and the archive root still contains `requirements.txt` and `docker-entrypoint.sh`, which the add-on's build copies.
- The updater's global sed (`"1.6"` → `"1.7"`) simulated over the add-on: it touches the `ARG BUILD_UPSTREAM` line and nothing else. `ha_version.py --selftest` passes 48/48, and against `--current 2.1.0` it yields `2.1.1` for upstream `1.7`/`1.8`/`2.0`, `2.2` for `2.2` and `3.0` for `3.0` — always strictly newer, so Home Assistant keeps offering the update even though the add-on runs a `2.x` series against upstream's `1.x`.
- Independent review by Codex (gpt-5.6-sol) against the upstream sources: `docker-entrypoint.sh` is byte-identical between the two pins, upstream still resolves persistent state to `/fgc/data` (so the `/fgc/data -> /data` symlink contract holds), the `ClaimedGame` schema is unchanged so an existing `fgc.db` needs no migration, and the exported `NOTIFY_UPDATES` survives to the Python process because upstream loads `.env` with `override=False`.

## Verified in CI

The add-on build job is green on both architectures, and the log shows the changed layers actually ran rather than being served from cache:

```text
#10 [ 4/13] RUN (curl ... /archive/v1.6.tar.gz ... || curl ... /archive/1.6.tar.gz ...) && tar ... && pip install ...
#10 DONE 42.6s   (aarch64)
#10 DONE 10.5s   (amd64)
```

pip resolved the new dependency set on aarch64 as well — `nodriver-0.50.3`, `psutil-7.2.2`, `browserforge-1.2.4`, `tzdata-2026.3` — which closes the aarch64 wheel question this PR originally listed as reasoning rather than observation. All 13 layers build on both architectures.

## Not verified

- **Runtime claiming behaviour.** The add-on is not installed on the machine this was prepared on, so no claiming run was observed against the new upstream. A green build proves the image assembles, not that a claim succeeds.
- **The Chromium managed policy in a live session.** It is carried over verbatim from upstream, where it was added against an observed dialog; it was not exercised here.
- **A live updater run.** The bot runs weekly against master, so the first automatic bump is only observable after merge.
- The new stores (Ubisoft, Fab, AliExpress, Epic mobile) are shipped but untested — they are opt-in via `STORES` and off by default.

## Rollback

The riskiest change is the upstream version itself. Setting `ARG BUILD_UPSTREAM` in `free_games_claimer/Dockerfile` back to an older release restores that image on its own; the Chromium-policy hunk and the `NOTIFY_UPDATES` default are independent and harmless against 1.1. To stop automatic tracking entirely, set `"paused": true` in `free_games_claimer/updater.json` — that alone freezes the add-on again without touching the build.

**Trade-off accepted:** a tag can be force-moved or deleted upstream, which a commit SHA cannot. That is the price of automatic tracking, and the same one every other auto-updated add-on in this repo pays.
