### PR TITLE
docs(skill): fold recent-issue lessons and the simplify-after-review pass into hassio-addon-workflow

### DIFF
--- a/.claude/skills/hassio-addon-workflow/SKILL.md
+++ b/.claude/skills/hassio-addon-workflow/SKILL.md
@@ -172,7 +172,9 @@ work" — either it was exercised, or say plainly it wasn't.
 
 Light path: verification is `validate.sh` plus CI; anything beyond that is Assumed. Full loop: CI
 passing proves the build works, not that the change does anything — re-run the measurement that
-motivated the work once the rebuilt add-on is running. Real "merged and inert" examples, and what
+motivated the work once the rebuilt add-on is running. After merge, confirm the commit survived
+on `origin/master`: the builder's revert-on-failure job can revert a merge for reasons unrelated
+to your diff (see `references/traps.md#ci-and-review-bots`). Real "merged and inert" examples, and what
 to do when a fix can't be self-verified: `references/evidence.md`.
 
 ## 10. Calibrate and report
@@ -190,6 +192,10 @@ Risk + rollback                 — the riskiest hunk and how to revert it alone
 
 Lead with anything that did not work — a merged PR that achieved nothing is the single most
 important sentence in the report. Give confidence per claim, not one blanket number.
+
+**Feed the skill.** When a shipped fix needed a follow-up PR, or a reviewer caught something this
+skill should have, add the distilled lesson to the matching `references/` file in that follow-up
+PR — one entry, with the PR numbers. That loop is what keeps this file short and the traps real.
 
 Scripts are meant to be **run, not read** — each is cited at its point of use above; read one
 only if its output surprises you.

--- a/.claude/skills/hassio-addon-workflow/SKILL.md
+++ b/.claude/skills/hassio-addon-workflow/SKILL.md
@@ -29,8 +29,8 @@ Triage first, then one of two paths:
   resolve bot comments.
 - **Full loop** — performance/RAM/CPU work, diagnosis, anything changing a shipped default,
   ladder levels 4-6, or an explicit Codex-check request: scope → measure → plan → Codex reviews
-  the plan → implement → simplify → Codex reviews the code → PR → resolve comments → verify in
-  production → report.
+  the plan → implement → simplify → Codex reviews the code → **simplify again** → PR → resolve
+  comments → verify in production → report.
 
 Escalate mid-flight if a light task grows — touches a default, needs a new script or service, or
 reveals a deeper problem.
@@ -42,7 +42,10 @@ where every add-on solves a problem the same way is worth more than a locally ni
 design. Prefer reusing or extending over adding a parallel implementation, and when you must add
 something new, spell it the way the rest of the repo spells it (naming, option names, script
 numbering, file layout). Complexity is bought only by a **measurement** showing a concrete,
-user-visible cost on a real host — never by reasoning about hypothetical performance.
+user-visible cost on a real host — never by reasoning about hypothetical performance, and never by
+reasoning about a hypothetical *host* either. A defensive branch is complexity like any other: name
+the input that reaches it and the image or host where that happens, or delete it and let the case
+fail visibly instead.
 
 **Repo layout.** `alexbelgium/hassio-addons`; each add-on is a top-level directory. This skill is
 checked in at `.claude/skills/hassio-addon-workflow/` (canonical copy). Set the skill root once,
@@ -113,6 +116,9 @@ Attack your own plan before implementing:
 - What is the **blast radius** if the assumption underneath it is wrong?
 - What am I **inferring** that I could instead **detect at runtime** or **record explicitly**?
   Highest-yield question here — see `references/evidence.md`'s failure-mode section.
+- For every branch that exists **only to survive something going wrong**: what input reaches it,
+  on which image? Go and look. A fallback for a configuration you cannot find an instance of is
+  not robustness, it is a second code path nobody will ever exercise or notice rotting.
 
 Full loop only, before writing code: get Codex's independent read on the plan. Spawn a subagent
 whose prompt includes the path `references/codex-review.md` and tells it to follow that file's
@@ -140,10 +146,17 @@ justify the divergence in the PR body — but never at the cost of an isolation 
 numbered script, not an edit. Case studies of what happens when this check is skipped:
 `references/simplify.md`.
 
-## 6. Codex attacks the code (full loop only)
+## 6. Codex attacks the code, then simplify what the review added (full loop only)
 
 Same delegated invocation, pointed at `git diff origin/master...HEAD` plus your reasoning per
 hunk. Details in `references/codex-review.md`.
