### PR TITLE
fix(templates): populate /run/s6/container_environment when ha_entrypoint.sh is PID 1

### DIFF
--- a/.templates/ha_entrypoint.sh
+++ b/.templates/ha_entrypoint.sh
@@ -168,6 +168,59 @@ if [ -z "$shebang" ]; then
   exit 1
 fi
 
+#####################################
+# Seed the s6 container environment #
+#####################################
+
+# s6-overlay's stage 1 dumps the container's environment into /run/s6/container_environment, and
+# `with-contenv` reads it back (emptyenv -p; s6-envdir). Add-ons that override the base image's
+# ENTRYPOINT ["/init"] with ENTRYPOINT ["/usr/bin/env"] plus CMD ["/ha_entrypoint.sh"] never run
+# stage 1, so nothing creates that directory and every #!/usr/bin/with-contenv script outside the
+# three globs whose shebang is rewritten below either exits non-zero before its first line
+# (directory missing: s6-envdir errors) or runs against whatever a cont-init script happened to
+# leave there -- measured at 16 variables instead of 110, SUPERVISOR_TOKEN among the missing.
+# Neither says anything, so all that surfaces is what the caller makes of it: a HEALTHCHECK
+# reporting "unhealthy", a cron job doing nothing. So dump the environment here instead.
+#
+# Deliberately after the shebang probe above, not next to the other PID 1 setup: the probe's first
+# candidate is "/command/with-contenv bashio" and it fails today in exactly these add-ons, so the
+# probe falls through to "/usr/bin/env bashio". Seeding earlier would make that candidate start
+# succeeding and flip the shebang of every cont-init and service script here, so scripts launched
+# directly would lose what an earlier sourced script exported -- a far larger change than this.
+#
+# It does switch on two dormant writes: 00-global_var.sh and 01-config_yaml.sh push their values
+# into the envdir, but only `if [ -d ]`. That is what those lines are for, and it means out-of-glob
+# scripts now see the user's configured options too.
+
+S6_CONTAINER_ENV="/run/s6/container_environment"
+
+# Only when this script is PID 1 -- under /init it is the stage-2 hook and stage 1 has already
+# written the directory -- and only where with-contenv exists to care.
+if $PID1 && { [ -x /command/with-contenv ] || [ -x /usr/bin/with-contenv ]; }; then
+  # Filled in a sibling and renamed into place, never written to live. A half-populated envdir is
+  # worse than an absent one: s6-envdir accepts it, so a with-contenv script starts and runs
+  # against an environment quietly missing SUPERVISOR_TOKEN, where an absent one stops it at its
+  # shebang. rename(2) means a concurrent reader -- a HEALTHCHECK can run alongside PID 1 -- sees
+  # the directory either absent or complete, never mid-dump.
+  #
+  # Cleared rather than written over: /run is not a tmpfs here, so an image layer can persist
+  # entries, and writing name by name would merge into them and leave variables PID 1 does not
+  # have, a stale SUPERVISOR_TOKEN among them. A failed rm has to abort the chain, because mkdir -p
+  # accepts a surviving symlink-to-directory and would let the dump follow it. rm does not traverse
+  # a symlink, but it would empty anything bind-mounted at this exact path -- not a configuration
+  # any add-on uses, and not one s6 would tolerate either.
+  if rm -rf "$S6_CONTAINER_ENV" "$S6_CONTAINER_ENV.tmp" && mkdir -p "$S6_CONTAINER_ENV.tmp" &&
+    s6-dumpenv -- "$S6_CONTAINER_ENV.tmp" && mv "$S6_CONTAINER_ENV.tmp" "$S6_CONTAINER_ENV"; then
+    echo "Populated $S6_CONTAINER_ENV for with-contenv"
+  else
+    # Leaves the directory absent, which is exactly how this fails today -- so the failure mode is
+    # unchanged, not newly degraded. Never fatal, a read-only /run must still let the add-on boot,
+    # but never silent either, since the shebang failure it leaves behind says nothing on its own.
+    rm -rf "$S6_CONTAINER_ENV" "$S6_CONTAINER_ENV.tmp" 2>/dev/null || true
+    echo -e "\e[38;5;214m$(date) WARNING: could not populate $S6_CONTAINER_ENV; scripts with a with-contenv shebang will fail at their shebang, as they did before this was attempted\e[0m"
+  fi
+fi
+
 ####################################
 # Bashio library for source fallback
 ####################################

