### PR TITLE
Revert "Revert "feat(sabnzbd): enable Home Assistant ingress""

### DIFF
--- a/sabnzbd/CHANGELOG.md
+++ b/sabnzbd/CHANGELOG.md
@@ -1,4 +1,8 @@
  
+## 5.1.1.2 (2026-08-25)
+- Ingress is now enabled: the WebUI opens directly in the Home Assistant sidebar, and the "Open Web UI" button now goes there. Access by ip:port is unchanged, but has to be typed rather than clicked, as Home Assistant does not allow an add-on to offer both.
+- Note for users who set a "Host verification" whitelist in SABnzbd: ingress sends `Host: 127.0.0.1:8080` upstream, because SABnzbd rejects any Host that is not an IP literal. That whitelist therefore no longer filters the ingress route, which is gated by Home Assistant authentication instead. Direct ip:port access is unchanged and still filtered.
+
 ## 5.1.1 (2026-08-22)
 - Update to latest version from linuxserver/docker-sabnzbd (changelog : https://github.com/linuxserver/docker-sabnzbd/releases)
  

--- a/sabnzbd/config.yaml
+++ b/sabnzbd/config.yaml
@@ -70,7 +70,7 @@ environment:
   PGID: "0"
   PUID: "0"
 image: ghcr.io/alexbelgium/sabnzbd-{arch}
-ingress_entry: sabnzbd
+ingress: true
 init: false
 map:
   - addon_config:rw
@@ -106,5 +106,4 @@ schema:
 slug: sabnzbd
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "5.1.1"
-webui: http://[HOST]:[PORT:8080]
+version: "5.1.1.2"

--- a/sabnzbd/rootfs/etc/cont-init.d/32-nginx_ingress.sh
+++ b/sabnzbd/rootfs/etc/cont-init.d/32-nginx_ingress.sh
@@ -1,21 +1,14 @@
 #!/usr/bin/with-contenv bashio
 # shellcheck shell=bash
-# shellcheck disable=SC2317
 set -e
 
 #################
 # NGINX SETTING #
 #################
 
-exit 0
-
 ingress_port=$(bashio::addon.ingress_port)
 ingress_interface=$(bashio::addon.ip_address)
+ingress_entry=$(bashio::addon.ingress_entry)
 sed -i "s/%%port%%/${ingress_port}/g" /etc/nginx/servers/ingress.conf
 sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
-
-# Allows serving js
-sed -i 's/<!-- %if-not-debug% -->/<!-- %if-not-debug%  /g' /app/sabnzbd/webui/index.html
-sed -i 's/<!-- %end% -->/   %end% -->/g' /app/sabnzbd/webui/index.html
-sed -i 's/<!-- %if-debug%/<!-- %if-debug% -->/g' /app/sabnzbd/webui/index.html
-sed -i 's/	%end% -->/<!-- 	%end% -->/g' /app/sabnzbd/webui/index.html
+sed -i "s|%%ingress_entry%%|${ingress_entry}|g" /etc/nginx/servers/ingress.conf

--- a/sabnzbd/rootfs/etc/nginx/servers/ingress.conf
+++ b/sabnzbd/rootfs/etc/nginx/servers/ingress.conf
@@ -2,22 +2,34 @@ server {
     listen %%interface%%:%%port%% default_server;
 
     include /etc/nginx/includes/server_params.conf;
-    include /etc/nginx/includes/proxy_params.conf;
 
     client_max_body_size 0;
 
-   location / {
-       add_header Access-Control-Allow-Origin *;
-       proxy_connect_timeout 30m;
-       proxy_send_timeout 30m;
-       proxy_read_timeout 30m;
-       proxy_pass         http://127.0.0.1:8080;
+    location / {
+        proxy_pass http://127.0.0.1:8080;
 
-       proxy_set_header Accept-Encoding "";
-      # Correct url without port when using https
-      sub_filter_once off;
-      sub_filter_types *;
-      sub_filter /sabnzbd %%ingress_entry%%/sabnzbd;
-  }
+        # SABnzbd refuses any request whose Host is not an IP literal
+        # ("Access denied - Hostname verification failed"), so send the
+        # upstream socket rather than the browser's host. X-Forwarded-For is
+        # the only other header it reads (for its verify_xff_header option).
+        proxy_set_header Host            $proxy_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
+        # The interface itself only emits relative links, so no body
+        # rewriting is needed. Redirects are the exception: Raiser() emits
+        # a path under url_base, so prefix them with the ingress entry.
+        # absolute_redirect must stay off, or nginx expands the rewritten
+        # Location into http://<browser host>:<ingress port>/..., a port the
+        # browser cannot reach.
+        proxy_redirect    / %%ingress_entry%%/;
+        absolute_redirect off;
+
+        # The login cookie is hardcoded to Path=/, which on the ingress
+        # origin would send it to every other add-on's ingress path too.
+        proxy_cookie_path / %%ingress_entry%%/;
+
+        proxy_http_version 1.1;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+    }
 }

--- a/sabnzbd/rootfs/etc/services.d/nginx/finish
+++ b/sabnzbd/rootfs/etc/services.d/nginx/finish
@@ -1,0 +1,9 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+# ==============================================================================
+# Stop the container when Nginx fails, so ingress does not silently go dead
+# ==============================================================================
+if [[ "$1" -ne 0 && "$1" -ne 256 ]]; then
+    bashio::log.error "Nginx exited with code $1"
+    kill -15 1
+fi

--- a/sabnzbd/rootfs/etc/services.d/nginx/run
+++ b/sabnzbd/rootfs/etc/services.d/nginx/run
@@ -1,0 +1,11 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+set -e
+# ==============================================================================
+
+# Wait for sabnzbd to become available
+bashio::net.wait_for 8080 localhost 900
+
+bashio::log.info "Starting NGinx..."
+
+exec nginx


### PR DESCRIPTION
Reverts alexbelgium/hassio-addons#3021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Home Assistant sidebar ingress for direct access to the SABnzbd WebUI.
  * Added support for ingress routing while retaining direct IP-and-port access.
  * Improved handling of redirects, cookies, forwarded headers, and long-running connections through ingress.

* **Bug Fixes**
  * SABnzbd ingress access is no longer blocked by host verification settings.
  * Added monitoring to stop the add-on if its ingress service exits unexpectedly.

* **Documentation**
  * Added release notes for version 5.1.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->