### PR TITLE
fix(skill): stop the workflow scripts reporting verdicts they have not established

### DIFF
--- a/.claude/skills/hassio-addon-workflow/scripts/pr_review.sh
+++ b/.claude/skills/hassio-addon-workflow/scripts/pr_review.sh
@@ -108,7 +108,7 @@ watch)
     done
     [ "$wfail" -eq 2 ] && echo "gave up after ${MINS}m, checks still unsettled — NOT a pass"
     # A PR touching no */config.* skips the CHANGELOG, linter and build jobs outright (#3018).
-    case "${c:-}" in *skipping*) echo "some checks SKIPPED — a skipped job tested nothing" ;; esac
+    case "${c:-}" in *skipping*) echo "  ...of which some were SKIPPED — a skipped job tested nothing" ;; esac
     echo "note: long queues here are usually account runner contention, not your diff."
     exit "$wfail"
     ;;

--- a/.claude/skills/hassio-addon-workflow/scripts/pr_review.sh
+++ b/.claude/skills/hassio-addon-workflow/scripts/pr_review.sh
@@ -90,6 +90,7 @@ resolve)
     ;;
 watch)
     MINS="${3:-180}"   # the addon build alone has taken ~3h; 20 was far too short
+    wfail=2            # not 0: running out of minutes with checks still pending is not a pass
     for i in $(seq 1 "$MINS"); do
         c=$(gh pr checks "$PR" 2> /dev/null | awk '{print $1"="$2}' | tr '\n' ' ')
         if [ -z "$c" ]; then
@@ -102,11 +103,14 @@ watch)
         case "$c" in
         *pending*) sleep 60 ;;
         *fail* | *error* | *cancel*) echo "settled — with FAILURES (see above)"; wfail=1; break ;;
-        *) echo "settled — all passing"; break ;;
+        *) echo "settled — all passing"; wfail=0; break ;;
         esac
     done
+    [ "$wfail" -eq 2 ] && echo "gave up after ${MINS}m, checks still unsettled — NOT a pass"
+    # A PR touching no */config.* skips the CHANGELOG, linter and build jobs outright (#3018).
+    case "${c:-}" in *skipping*) echo "some checks SKIPPED — a skipped job tested nothing" ;; esac
     echo "note: long queues here are usually account runner contention, not your diff."
-    exit "${wfail:-0}"
+    exit "$wfail"
     ;;
 *) echo "unknown: $CMD"; exit 1 ;;
 esac

--- a/.claude/skills/hassio-addon-workflow/scripts/preflight.sh
+++ b/.claude/skills/hassio-addon-workflow/scripts/preflight.sh
@@ -64,7 +64,8 @@ if [ -n "${BUILD_VERSION:-}" ]; then
         echo "  $SLUG/config.yaml version = $here"
         echo "  running image BUILD_VERSION = $BUILD_VERSION"
         if [ "$here" = "$BUILD_VERSION" ]; then
-            echo "  MATCH — this checkout corresponds to the running image."
+            # version is bumped once per PR, so a later commit or a dirty tree matches here.
+            echo "  VERSION MATCH — source revision itself is not verified."
         else
             echo "  MISMATCH — this branch is NOT what is running."
             git fetch origin master --quiet 2> /dev/null

--- a/.claude/skills/hassio-addon-workflow/scripts/validate.sh
+++ b/.claude/skills/hassio-addon-workflow/scripts/validate.sh
@@ -4,7 +4,7 @@
 # rather than implying the build was checked.
 #
 # --vs-master re-lints each changed file at origin/master and prints only findings your diff
-# ADDED. Without it you will chase warnings that were already in the file.
+# ADDED, and fails if there are any. Without it you will chase warnings that were already there.
 #
 # Usage: validate.sh [addon-dir] [--vs-master]
 set -uo pipefail
@@ -31,17 +31,21 @@ echo "== validating $ADDON =="
 
 fail=0
 note() { printf '  %-13s %s\n' "$1" "$2"; }
+# execline `run`/`finish` files are not shell (25 of them here, across 21 add-ons). Neither
+# linter below can read one, so anything either says about it is noise.
+is_execline() { local l; IFS= read -r l < "$1" 2> /dev/null; [[ $l == '#!'*execlineb* ]]; }
 