--- a/portainer_agent/CHANGELOG.md
+++ b/portainer_agent/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.44.0.1 (2026-08-24)
+
+- Rebuild to pick up a fix in the shared entrypoint: when `ha_entrypoint.sh` runs as PID 1, as it does in this add-on, it now populates `/run/s6/container_environment`, so a script carrying a `#!/usr/bin/with-contenv` shebang gets a populated environment including `SUPERVISOR_TOKEN` instead of failing at its shebang. Nothing shipped in this add-on still uses that shebang (the healthcheck moved to plain bash in 2.44.0), so this changes nothing about the agent itself; it matters for a `script.sh` added by the user, and it is the add-on that build-tests the shared change
+
 ## 2.44.0 (2026-08-23)
 
 - Fix: Use `portainer/agent:alpine-sts` to match the STS release channel configured in `updater.json`

--- a/portainer_agent/config.yaml
+++ b/portainer_agent/config.yaml
@@ -41,4 +41,4 @@ schema:
 slug: portainer_agent
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "2.44.0"
+version: "2.44.0.1"


### PR DESCRIPTION
Closes #3006.

## What was measured

Inside a running add-on of this repo whose PID 1 is `/bin/bash /ha_entrypoint.sh`, the same trivial script run with and without a `with-contenv` shebang:

```
under #!/usr/bin/with-contenv bashio:  SUPERVISOR_TOKEN unset,  16 variables
plain:                                 SUPERVISOR_TOKEN set,   110 variables
```

That is a different failure from the one #3006 describes, and a worse one. The issue predicted that `with-contenv` scripts *fail* in these add-ons, because `s6-envdir` errors on a missing `/run/s6/container_environment`. That is what happens where nothing creates the directory. Where a cont-init script happens to create it for its own reasons — `claude_desktop`'s `20-folders.sh` does — `with-contenv` succeeds and silently hands the script whatever that one script left there. `emptyenv -p` has already thrown the real environment away by then.

Both failures are silent by construction: no message either way, only whatever the caller makes of a non-zero exit or of a missing variable. In #3002 the caller was Docker's `HEALTHCHECK`, and the add-on read `unhealthy` in Portainer for eight months.

## What changed

`.templates/ha_entrypoint.sh` now dumps its own environment into `/run/s6/container_environment` when it is PID 1, which is what s6-overlay's stage 1 would have done had the add-on not overridden `ENTRYPOINT ["/init"]`. `s6-dumpenv` when the image has it — the same tool s6-overlay uses — otherwise a pure-bash writer.

Verified by reading the seeded directory back through the real `emptyenv -p` / `s6-envdir -Lfn` pair that `with-contenv` itself uses: 109 variables with `SUPERVISOR_TOKEN` present via `s6-dumpenv`, 107 via the bash fallback, and a multi-line value byte-exact through both. The two the fallback misses are `_` and `SENTRY-TRACE`; it covers every name bash can reference, and its files are byte-identical to `s6-dumpenv`'s, mode included. That is why `s6-dumpenv` stays preferred rather than being dropped for one code path.

Three decisions worth arguing with:

**Placed after the shebang probe, not with the other PID 1 setup.** The probe's first candidate is `/command/with-contenv bashio`, and it fails today in exactly these add-ons, so the probe falls through to `/usr/bin/env bashio`. Seeding earlier would make that first candidate start succeeding and flip the shebang of every cont-init and service script in every add-on that lands here. Directly-executed scripts would then lose the environment exported by an earlier sourced one. That is a much larger change than this fixes, so the seed goes after selection and this boot's shebang choice is bit-for-bit what it is today.