+
+Then run step 5's checks again over the hunks the review changed. Adversarial review only ever
+argues *for* another branch — that is its job — so accepting objections ratchets the diff upward,
+and nothing else in the loop walks it back down. For each accepted objection: is the case it
+defends one you have now demonstrated, or one you have merely been told about? Taking a
+correctness objection often deletes the code that made it necessary, and a fix that collapses back
+to fewer lines than you started the review with is the normal outcome, not a suspicious one.
 
 ## 7. Open the PR
 

--- a/.claude/skills/hassio-addon-workflow/SKILL.md
+++ b/.claude/skills/hassio-addon-workflow/SKILL.md
@@ -172,9 +172,10 @@ work" — either it was exercised, or say plainly it wasn't.
 
 Light path: verification is `validate.sh` plus CI; anything beyond that is Assumed. Full loop: CI
 passing proves the build works, not that the change does anything — re-run the measurement that
-motivated the work once the rebuilt add-on is running. After merge, confirm the commit survived
-on `origin/master`: the builder's revert-on-failure job can revert a merge for reasons unrelated
-to your diff (see `references/traps.md#ci-and-review-bots`). Real "merged and inert" examples, and what
+motivated the work once the rebuilt add-on is running. After merge, `git fetch origin master`
+(the tracking ref is stale otherwise), then confirm the commit survived on `origin/master`: the
+builder's revert-on-failure job can revert a merge for reasons unrelated to your diff (see
+`references/traps.md#ci-and-review-bots`). Real "merged and inert" examples, and what
 to do when a fix can't be self-verified: `references/evidence.md`.
 
 ## 10. Calibrate and report

--- a/.claude/skills/hassio-addon-workflow/SKILL.md
+++ b/.claude/skills/hassio-addon-workflow/SKILL.md
@@ -191,7 +191,9 @@ work" — either it was exercised, or say plainly it wasn't.
 Light path: verification is `validate.sh` plus CI; anything beyond that is Assumed. Full loop: CI
 passing proves the build works, not that the change does anything — re-run the measurement that
 motivated the work once the rebuilt add-on is running. After merge, `git fetch origin master`
-(the tracking ref is stale otherwise), then confirm the commit survived on `origin/master`: the
+(the tracking ref is stale otherwise), then confirm the *changes* survived — `git diff
+origin/master -- <the paths you touched>` comes back empty. Ancestry is not the check: a revert
+leaves your commit in history and undoes its tree, so `--contains` reports success either way. The
 builder's revert-on-failure job can revert a merge for reasons unrelated to your diff (see
 `references/traps.md#ci-and-review-bots`). Real "merged and inert" examples, and what
 to do when a fix can't be self-verified: `references/evidence.md`.

--- a/.claude/skills/hassio-addon-workflow/references/codex-review.md
+++ b/.claude/skills/hassio-addon-workflow/references/codex-review.md
@@ -39,3 +39,10 @@ codex exec --model gpt-5.6-sol --sandbox read-only --skip-git-repo-check \
 **Codex agrees with confident premises.** It has confirmed a wrong conclusion stated too
 confidently, and separately caught a genuine methodology error in the same review. Treat its
 confirmations with the same scepticism as its objections — especially about the build.
+
+**Its objections ratchet complexity upward.** An adversarial reviewer is asked to find what could
+go wrong, so its output is a list of arguments for more code; it is never asked whether the branch
+it wants is reachable. Separate "this is wrong" from "this is undefended" before you write
+anything: the first is a bug and you fix it, the second is a claim about some host, and it needs
+the same demonstration you would demand of a measurement. That is what step 6's second simplify
+pass is for.

--- a/.claude/skills/hassio-addon-workflow/references/simplify.md
+++ b/.claude/skills/hassio-addon-workflow/references/simplify.md
@@ -1,7 +1,7 @@
 # Simplify — case studies
 
 Evidence for why the mechanism ladder in SKILL.md step 3 exists, and why levels 4-6 need a reason
-that survives being said out loud. In all three cases the simpler option existed and was skipped.
+that survives being said out loud. In each case the simpler option existed and was skipped.
 Being able to build the complicated thing is not a reason to.
 
 - A rejected PR spent a **388-line TCP proxy plus a 142-line monkeypatch of a private upstream
@@ -13,6 +13,13 @@ Being able to build the complicated thing is not a reason to.
 - A resolution cap shipped as a **new init script writing an s6 envdir** — the wrong mechanism
   entirely (ladder level 4). Renaming the option to the env var the service already reads
   (level 1) would have worked, and the new script did not.