-# Shell: bash -n then shellcheck -x (follows sourced files, as CI does).
-while IFS= read -r f; do
-    [ -f "$f" ] || continue
+# Shell: bash -n then shellcheck -x (follows sourced files, as CI does). One list for both.
+files=()
+while IFS= read -r f; do is_execline "$f" || files+=("$f"); done \
+    < <(find "$ADDON" -type f \( -name '*.sh' -o -name 'run' -o -name 'finish' -o -name 'autostart' \) 2> /dev/null)
+for f in "${files[@]}"; do
     if ! out=$(bash -n "$f" 2>&1); then note "bash -n" "FAIL $f"; echo "$out" | sed 's/^/      /'; fail=1; fi
-done < <(find "$ADDON" -type f \( -name '*.sh' -o -name 'run' -o -name 'finish' -o -name 'autostart' \) 2> /dev/null)
-[ "$fail" -eq 0 ] && note "bash -n" "ok"
+done
+[ "$fail" -eq 0 ] && note "bash -n" "ok (${#files[@]} files)"
 
-if command -v shellcheck > /dev/null 2>&1; then
-    sc=$(find "$ADDON" -type f \( -name '*.sh' -o -name 'autostart' -o -name 'run' -o -name 'finish' \) -print0 2> /dev/null |
-        xargs -0 -r shellcheck -x -f gcc 2>&1)
+if [ "${#files[@]}" -gt 0 ] && command -v shellcheck > /dev/null 2>&1; then
+    sc=$(shellcheck -x -f gcc "${files[@]}" 2>&1)
     if [ -n "$sc" ]; then
         note "shellcheck" "$(printf '%s\n' "$sc" | grep -c .) finding(s)"
         printf '%s\n' "$sc" | sed 's/^/      /' | head -20
@@ -50,7 +54,10 @@ fi
 
 command -v hadolint > /dev/null 2>&1 && [ -f "$ADDON/Dockerfile" ] && {
     hl=$(hadolint "$ADDON/Dockerfile" 2>&1)
-    [ -n "$hl" ] && { note "hadolint" "$(printf '%s\n' "$hl" | grep -c .) finding(s)"; printf '%s\n' "$hl" | sed 's/^/      /' | head -10; } || note "hadolint" "clean"
+    if [ -n "$hl" ]; then
+        note "hadolint" "$(printf '%s\n' "$hl" | grep -c .) finding(s)"
+        printf '%s\n' "$hl" | sed 's/^/      /' | head -10
+    else note "hadolint" "clean"; fi
 }
 
 if [ -f "$ADDON/config.yaml" ]; then
@@ -79,7 +86,8 @@ $VS_MASTER && command -v npx > /dev/null 2>&1 && [ -f "$ADDON/CHANGELOG.md" ] &&
 
 echo
 echo "== CI requirements =="
-if git diff --name-only origin/master...HEAD 2> /dev/null | grep -q "$ADDON/CHANGELOG.md"; then
+# -Fxq, not -q: unanchored, seerr's is matched by zzz_archived_overseerr's, and . is a wildcard.
+if git diff --name-only origin/master...HEAD 2> /dev/null | grep -Fxq "$ADDON/CHANGELOG.md"; then
     note "CHANGELOG" "updated"
 else
     # This one IS gated: onpr_check-pr.yaml exits 1 without it.
@@ -98,8 +106,15 @@ if $VS_MASTER; then
     echo
     echo "== findings ADDED by this diff (pre-existing ones filtered out) =="
     tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
-    git diff --name-only origin/master...HEAD -- "$ADDON" 2> /dev/null | while IFS= read -r f; do
-        git show "origin/master:$f" > "$tmp/base" 2> /dev/null || continue
+    added=0
+    # Fed by process substitution, not a pipe: a pipeline runs this in a subshell, where the
+    # findings below could never reach $fail and the verdict would contradict the list.
+    while IFS= read -r f; do
+        # Deleted: linting the path that is gone invents a finding. Added: no base, and an
+        # empty one says the right thing — every finding in it is one this diff added.
+        [ -f "$f" ] || continue
+        is_execline "$f" && continue
+        git show "origin/master:$f" > "$tmp/base" 2> /dev/null || : > "$tmp/base"
         # A missing linter must be a visible skip, not a silent "no new findings":
         # its "command not found" error is identical for base and head, so comm would
         # cancel it out and report a false clean.
