### PR TITLE
fix(sabnzbd): stop forwarding X-Forwarded-For, which ingress 403s on

### DIFF
--- a/.claude/skills/hassio-addon-workflow/references/evidence.md
+++ b/.claude/skills/hassio-addon-workflow/references/evidence.md
@@ -34,6 +34,12 @@ then generalising it to all hosts.**
   would have deleted a user's hand-written configuration.
 - A GPU probe created a hardware context — but that proved the driver worked, not that Chromium's
   GPU path did.
+- SABnzbd's source was grepped to see which proxy headers it reads, and `X-Forwarded-For` was
+  forwarded because it reads that one — but `verify_xff_header` is on by default and makes it
+  *reject* every address in the chain that is not local, so ingress answered 403 for anyone
+  reaching Home Assistant from outside the LAN (#3019, fixed in #3023). Every check ran from
+  inside the container, where no such header exists. **That an app reads a header is not a reason
+  to send it — find out what it does with it, and exercise the path a remote user takes.**
 
 The pattern is always *inference standing in for detection*. Before changing a default, ask what
 this is like on a host unlike yours. Prefer detecting the condition at runtime over asserting it.

--- a/sabnzbd/CHANGELOG.md
+++ b/sabnzbd/CHANGELOG.md
@@ -1,4 +1,7 @@
  
+## 5.1.1.3 (2026-08-25)
+- Fixed ingress returning `403 External internet access denied` when Home Assistant is reached from outside the local network. SABnzbd's `verify_xff_header` option, which is on by default, refuses any request whose `X-Forwarded-For` chain contains a non-local address, so the proxy no longer forwards that header.
+
 ## 5.1.1.2 (2026-08-25)
 - Ingress is now enabled: the WebUI opens directly in the Home Assistant sidebar, and the "Open Web UI" button now goes there. Access by ip:port is unchanged, but has to be typed rather than clicked, as Home Assistant does not allow an add-on to offer both.
 - Note for users who set a "Host verification" whitelist in SABnzbd: ingress sends `Host: 127.0.0.1:8080` upstream, because SABnzbd rejects any Host that is not an IP literal. That whitelist therefore no longer filters the ingress route, which is gated by Home Assistant authentication instead. Direct ip:port access is unchanged and still filtered.

--- a/sabnzbd/config.yaml
+++ b/sabnzbd/config.yaml
@@ -106,4 +106,4 @@ schema:
 slug: sabnzbd
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "5.1.1.2"
+version: "5.1.1.3"

--- a/sabnzbd/rootfs/etc/nginx/servers/ingress.conf
+++ b/sabnzbd/rootfs/etc/nginx/servers/ingress.conf
@@ -10,10 +10,17 @@ server {
 
         # SABnzbd refuses any request whose Host is not an IP literal
         # ("Access denied - Hostname verification failed"), so send the
-        # upstream socket rather than the browser's host. X-Forwarded-For is
-        # the only other header it reads (for its verify_xff_header option).
+        # upstream socket rather than the browser's host.
         proxy_set_header Host            $proxy_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        # X-Forwarded-For must NOT be forwarded. verify_xff_header defaults to
+        # on, and check_access() then requires every address in the header to
+        # be local, so Supervisor's copy of the browser's public address makes
+        # SABnzbd answer 403 "External internet access denied" for anyone
+        # reaching Home Assistant from outside the LAN. Clearing it leaves
+        # SABnzbd looking at nginx's own loopback address. Access is gated by
+        # Home Assistant authentication before it ever reaches this proxy.
+        proxy_set_header X-Forwarded-For "";
 
         # The interface itself only emits relative links, so no body
         # rewriting is needed. Redirects are the exception: Raiser() emits


### PR DESCRIPTION
Ingress from #3019 answers `403 External internet access denied - https://sabnzbd.org/access-denied` when Home Assistant is reached from outside the LAN. Reported against the deployed 5.1.1.2.

## Root cause

`check_access()` in `sabnzbd/interface.py`:

```python
# Never check the XFF header unless access would have been granted based on the remote IP alone!
if is_allowed and cfg.verify_xff_header() and (xff_ips := clean_comma_separated_list(
        cherrypy.request.headers.get("X-Forwarded-For"))):
    is_allowed = all(is_local_addr(ip) or is_loopback_addr(ip) for ip in xff_ips)
```

nginx's own address is loopback, so the first test passes and SABnzbd goes on to require that **every** address in `X-Forwarded-For` also be local. Supervisor puts the browser's address there, so a remote user is refused. `verify_xff_header` defaults to on (`cfg.py:531`) — this is not something a user opted into.

## Reproduced

Against the running add-on, `GET /config/general/`:

| `X-Forwarded-For` | |
|---|---|
| *(absent)* | 200 |
| `81.164.12.7` | **403** `External internet access denied` |
| `81.164.12.7, 172.30.32.2` | **403** |
| `192.168.1.44` | 200 |

Which is exactly the reported symptom: fine on the LAN, refused from outside.

## The fix

`proxy_set_header X-Forwarded-For "";` — nginx drops the header entirely, so SABnzbd sees only nginx's loopback address, which is what it saw before #3019 added the header at all. Ingress is gated by Home Assistant authentication before a request reaches this proxy, so nothing is weakened; SABnzbd's own IP-based exposure check cannot meaningfully apply to a loopback reverse proxy in the first place.

I forwarded the header in #3019 because grepping the source showed SABnzbd *reads* it. That was the wrong test — what it does with it is reject.

## Verified

Ran the shipped `nginx.conf` and `servers/ingress.conf` in front of the live add-on, both variants side by side on separate ports, placeholders substituted exactly as `32-nginx_ingress.sh` substitutes them, `Host: ha.alexandrep.cc` on every request:

- current config → 403 for `81.164.12.7` and for the `81.164.12.7, 172.30.32.2` chain; 200 for `192.168.1.44`
- fixed config → **200 for all three**
- `/`, `/wizard`, `/config` still redirect to a path under the ingress entry; `/static/javascripts/glitter.js`, `/staticcfg/css/style.css` and `/api?mode=version` still 200

One useful accident: this instance came back from the rebuild with an **empty `url_base`** (it serves at `/` and 404s on `/sabnzbd/`), where the one I developed against had `/sabnzbd`. The pass-through routing is therefore now confirmed against both values — which is what dropping `ingress_entry` in #3019 was for.

**Not verified**: the Docker build (no dockerd locally; CI is the gate), and the login flow, which still has no credentials on the instance I can reach.

## Skill change in the same PR

`references/evidence.md` gains one bullet recording the methodology error — that an app reading a header is not a reason to send it, and that every check ran from inside the container, where no such header exists. The skill's own rule is to feed a lesson back in the follow-up PR that fixes it.

## Rollback

`git revert` this commit restores the previous header behaviour. It re-breaks remote access but changes nothing else; ingress on the LAN works either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed remote access through Home Assistant ingress, preventing HTTP 403 errors caused by proxy header validation.
  - Improved proxy handling for SABnzbd requests to ensure external users can access the add-on reliably.

- **Changelog**
  - Added release notes for version 5.1.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->