### PR TITLE
feat(sabnzbd): enable Home Assistant ingress

### DIFF
--- a/sabnzbd/CHANGELOG.md
+++ b/sabnzbd/CHANGELOG.md
@@ -1,4 +1,8 @@
  
+## 5.1.1.1 (25-08-2026)
+- Ingress is now enabled: the WebUI opens directly in the Home Assistant sidebar, no port needed. Access by ip:port is unchanged.
+- Note for users who set a "Host verification" whitelist in SABnzbd: ingress traffic reaches SABnzbd as `127.0.0.1:8080`, so it is not subject to that whitelist. Direct ip:port access still is.
+
 ## 5.1.1 (2026-08-22)
 - Update to latest version from linuxserver/docker-sabnzbd (changelog : https://github.com/linuxserver/docker-sabnzbd/releases)
  

--- a/sabnzbd/CHANGELOG.md
+++ b/sabnzbd/CHANGELOG.md
@@ -1,5 +1,5 @@
  
-## 5.1.1.2 (25-08-2026)
+## 5.1.1.2 (2026-08-25)
 - Ingress is now enabled: the WebUI opens directly in the Home Assistant sidebar, and the "Open Web UI" button now goes there. Access by ip:port is unchanged, but has to be typed rather than clicked, as Home Assistant does not allow an add-on to offer both.
 - Note for users who set a "Host verification" whitelist in SABnzbd: ingress sends `Host: 127.0.0.1:8080` upstream, because SABnzbd rejects any Host that is not an IP literal. That whitelist therefore no longer filters the ingress route, which is gated by Home Assistant authentication instead. Direct ip:port access is unchanged and still filtered.
 

--- a/sabnzbd/CHANGELOG.md
+++ b/sabnzbd/CHANGELOG.md
@@ -1,6 +1,6 @@
  
-## 5.1.1.1 (25-08-2026)
-- Ingress is now enabled: the WebUI opens directly in the Home Assistant sidebar, no port needed. Access by ip:port is unchanged.
+## 5.1.1.2 (25-08-2026)
+- Ingress is now enabled: the WebUI opens directly in the Home Assistant sidebar, and the "Open Web UI" button now goes there. Access by ip:port is unchanged, but has to be typed rather than clicked, as Home Assistant does not allow an add-on to offer both.
 - Note for users who set a "Host verification" whitelist in SABnzbd: ingress sends `Host: 127.0.0.1:8080` upstream, because SABnzbd rejects any Host that is not an IP literal. That whitelist therefore no longer filters the ingress route, which is gated by Home Assistant authentication instead. Direct ip:port access is unchanged and still filtered.
 
 ## 5.1.1 (2026-08-22)

--- a/sabnzbd/CHANGELOG.md
+++ b/sabnzbd/CHANGELOG.md
@@ -1,7 +1,7 @@
  
 ## 5.1.1.1 (25-08-2026)
 - Ingress is now enabled: the WebUI opens directly in the Home Assistant sidebar, no port needed. Access by ip:port is unchanged.
-- Note for users who set a "Host verification" whitelist in SABnzbd: ingress traffic reaches SABnzbd as `127.0.0.1:8080`, so it is not subject to that whitelist. Direct ip:port access still is.
+- Note for users who set a "Host verification" whitelist in SABnzbd: ingress sends `Host: 127.0.0.1:8080` upstream, because SABnzbd rejects any Host that is not an IP literal. That whitelist therefore no longer filters the ingress route, which is gated by Home Assistant authentication instead. Direct ip:port access is unchanged and still filtered.
 
 ## 5.1.1 (2026-08-22)
 - Update to latest version from linuxserver/docker-sabnzbd (changelog : https://github.com/linuxserver/docker-sabnzbd/releases)

--- a/sabnzbd/config.yaml
+++ b/sabnzbd/config.yaml
@@ -70,7 +70,7 @@ environment:
   PGID: "0"
   PUID: "0"
 image: ghcr.io/alexbelgium/sabnzbd-{arch}
-ingress_entry: sabnzbd
+ingress: true
 init: false
 map:
   - addon_config:rw
@@ -106,5 +106,5 @@ schema:
 slug: sabnzbd
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "5.1.1"
+version: "5.1.1.1"
 webui: http://[HOST]:[PORT:8080]

--- a/sabnzbd/config.yaml
+++ b/sabnzbd/config.yaml
@@ -106,5 +106,4 @@ schema:
 slug: sabnzbd
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "5.1.1.1"
-webui: http://[HOST]:[PORT:8080]
+version: "5.1.1.2"

--- a/sabnzbd/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/sabnzbd/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -1,21 +1,14 @@
 #!/usr/bin/with-contenv bashio
 # shellcheck shell=bash
-# shellcheck disable=SC2317
 set -e
 
 #################
 # NGINX SETTING #
 #################
 
-exit 0
-
 ingress_port=$(bashio::addon.ingress_port)
 ingress_interface=$(bashio::addon.ip_address)
+ingress_entry=$(bashio::addon.ingress_entry)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
-
-# Allows serving js
-sed -i 's/<!-- %if-not-debug% -->/<!-- %if-not-debug%  /g' /app/sabnzbd/webui/index.html
-sed -i 's/<!-- %end% -->/   %end% -->/g' /app/sabnzbd/webui/index.html
-sed -i 's/<!-- %if-debug%/<!-- %if-debug% -->/g' /app/sabnzbd/webui/index.html
-sed -i 's/	%end% -->/<!-- 	%end% -->/g' /app/sabnzbd/webui/index.html
+sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf

--- a/sabnzbd/rootfs/etc/nginx/servers/ingress.conf
+++ b/sabnzbd/rootfs/etc/nginx/servers/ingress.conf
@@ -10,16 +10,23 @@ server {
 
         # SABnzbd refuses any request whose Host is not an IP literal
         # ("Access denied - Hostname verification failed"), so send the
-        # upstream socket rather than the browser's host.
-        proxy_set_header Host              $proxy_host;
-        proxy_set_header X-Real-IP         $remote_addr;
-        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        # upstream socket rather than the browser's host. X-Forwarded-For is
+        # the only other header it reads (for its verify_xff_header option).
+        proxy_set_header Host            $proxy_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
         # The interface itself only emits relative links, so no body
         # rewriting is needed. Redirects are the exception: Raiser() emits
         # a path under url_base, so prefix them with the ingress entry.
-        proxy_redirect / %%ingress_entry%%/;
+        # absolute_redirect must stay off, or nginx expands the rewritten
+        # Location into http://<browser host>:<ingress port>/..., a port the
+        # browser cannot reach.
+        proxy_redirect    / %%ingress_entry%%/;
+        absolute_redirect off;
+
+        # The login cookie is hardcoded to Path=/, which on the ingress
+        # origin would send it to every other add-on's ingress path too.
+        proxy_cookie_path / %%ingress_entry%%/;
 
         proxy_http_version 1.1;
         proxy_read_timeout 86400s;

--- a/sabnzbd/rootfs/etc/nginx/servers/ingress.conf
+++ b/sabnzbd/rootfs/etc/nginx/servers/ingress.conf
@@ -2,22 +2,27 @@ server {
     listen %%interface%%:%%port%% default_server;
 
     include /etc/nginx/includes/server_params.conf;
-    include /etc/nginx/includes/proxy_params.conf;
 
     client_max_body_size 0;
 
-   location / {
-       add_header Access-Control-Allow-Origin *;
-       proxy_connect_timeout 30m;
-       proxy_send_timeout 30m;
-       proxy_read_timeout 30m;
-       proxy_pass         http://127.0.0.1:8080;
+    location / {
+        proxy_pass http://127.0.0.1:8080;
 
-       proxy_set_header Accept-Encoding "";
-      # Correct url without port when using https
-      sub_filter_once off;
-      sub_filter_types *;
-      sub_filter /sabnzbd %%ingress_entry%%/sabnzbd;
-  }
+        # SABnzbd refuses any request whose Host is not an IP literal
+        # ("Access denied - Hostname verification failed"), so send the
+        # upstream socket rather than the browser's host.
+        proxy_set_header Host              $proxy_host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
 
+        # The interface itself only emits relative links, so no body
+        # rewriting is needed. Redirects are the exception: Raiser() emits
+        # a path under url_base, so prefix them with the ingress entry.
+        proxy_redirect / %%ingress_entry%%/;
+
+        proxy_http_version 1.1;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+    }
 }

--- a/sabnzbd/rootfs/etc/services.d/nginx/finish
+++ b/sabnzbd/rootfs/etc/services.d/nginx/finish
@@ -1,0 +1,8 @@
+#!/usr/bin/execlineb -S0
+# ==============================================================================
+# Take down the S6 supervision tree when Nginx fails
+# ==============================================================================
+if { s6-test ${1} -ne 0 }
+if { s6-test ${1} -ne 256 }
+
+s6-svscanctl -t /var/run/s6/services

--- a/sabnzbd/rootfs/etc/services.d/nginx/finish
+++ b/sabnzbd/rootfs/etc/services.d/nginx/finish
@@ -1,8 +1,9 @@
-#!/usr/bin/execlineb -S0
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
 # ==============================================================================
-# Take down the S6 supervision tree when Nginx fails
+# Stop the container when Nginx fails, so ingress does not silently go dead
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
-
-s6-svscanctl -t /var/run/s6/services
+if [[ "$1" -ne 0 && "$1" -ne 256 ]]; then
+    bashio::log.error "Nginx exited with code $1"
+    kill -15 1
+fi

--- a/sabnzbd/rootfs/etc/services.d/nginx/run
+++ b/sabnzbd/rootfs/etc/services.d/nginx/run
@@ -1,0 +1,11 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+# ==============================================================================
+
+# Wait for sabnzbd to become available
+bashio::net.wait_for 8080 localhost 900
+
+bashio::log.info "Starting NGinx..."
+
+exec nginx


### PR DESCRIPTION
Enables Home Assistant ingress for the **sabnzbd** add-on, so the WebUI opens in the sidebar instead of only on `ip:port`.

Most of the work was already committed and switched off. `sabnzbd/rootfs/` carried a complete nginx scaffold, `cont-init.d/32-nginx_ingress.sh` was short-circuited by an `exit 0` on its fifth line, and the Dockerfile is byte-identical to `nzbget/`'s, `ENV PACKAGES="nginx"` included. Only `ingress: true` and the s6 service that starts nginx were missing. `nzbget` is the reference implementation here and `services.d/nginx/finish` is copied from it verbatim; `run` differs only in the port it waits on.

## What was measured

Against the add-on running on my host (SABnzbd 5.1.1, LSIO image), plus the 5.1.1 source:

- **The interface emits only relative links.** `href="../../config/general/"`, `href="../../staticcfg/css/Auto.css"`, `src="../../staticcfg/js/jquery-3.5.1.min.js"`, `action="saveGeneral"`, `action="./one"`. Grepping the source for `(href|src|action)="/` across `interfaces/{Glitter,Config,wizard}`, and for absolute `url:` literals in the Glitter JavaScript, returns nothing. So this proxies straight through with no path rewriting, and **no `sub_filter`**. The previous config's `sub_filter /sabnzbd %%ingress_entry%%/sabnzbd` would also have mangled the `https://sabnzbd.org/wiki/...` help links that appear on every config page into `https:/api/hassio_ingress/<token>/sabnzbd.org/wiki/...`.
- **Redirects are the one exception.** `interface.py`'s `Raiser()` does `root = cfg.url_base() + root`, so `GET /` answers `303 Location: /sabnzbd/wizard/`. Every redirect observed was a path, never a full URL, so one `proxy_redirect` covers them.
- **SABnzbd rejects a Host header that is not an IP literal.** `Host: homeassistant` → `403 Access denied - Hostname verification failed`; `Host: 192.168.1.5:8123` → `200`. nginx therefore sends `$proxy_host` and does not include the shared `proxy_params.conf`, which forwards `$http_host`.
- **Only `X-Forwarded-For` is forwarded besides Host.** The source reads it (`interface.py:133`, and the `verify_xff_header` option) and never reads `X-Real-IP`, `X-Forwarded-Proto`, `X-Forwarded-Host` or `Upgrade`. Those were dropped rather than copied over. SABnzbd 5.x has no WebSocket or SSE endpoint — Glitter polls the HTTP API — so `Upgrade`/`Connection` go with them.
- **`ingress_entry: sabnzbd` is dropped, not kept.** Supervisor appends it to the ingress URL, so the sidebar would open `<entry>/sabnzbd`, which only resolves while the user's `url_base` is literally `/sabnzbd` — a setting they can change, and whose code default is the empty string. SABnzbd serves the same interface at `/` as under its `url_base` (checked for `/config/general/`, `/static/`, `/staticcfg/` and `/wizard/`), so entering at the ingress root works for any value.

## Two things the review caught

Codex reviewed the plan and then the diff. It refuted nothing about the routing, but flagged that SABnzbd hardcodes its login cookie to `Path=/` (`interface.py:316`), which on the shared ingress origin means the browser sends it to every other add-on's ingress path too. Hence `proxy_cookie_path`.

The second one only showed up when I ran the config. With nginx's default `absolute_redirect on`, the rewritten `Location` came back as `http://homeassistant.local:18099/api/hassio_ingress/<token>/sabnzbd/wizard/` — nginx expands a scheme-less replacement using the browser's Host and its own listen port, and that port is the add-on's internal ingress port, which the browser cannot reach. `absolute_redirect off` keeps it a path.

## Verified

I ran the shipped `nginx.conf` and `servers/ingress.conf` — placeholders substituted exactly as `32-nginx_ingress.sh` substitutes them — in front of the live add-on, with the browser Host set to a non-IP hostname on every request:

- `/`, `/sabnzbd/`, `/config`, `/wizard`, `/sabnzbd/config` → 303/301 with `Location` a path under the ingress entry, e.g. `/api/hassio_ingress/TESTTOKEN/sabnzbd/wizard/`
- `/sabnzbd/config/general/`, `/config/general/`, `/sabnzbd/wizard/`, `/sabnzbd/api?mode=version`, and both static roots → 200
- a stub upstream emitting `Set-Cookie: login_cookie=abc123; Path=/` → rewritten to `Path=/api/hassio_ingress/TESTTOKEN/`
- `X-Frame-Options: SameOrigin` passes through once, alongside the `server_params.conf` headers
- empty nginx error log

## Not verified

- **The Docker build.** No dockerd locally; CI is the gate.
- **The login flow at runtime.** My install has `username = ""`, so I did not exercise it. That it works is reasoned from source: login and logout redirect through the same `Raiser()`, the login form posts to `action="./"`, and the cookie path is rewritten as shown above.
- **The s6 service actually starting nginx in the built image.** `finish` is byte-identical to nzbget's and `run` differs only in the port; `nginx.conf` has `daemon off;` and `pid /var/run/nginx.pid;`, and apparmor.txt (identical to nzbget's but for the profile name) has `/var/run/** mrwkl` and `/etc/services.d/** rwix`.

## Behaviour change worth knowing

Ingress sends `Host: 127.0.0.1:8080` upstream, because SABnzbd rejects anything else. A user who set a **Host verification whitelist** in SABnzbd will find it no longer filters the ingress route — Home Assistant authentication is the boundary there instead. Direct `ip:port` access does not go through nginx and is unchanged. Similarly, unless `verify_xff_header` is on, SABnzbd sees ingress requests as coming from loopback, so `inet_exposure` treats them as local. Both are noted in the CHANGELOG.

## Rollback

The riskiest hunk is `servers/ingress.conf`. Reverting `sabnzbd/config.yaml` to `ingress_entry: sabnzbd` (dropping `ingress: true`) disables the whole feature on its own and leaves everything else inert, exactly as it was before this PR — nginx would still start, but nothing would route to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Home Assistant ingress support, allowing the SABnzbd Web UI to open from the Home Assistant sidebar.
  - Ingress access remains protected by Home Assistant authentication.
  - Direct IP-and-port access remains available by manually entering the address.

- **Bug Fixes**
  - Improved redirects, cookie handling, and connection reliability when accessing the Web UI through ingress.
  - Preserved host verification behavior for direct access.
  - Improved Web UI startup and shutdown handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->