**The directory is cleared, not overwritten.** `/run` is not a tmpfs in these containers, so an image layer or a bind mount can persist entries there, and writing name-by-name would merge into them — leaving variables PID 1 does not have, a stale `SUPERVISOR_TOKEN` among them. A failed `rm` aborts the whole attempt rather than continuing: `mkdir -p` accepts a surviving symlink-to-directory and would let the writes follow it.

**Failure removes the directory and warns.** A half-written envdir is worse than none, and this is the asymmetry that makes it worth the extra branch: `s6-envdir` accepts a partial directory, so the script starts and runs against an environment quietly missing `SUPERVISOR_TOKEN`, where an absent directory at least stops it at its shebang. On failure it therefore fails closed exactly as it does today, but says so in the log — silence is the actual complaint in #3006.

## Scope expansion this carries

This also activates two previously dormant persistence paths. `.templates/00-global_var.sh:274` and `.templates/01-config_yaml.sh:203` write their processed values into the envdir, but only `if [ -d ]`. In affected PID-1 add-ons those values — configured add-on options and `config.yaml`-derived ones, including anything secret passed through `env_vars` — can now reach later scripts that explicitly use `with-contenv`: health checks, cron jobs, CLI wrappers, `script.sh`. Only variables written by a writer that already ran, and only processes that invoke `with-contenv`.

That is what those two lines are for, and it matches what these add-ons would already do under s6-overlay's `/init` — but it is a real environment-scope change for the ones that don't, and I would rather state it than have it discovered.

## Blast radius and rollback

`.templates/` reaches every add-on at its next rebuild, so this arrives gradually rather than all at once. The whole change is one self-contained block in `.templates/ha_entrypoint.sh` guarded by `if $PID1`; reverting that block alone restores current behaviour, and the `portainer_agent` bump is independent of it.

Add-ons that override `ENTRYPOINT` and so are affected: 49. Under s6-overlay's `/init` this script runs as the stage-2 hook rather than PID 1, so for every other add-on the block does not execute at all.

`portainer_agent` is bumped to `2.44.0.1` because its Dockerfile `COPY`s `ha_entrypoint.sh` from the build context, which is what gives CI a real build of the new template. Nothing shipped in that add-on still carries a `with-contenv` shebang — the healthcheck moved to plain bash in 2.44.0 — so the rebuild changes nothing about the agent itself.

## Not verified

- **No Docker build locally** (no dockerd); CI is the only gate on that.
- **Not verified in a running container.** Everything above was measured by exercising the seeding logic and the real `s6-envdir` reader inside a live add-on, not by rebuilding an image and booting it. The claim that a rebuilt add-on's healthcheck/cron/CLI scripts then see the full environment follows from those measurements; it has not been observed end-to-end.
- **The bash fallback path is untested in production** — every image checked ships `s6-dumpenv`, so it exists for images that ship s6-overlay without s6-portable-utils, which I could not find an example of.
- `claude_desktop`, the other add-on #3006 lists, is **not** bumped here. Its Dockerfile curls the templates from `master` rather than the build context, so a PR build would test the old file either way; it picks this up on its next rebuild.

## Not done

The architecturally clean fix is to stop overriding `/init` in those 49 images and let s6 stage 1 run, which would also fix PID 1 signal handling and service supervision. That is a much larger change — `ha_entrypoint.sh` currently launches service run files and restart loops by hand — and is not attempted here.

Plan and code both reviewed independently by Codex (gpt-5.2), which blocked twice: on treating a non-empty directory as valid (its point, and my own 16-variable measurement was the counter-example), and on leaving a partially written directory behind after a failed seed. Both are fixed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed startup environment handling so user scripts can access exported variables, including `SUPERVISOR_TOKEN`.
  * Improved resilience when environment setup encounters an error, allowing startup to continue safely without interruption.

* **Chores**
  * Updated the Portainer Agent add-on to version 2.44.0.1.
  * Added changelog documentation for the updated release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->