@@ -115,12 +130,16 @@ if $VS_MASTER; then
                 cmd() { hadolint "$1" 2>&1 | sed 's/^[^:]*//; s/^:[0-9]*//'; } ;;
             *) continue ;;
         esac
-        cp "$tmp/base" "$tmp/base_f"; b=$(cmd "$tmp/base_f" | sort)
+        b=$(cmd "$tmp/base" | sort)
         a=$(cmd "$f" | sort)
-        new=$(comm -13 <(printf '%s\n' "$b") <(printf '%s\n' "$a") | grep -c .)
-        [ "$new" -gt 0 ] && { echo "  $f: $new NEW finding(s)"; comm -13 <(printf '%s\n' "$b") <(printf '%s\n' "$a") | sed 's/^/      /' | head -5; }
-    done
-    echo "  (nothing listed above = your diff introduced no new lint findings)"
+        new=$(comm -13 <(printf '%s\n' "$b") <(printf '%s\n' "$a"))
+        [ -n "$new" ] && {
+            echo "  $f: $(printf '%s\n' "$new" | grep -c .) NEW finding(s)"
+            printf '%s\n' "$new" | sed 's/^/      /' | head -5
+            added=1; fail=1
+        }
+    done < <(git diff --name-only origin/master...HEAD -- "$ADDON" 2> /dev/null)
+    [ "$added" -eq 0 ] && echo "  (none — this diff introduced no new lint findings)"
 fi
 
 echo

--- a/.claude/skills/hassio-addon-workflow/scripts/validate.sh
+++ b/.claude/skills/hassio-addon-workflow/scripts/validate.sh
@@ -8,6 +8,9 @@
 #
 # Usage: validate.sh [addon-dir] [--vs-master]
 set -uo pipefail
+# git diff prints repo-root-relative paths and $ADDON is a top-level directory name: neither
+# resolves from a subdirectory, where the -f guard below would skip every file and report clean.
+if root=$(git rev-parse --show-toplevel 2> /dev/null); then cd "$root" || exit 1; fi
 
 ADDON="${1:-}"
 [ "${ADDON:-}" = "--vs-master" ] && { ADDON=""; set -- --vs-master; }
@@ -42,7 +45,7 @@ while IFS= read -r f; do is_execline "$f" || files+=("$f"); done \
 for f in "${files[@]}"; do
     if ! out=$(bash -n "$f" 2>&1); then note "bash -n" "FAIL $f"; echo "$out" | sed 's/^/      /'; fail=1; fi
 done
-[ "$fail" -eq 0 ] && note "bash -n" "ok (${#files[@]} files)"
+[ "$fail" -eq 0 ] && note "bash -n" "${#files[@]} file(s) checked"
 
 if [ "${#files[@]}" -gt 0 ] && command -v shellcheck > /dev/null 2>&1; then
     sc=$(shellcheck -x -f gcc "${files[@]}" 2>&1)
@@ -87,11 +90,13 @@ $VS_MASTER && command -v npx > /dev/null 2>&1 && [ -f "$ADDON/CHANGELOG.md" ] &&
 echo
 echo "== CI requirements =="
 # -Fxq, not -q: unanchored, seerr's is matched by zzz_archived_overseerr's, and . is a wildcard.
+# Stricter than the gate itself, whose quoted =~ accepts that same collision
+# (onpr_check-pr.yaml:75), so this can fail where CI passes — the wrong add-on's is still wrong.
 if git diff --name-only origin/master...HEAD 2> /dev/null | grep -Fxq "$ADDON/CHANGELOG.md"; then
     note "CHANGELOG" "updated"
 else
     # This one IS gated: onpr_check-pr.yaml exits 1 without it.
-    note "CHANGELOG" "NOT UPDATED — this is the one CI hard-gate"; fail=1
+    note "CHANGELOG" "NOT UPDATED for $ADDON — CI hard-gates this"; fail=1
 fi
 if git diff origin/master...HEAD -- "$ADDON/config.yaml" 2> /dev/null | grep -q '^+version:'; then
     note "version" "bumped"