+- A calibre-web trusted-ips fix injected the add-on's **per-boot IP**, which forced a
+  rewrite-every-boot design that erased user entries; preserving them then needed merge logic
+  plus a state file recording what was injected (+34 lines, PR #3009 — closed unmerged). Asking
+  "is there a constant that makes the rewrite unnecessary?" gave the shipped fix: trust the
+  static supervisor range `172.30.32.0/23`, one idempotent statement, **net −6 lines**
+  (PR #3010). Complexity spent working around a changing value is a sign to hunt for the
+  constant instead.
 
 ## Checks worth running against your own diff
 

--- a/.claude/skills/hassio-addon-workflow/references/simplify.md
+++ b/.claude/skills/hassio-addon-workflow/references/simplify.md
@@ -13,6 +13,15 @@ Being able to build the complicated thing is not a reason to.
 - A resolution cap shipped as a **new init script writing an s6 envdir** — the wrong mechanism
   entirely (ladder level 4). Renaming the option to the env var the service already reads
   (level 1) would have worked, and the new script did not.
+- A `.templates/ha_entrypoint.sh` fix went to review at 25 lines of code and merged at 10. Two
+  sources of the excess, and neither was caught by the loop: a **pure-bash fallback** written at
+  implement time for images shipping `with-contenv` but not `s6-dumpenv` — reasoned from the two
+  binaries living in different s6 packages, never demonstrated on any real image, and the case it
+  defended would have degraded to the pre-fix behaviour anyway — and a **helper function plus a
+  second reset** that existed only to serve that fallback. Deleting the fallback deleted all of
+  it. The rest of the review's objections were correct and cost two tokens on an existing line.
+  It took the maintainer asking "is this the simplest way possible?" to run the pass that step 6
+  now requires.
 
 ## Checks worth running against your own diff
 
@@ -25,6 +34,11 @@ Being able to build the complicated thing is not a reason to.
   A removal that depends on a host default still needs the same verification as an addition.
 - **Is the fix bigger than the thing it fixes?** That is a smell, not a rule — but it usually
   means the problem was framed one level too deep.
+- **For each defensive branch: what input reaches it, on which image or host?** Go and check,
+  the way you would check a measurement. If you cannot produce the case, delete the branch — the
+  situation then fails the way it already fails today, visibly, instead of through a second path
+  that is never exercised and silently rots as the base images move. Write down in the PR body
+  what you cut and why, so the next person does not re-add it from the same reasoning.
 - **How does this fail in three years**, when the base image, Electron, or upstream has moved?
   Code that reads a documented knob keeps working. Code that reaches into private internals
   does not.

--- a/.claude/skills/hassio-addon-workflow/references/traps.md
+++ b/.claude/skills/hassio-addon-workflow/references/traps.md
@@ -11,6 +11,7 @@ workflows and lint rules — that is not repeated here.
 - [Environment and workspace](#environment-and-workspace)
 - [Measurement](#measurement)
 - [Passing values into base-image services](#passing-values-into-base-image-services)
+- [Writing into an app's own config](#writing-into-an-apps-own-config)
 - [Shell and bashio](#shell-and-bashio)
 - [Dockerfile and architecture](#dockerfile-and-architecture)
 - [Versioning](#versioning)
@@ -116,6 +117,20 @@ place for filesystem and permission setup.
 the openbox autostart. (ANGLE's OpenGL backend, for instance, fails with "Could not open the
 default X display".)
 
+## Writing into an app's own config
+
+**A field your cont-init script writes may also be user-editable in the app's UI.** An
+unconditional `UPDATE`/overwrite on every boot silently erases whatever the user added there,
+and containers are recreated on restart so it re-erases forever (calibre-web
+`config_reverse_proxy_trusted_ips`, #3004 — flagged by two review bots, fixed in #3010).
+Prepend/merge with an idempotence guard instead of assigning.
+
+**Prefer values that are constant across boots.** The add-on's own IP changes every restart,
+so injecting it forces a rewrite-every-boot design plus stale-entry cleanup (a stale trusted IP
+can be handed to a *different* add-on later). Trusting the whole supervisor range
+`172.30.32.0/23` is constant, written once. For dual-stack listeners the IPv4 form never
+matches IPv4-mapped addresses — also list the mapped form (`::ffff:172.30.32.0/119`).
+
 ## Shell and bashio
 
 **`bashio::config` for lists**: `while read ... < <(bashio::config ...)` silently yields an empty
@@ -194,6 +209,12 @@ All three hard gates below are matrixed over `check-addon-changes.outputs.change
   it *cannot* fail a PR. Fix real findings anyway, but do not treat it as a blocker.
 - **Version bump** — no workflow checks it. It is repo convention, and required for Supervisor to
   offer the rebuild, but it will not fail CI.
+
+**"Merged" is not "on master".** The push builder's revert-on-failure job reverts the merge
+commit when its prebuild step fails — including failures unrelated to your diff. A seerr fix
+merged at 05:15 and was reverted one minute later because `EndBug/add-and-commit`'s floating
+`v11` tag had moved to a broken release (#2993, reapplied verbatim in #2997). After merge, confirm
+your commit's tree is still what `origin/master` holds before declaring done.
 
 **CI rewrites your shell scripts.** `lint.yml` runs `shfmt -w -i 4 -ci -bn -sr` over every `*.sh`
 and `run`, plus a `chmod +x` pass, on schedule. Repo-wide reformatting commits land on master

--- a/.claude/skills/hassio-addon-workflow/references/traps.md
+++ b/.claude/skills/hassio-addon-workflow/references/traps.md
@@ -131,6 +131,12 @@ can be handed to a *different* add-on later). Trusting the whole supervisor rang
 `172.30.32.0/23` is constant, written once. For dual-stack listeners the IPv4 form never
 matches IPv4-mapped addresses — also list the mapped form (`::ffff:172.30.32.0/119`).
 
+Constant is not free when the value gates **authentication**: trusting the whole range means any
+add-on on the supervisor network can send the auth header and impersonate a user. #3010 shipped
+that as an explicit, stated trade-off with the maintainer's sign-off. State the blast radius in
+the PR body and get the maintainer's call before widening trust — never present it as a neutral
+simplification.
+
 ## Shell and bashio
 
 **`bashio::config` for lists**: `while read ... < <(bashio::config ...)` silently yields an empty

--- a/.claude/skills/hassio-addon-workflow/references/traps.md
+++ b/.claude/skills/hassio-addon-workflow/references/traps.md
@@ -221,8 +221,11 @@ commit when its prebuild step fails — including failures unrelated to your dif
 merged at 05:15 and was reverted one minute later because `EndBug/add-and-commit`'s floating
 `v11` tag had moved to a broken release (#2993, reapplied verbatim in #2997). After merge,
 `git fetch origin master` first — the remote-tracking ref is stale otherwise and would "confirm"
-against pre-merge state — then check your commit's tree is still what `origin/master` holds
-before declaring done.
+against pre-merge state — then check that `git diff origin/master -- <the paths you touched>` is
+empty before declaring done. Scope it to your paths: master moves under you, so whole-tree
+equality fails on unrelated commits. Ancestry is not the check either — this repo squash-merges,
+so a merged PR head is never an ancestor of `master` (verified on #3010, whose fix is live), and
+a revert leaves the original commit an ancestor anyway.
 
 **CI rewrites your shell scripts.** `lint.yml` runs `shfmt -w -i 4 -ci -bn -sr` over every `*.sh`
 and `run`, plus a `chmod +x` pass, on schedule. Repo-wide reformatting commits land on master

--- a/.claude/skills/hassio-addon-workflow/references/traps.md
+++ b/.claude/skills/hassio-addon-workflow/references/traps.md
@@ -219,8 +219,10 @@ All three hard gates below are matrixed over `check-addon-changes.outputs.change
 **"Merged" is not "on master".** The push builder's revert-on-failure job reverts the merge
 commit when its prebuild step fails — including failures unrelated to your diff. A seerr fix
 merged at 05:15 and was reverted one minute later because `EndBug/add-and-commit`'s floating
-`v11` tag had moved to a broken release (#2993, reapplied verbatim in #2997). After merge, confirm
-your commit's tree is still what `origin/master` holds before declaring done.
+`v11` tag had moved to a broken release (#2993, reapplied verbatim in #2997). After merge,
+`git fetch origin master` first — the remote-tracking ref is stale otherwise and would "confirm"
+against pre-merge state — then check your commit's tree is still what `origin/master` holds
+before declaring done.
 
 **CI rewrites your shell scripts.** `lint.yml` runs `shfmt -w -i 4 -ci -bn -sr` over every `*.sh`
 and `run`, plus a `chmod +x` pass, on schedule. Repo-wide reformatting commits land on master


### PR DESCRIPTION
Consolidates the two open skill PRs into one. **Supersedes #3014**, which is closed — both edited the same three files and conflicted in `references/simplify.md`. No add-on is touched.

## Part 1 — lessons from the last month of solved issues

**From the calibre-web ingress saga (#3003 → #3004, #3009 closed, #3010 merged):**
- `traps.md`, new section *Writing into an app's own config* — a field a cont-init script writes may be user-editable in the app's UI, so an unconditional overwrite silently erases user entries on every boot; prefer boot-constant values over the per-boot add-on IP; dual-stack listeners need the IPv4-mapped range form too. Widening trust for an auth header is an impersonation trade-off needing the maintainer's explicit call, not a neutral simplification.
- `simplify.md`, case study — #3009 spent +34 lines of merge machinery and a state file working around a per-boot-changing value; #3010 asked "is there a constant?" and shipped at net −6 lines.

**From the seerr builder revert (#2975 → #2993 merged-then-reverted, #2997):**
- `traps.md` — "merged" is not "on master": the builder's revert-on-failure job can revert a merge for reasons unrelated to the diff (a floating action tag broke, #2996). Step 9 now fetches `origin master` first, then checks the commit survived; the tracking ref is stale otherwise.

**Process:**
- Step 10 gains a standing rule that a follow-up PR to a shipped fix also adds the distilled lesson to the matching `references/` file — which is what this PR does by hand, made routine.

## Part 2 — carried over from #3014, unchanged

- Full loop gains an explicit **simplify again** pass after the code review.
- Standing rule covers hypothetical *hosts*, not just hypothetical performance.
- Step 6 re-runs step 5's checks over the hunks the review touched, and says plainly that a fix collapsing back to fewer lines than it had before the review is the normal outcome.
- `codex-review.md` — the distinction to draw while reading objections: "this is wrong" is a bug you fix; "this is undefended" is a claim about some host, needing the same demonstration you would demand of a measurement.
- `simplify.md` — the `ha_entrypoint.sh` case study from #3013.

## Part 3 — applied on top, from reviewing #3014

**The defensive-branch rule contradicted the `/dev/shm` bullet two entries above it.** As written, "if you cannot produce the case, delete the branch" deletes `--disable-dev-shm-usage`, which `traps.md` says to keep *because* the size cannot be determined locally — HA ignores the add-on's `shm_size`, so it varies per install and measured 7.7 GB on one host. The bar is now **naming** the case, not reproducing it here, with both worked examples side by side: Docker's 64 MB default is documented behaviour HA does not override, so that guard stays; nobody could name an image shipping `with-contenv` without `s6-dumpenv`, so that fallback went. Cost asymmetry is stated too — a one-flag guard against a crash you cannot rule out is cheap, a second code path that degrades to the pre-fix behaviour anyway is not.

**Codex's open P2 on #3014 is closed.** The new pass edits code after step 4's `validate.sh` and behavioural tests have already run, and nothing re-ran them; deleting a branch is exactly the edit that leaves a stray `fi` behind. Step 6 now re-runs both over the final diff.

**Step 3's bullet lost two lines** that restated the standing rule verbatim, and `simplify.md`'s intro no longer says "In all three cases" while listing five.

## Verified

- No conflict markers anywhere in the skill tree.
- `markdownlint-cli2` with the repo's `.markdownlint.yaml`: **3 findings on this branch (MD032 ×2, MD040), the same 3 on `master`**, line numbers shifted only. No new findings.
- The conflict between the two branches was confirmed by actually merging them, not by reading the diffs: `CONFLICT (content): references/simplify.md`. Resolved by keeping both case studies — they are independent lessons.

## Not verified

Whether the added pass changes behaviour on the next full-loop task — only observable by running one. The `codex` CLI is not installed in this container, so no independent local `gpt-5.6-sol` pass was run; the Codex connector's review of #3014's head is what Part 3's second item addresses.

## Rollback

Documentation only, no add-on and no CI-gated file. Reverting the merge commit restores this PR to Part 1 alone; reverting the branch restores `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mbqutqkh7yTj4EnhWKFBQx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Home Assistant add-on workflow guidance with a second simplification pass after review.
  * Added instructions to distinguish confirmed issues from unsupported claims and validate behavioral changes.
  * Expanded defensive-logic guidance to verify real hosts, images, inputs, and environments.
  * Added examples for stable configuration, fallback removal, documented deletions, and safer app-managed settings.
  * Refreshed production verification for stale references, unrelated changes, squash merges, automatic reverts, and capturing follow-up lessons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->