### PR TITLE
docs(skill): correct the CHANGELOG heading date format

### DIFF
--- a/.claude/skills/hassio-addon-workflow/SKILL.md
+++ b/.claude/skills/hassio-addon-workflow/SKILL.md
@@ -169,7 +169,9 @@ CI gates on a PR: **`CHANGELOG.md` updated** (hard fail), the **HA add-on linter
 (`frenck/action-addon-linter`, blocking — not the weekly Super-Linter, which is non-blocking), and
 the **add-on image build**. Bump `version` anyway (`X.Y.Z.N`, never `X.Y.Z-N`, see
 `references/traps.md#versioning`) — Supervisor won't offer a rebuild without it. Update
-`README.md` if you added options; match the CHANGELOG heading format `## X.Y (DD-MM-YYYY)`.
+`README.md` if you added options; write the CHANGELOG heading as `## <version> (<date>)`,
+matching the date format already in that file — almost always ISO `YYYY-MM-DD`, see
+`references/traps.md#ci-and-review-bots`.
 
 Write the body to a file, `gh pr create --body-file`: state what was measured, what changed,
 **what is not verified**, and how to roll back the riskiest hunk alone.

--- a/.claude/skills/hassio-addon-workflow/references/traps.md
+++ b/.claude/skills/hassio-addon-workflow/references/traps.md
@@ -241,6 +241,16 @@ account. Note it and move on rather than guessing.
 **Resolving a review thread requires GraphQL** (`resolveReviewThread`); the REST API cannot do it.
 `scripts/pr_review.sh` wraps fetch / reply / resolve.
 
+**CHANGELOG heading dates are ISO, whatever the bots' defaults say.** Match the format already in
+the add-on's file. Repo-wide that is `## <version> (YYYY-MM-DD)`: 7705 dated headings against 363
+in `DD-MM-YYYY`, and the newest entry is ISO in 125 of 135 add-ons. Copilot flags an ISO file that
+gets a `DD-MM-YYYY` entry (#3019). `DD-MM-YYYY` is not invented — it is what `onpush_builder.yaml`
+writes with `date '+%d-%m-%Y'` when it has to insert a heading you forgot, and what the
+addons_updater bot writes when its `date_iso8601` option is off (`99-run.sh`; it is on in
+production here) — but neither is a reason to write it yourself. The builder's duplicate check is
+`grep -q "^## ${version} ("`, keyed on the exact `config.yaml` version and blind to the date, so
+an ISO heading you wrote yourself still suppresses the bot's insertion.
+
 **The repo's `.markdownlint.yaml` does not disable MD022/MD032**, so a CHANGELOG will show
 dozens of pre-existing heading/list findings. They are noise because lint is `continue-on-error`,
 not because the config exempts them — don't cite the config as a reason to ignore a finding.


### PR DESCRIPTION
Step 7 of the add-on workflow skill told me to write `## X.Y (DD-MM-YYYY)`. The repo does not use that format, so following the instruction produced a CHANGELOG entry that Copilot flagged on #3019 and I had to fix in a second round.

## What the repo actually does

| | count |
|---|---|
| headings dated `YYYY-MM-DD` | 7705 |
| headings dated `DD-MM-YYYY` | 363 |
| add-ons whose newest entry is ISO | 125 of 135 |

## Where DD-MM-YYYY came from

It is not invented, which is presumably how it ended up in the skill:

- `onpush_builder.yaml` inserts `## ${version} ($(date '+%d-%m-%Y'))` when a push arrives and the add-on's CHANGELOG has no heading for the version in `config.yaml`.
- `addons_updater`'s `99-run.sh` defaults to `+%d-%m-%Y`, switching to `+%Y-%m-%d` only when its `date_iso8601` option is true. That option **is** true on the instance that writes to this repo — I read it back from the running add-on — which is why nearly everything on master is ISO.

Neither is a reason to write `DD-MM-YYYY` by hand.

## The change

`SKILL.md` step 7 now says to match the format already in the file, and points at `references/traps.md`. The traps entry carries the numbers, the two bot mechanisms, and one thing worth knowing: the builder's duplicate check is `grep -q "^## ${version} ("`, keyed on the exact `config.yaml` version and blind to the date, so an ISO heading you wrote yourself still suppresses the bot's insertion — writing ISO does not risk a duplicate heading.

## Verified / not verified

- **Verified** — the counts above, by grepping every `*/CHANGELOG.md` on master; `date_iso8601: true` read from the running `addons_updater` add-on's options via the Supervisor API; both bot code paths read in the files cited.
- **Not verified** — nothing to run here. This PR touches no add-on directory, so the three hard gates are `if:`-skipped rather than passing, as `traps.md` already notes.

## Rollback

Two files, docs only. `git revert` restores the previous wording with no runtime effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated changelog guidance to use each file’s existing date format, typically ISO `YYYY-MM-DD`.
  - Documented fallback behavior for changelog updates and version-based duplicate-heading checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->