### PR DESCRIPTION
Six defects in the skill's own scripts, all the same species: **a verdict printed as passed that never ran, or never proved what it claims.** Each was reproduced against a constructed diff before and after the fix.

## What was wrong

| Script | Defect | Effect |
|---|---|---|
| `validate.sh` | `run`/`finish` selected by filename, fed to `bash -n` + shellcheck | 21 add-ons always `FAILED` regardless of diff |
| `validate.sh` | `grep -q "$ADDON/CHANGELOG.md"` unanchored, `.` a wildcard | **false green on the one hard CI gate** |
| `validate.sh` | `--vs-master` skipped files absent from master | added files' findings silently dropped |
| `validate.sh` | `--vs-master` linted deleted paths | every deletion faked a finding |
| `validate.sh` | that loop was a pipeline (subshell) | new findings never reached the exit code |
| `validate.sh` | `bash -n ok` with zero files; hadolint `clean` after findings | checks reported as passed that never ran |
| `preflight.sh` | `MATCH` concluded from version equality | claimed revision identity it had not established |
| `pr_review.sh` | `watch` timeout fell out of the loop | exit 0 for checks that never settled |

The CHANGELOG one is the worst: five add-on names in this repo are suffixes of others — `seerr`/`zzz_archived_overseerr`, `birdnet-pi`/`battybirdnet-pi`, `mealie`/`social_to_mealie`, `plex`/`spotify_to_plex` — so bumping the wrong one reported the gate green while CI would fail.

## Measured, before → after

`validate.sh seerr --vs-master`, diff = two appended lines in one cont-init script:

```
before:  bash -n FAIL x2, shellcheck 15 finding(s), == local validation FAILED ==  (exit 1)
after:   bash -n ok (4 files), shellcheck 1 finding(s), 1 NEW finding listed, FAILED (exit 1)
```

Same verdict, opposite meaning: before it was red for two execline files the diff never touched; after it is red for the finding the diff added — which previously printed `(nothing listed above = your diff introduced no new lint findings)` and exited 0.

## Verified

Seven reproductions, each run against both revisions: execline add-on, newly added file, deleted file, add-on with zero shell files, CHANGELOG name collision, CHANGELOG true positive, and the `watch` exit codes across all four terminal states (`pending`→2, `fail`→1, `pass`→0, `skipping`→0).

## Not verified / left out

- **`skipping` counting as passing** was going to be left alone as undemonstrated — then this PR demonstrated it: `Addon linting`, `Check if CHANGELOG.md changed` and `Test addon build` all report `skipping`, because no `*/config.*` changed. Exit 0 is still right (skipped is the correct outcome here, not a failure), so `watch` now prints one line saying a skipped job tested nothing rather than changing the verdict.
- **`.templates` support in `validate.sh` is not in this diff.** The audit behind this PR claimed validate.sh wrongly asserts a CHANGELOG requirement for template-only changes; Codex corrected it — `changedAddons` is `[]` for such a PR, so CI skips the CHANGELOG gate, the linter *and* the build entirely. The right fix is therefore different from the one first proposed, and larger than this PR's scope.
- **Renames** are still treated as wholly new files. Conservative, and `--find-renames` machinery is not worth it for the one case.
- No CI runs on this PR: no `*/config.*` changed, so `changedAddons` is empty and every job is skipped. The scripts were exercised locally instead.

## Rollback

The three files are independent. `git checkout master -- .claude/skills/hassio-addon-workflow/scripts/validate.sh` reverts the riskiest one alone; the other two are a one-line message change and a three-line exit-code change.

## Review

Codex (gpt-5.6-sol) reviewed the audit that produced this and corrected two of its claims — the `.templates` CHANGELOG assertion above, and an adjacent-line tradeoff that does not exist (the comparison strips `file:line:col` before `comm`, so a warning that merely moves cancels). The deleted-file and `watch`-timeout defects are its finds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow monitoring now correctly reports failures when checks time out or fail, while clearly identifying skipped checks.
  * Validation now handles deleted, newly added, and specialized script files more accurately.
  * Changelog validation now requires exact matching to prevent false positives.
  * Validation now works correctly when run from a subdirectory.

* **Documentation**
  * Preflight messaging now clarifies that version matching does not verify the source revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->