### PR TITLE
fix(zoraxy): restore apk removed by the upstream image build

### DIFF
--- a/.claude/skills/hassio-addon-workflow/references/traps.md
+++ b/.claude/skills/hassio-addon-workflow/references/traps.md
@@ -163,6 +163,26 @@ the running image (`command -v <tool>`), and cross-check `/var/log/apt/history.l
 matching `apt-get install` line. An `if` block whose condition never matched leaves no trace and
 no error — one such block sat dead for weeks while appearing to guarantee driver verification.
 
+**Adding a build stage above `ARG BUILD_FROM` breaks the final `FROM`.** Global build args must
+be declared *before the first* `FROM` in the file; an `ARG` that follows one belongs to that stage
+only. Inserting a tools stage at the top of an add-on Dockerfile therefore demotes the
+`ARG BUILD_FROM` below it, and the final `FROM ${BUILD_FROM}` expands empty:
+`failed to solve: base name (${BUILD_FROM}) should not be blank`. Move `ARG BUILD_FROM` (and
+`ARG BUILD_VERSION`) above the new stage. `netalertx` does not hit this only because it hardcodes
+its base image instead of using `${BUILD_FROM}` — do not copy its ordering blindly
+(PR #3024).
+
+**A base image can lose its package manager between upstream releases.** Zoraxy v3.3.4 added
+`/sbin/apk` to the upstream cleanup step, so `ha_automodules.sh` failed with
+`apt-get: not found / apk: not found` (exit 127) on both architectures. The removal deleted only
+the binary — `/etc/apk` (repositories, keys, world) and `/lib/apk/db` survived, confirmed by a
+single `sbin/.wh.apk` whiteout in the layer — so copying `apk.static` from an
+`apk-tools-static` build stage restores package management in one line. Diff the upstream image
+configs across the two tags (`.history[].created_by` from the registry config blob) before
+theorising; it names the changed step exactly. Note `build_from` is often a floating `:latest`
+tag, so the builder's revert-on-failure does **not** restore a working build — the next rebuild
+fails identically until the Dockerfile is fixed (PR #3024).
+
 **Don't test for distro-specific filenames.** A guard on
 `/usr/share/vulkan/icd.d/intel_icd.x86_64.json` named a file Debian does not ship (it installs
 `intel_icd.json`), so fixing the arch variable alone would have turned dead code into a failing

--- a/zoraxy/CHANGELOG.md
+++ b/zoraxy/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.3.3.1 (29-08-2026)
+- Fix build failure against the current upstream image: since v3.3.4 the upstream
+  build deletes /sbin/apk, so the shared module and package scripts had no package
+  manager and failed with "apt-get: not found / apk: not found" (exit 127). The
+  statically-linked apk binary is now restored from a build stage.
+
 ## 3.3.3 (2026-06-19)
 - Initial release
 - Zoraxy reverse proxy with web management UI (port 8000) for Home Assistant

--- a/zoraxy/Dockerfile
+++ b/zoraxy/Dockerfile
@@ -10,6 +10,11 @@
 #               /`
 #=== Home Assistant Addon ===#
 
+# Declared before the first FROM so they stay global build args, usable by the
+# FROM of the final stage below.
+ARG BUILD_FROM
+ARG BUILD_VERSION
+
 ############################
 # 0 Tools stage (apk OK)   #
 ############################
@@ -26,8 +31,6 @@ RUN apk add --no-cache apk-tools-static
 # 1 Build Image #
 #################
 
-ARG BUILD_FROM
-ARG BUILD_VERSION
 FROM ${BUILD_FROM}
 
 ##################

--- a/zoraxy/Dockerfile
+++ b/zoraxy/Dockerfile
@@ -10,6 +10,18 @@
 #               /`
 #=== Home Assistant Addon ===#
 
+############################
+# 0 Tools stage (apk OK)   #
+############################
+# Upstream's image build ends with "rm -rf /sbin/apk" (added in v3.3.4), which
+# deletes the package manager binary but leaves /etc/apk (repositories, keys,
+# world) and /lib/apk/db intact. The shared build scripts below need a package
+# manager to install bash, curl and jq, none of which the image ships, so
+# restore apk from its statically-linked build. Keep this Alpine tag in sync
+# with the upstream base image (currently alpine-minirootfs-3.24.1).
+FROM alpine:3.24 AS ha_apk
+RUN apk add --no-cache apk-tools-static
+
 #################
 # 1 Build Image #
 #################
@@ -45,6 +57,9 @@ RUN if [ ! -f /bin/sh ] && [ -f /usr/bin/sh ]; then ln -s /usr/bin/sh /bin/sh; f
 # Persist Zoraxy data in /config (addon_config) instead of the ephemeral
 # upstream working directory, so the configuration survives add-on updates.
 RUN sed -i 's#/opt/zoraxy/config#/config#g' /opt/zoraxy/entrypoint.py
+
+# Restore the package manager deleted by the upstream image build (see stage 0)
+COPY --from=ha_apk /sbin/apk.static /sbin/apk
 
 # Modules
 ARG MODULES="00-banner.sh"

--- a/zoraxy/config.yaml
+++ b/zoraxy/config.yaml
@@ -6,7 +6,7 @@ image: ghcr.io/alexbelgium/zoraxy-{arch}
 name: Zoraxy
 slug: zoraxy
 url: https://github.com/alexbelgium/hassio-addons/tree/master/zoraxy
-version: "3.3.3"
+version: "3.3.3.1"
 init: false
 startup: services
 webui: "http://[HOST]:[PORT:8000]"


### PR DESCRIPTION
## Problem

The `Updater bot : zoraxy updated to 3.3.4` build failed on both architectures
([run 33220808110](https://github.com/alexbelgium/hassio-addons/actions/runs/33220808110))
and was reverted by the builder's revert-on-failure job (`290ec8c513`):

```
/ha_automodules.sh: line 15: apt-get: not found
/ha_automodules.sh: line 15: apk: not found
ERROR: process "/bin/sh -c ... /ha_automodules.sh ..." did not complete successfully: exit code: 127
```

The revert did **not** restore a working build. `build.json` pins the floating tag
`zoraxydocker/zoraxy:latest`, so the next rebuild of zoraxy fails identically
regardless of the `version` recorded in `config.yaml`.

## Root cause

Comparing the upstream image configs for `v3.3.3` and `v3.3.4` shows one changed
cleanup step:

```
v3.3.3:  ... && rm -rf         /var/cache/apk/* /tmp/*
v3.3.4:  ... && rm -rf /sbin/apk /var/cache/apk/* /tmp/*
```

Upstream now deletes the package manager. The image also ships neither `bash` nor
`curl` (its install list is `tzdata python3 sudo netcat-openbsd libressl-dev
openssh ca-certificates libc6-compat libstdc++`), so `ha_automodules.sh` tries to
install them, finds no package manager, and exits 127.

Inspecting the image layers shows the removal is recoverable: the only whiteout in
that layer is `sbin/.wh.apk`. `/etc/apk/repositories` (pointing at v3.24 main and
community), `/etc/apk/keys`, `/etc/apk/world` and `/lib/apk/db` all survive intact.
Restoring the binary alone restores package management.

## Fix

Add a build stage that provides `apk-tools-static`, and copy its statically-linked
binary into place before the shared module and package scripts run. This follows the
existing `ha_tools` stage idiom already used by `netalertx/Dockerfile`.

`apk.static` has no shared-library dependencies, so no library copying or musl-loader
handling is needed, and `apk-tools-static-3.0.7-r0` is present in Alpine v3.24 main
for both `x86_64` and `aarch64`.

## Version

Bumped to `3.3.3.1` — the local patch counter, since `updater.json` records
`upstream_version: 3.3.3`. `updater.json` is untouched; `addons_updater` will retry
the 3.3.4 bump on its own schedule, and that bump should now succeed.

Note that because `build_from` is the floating `:latest` tag, this build already
ships upstream 3.3.4 binaries while labelled 3.3.3.1. That mislabelling is
pre-existing behaviour of the floating tag and resolves itself at the next updater
run; pinning the tag instead would freeze the add-on, so it was left alone.

## Verified

- **Verified** — the regression, by fetching both upstream image configs from the
  registry and diffing the layer history; and the recoverability, by listing the
  layer tarballs (single `sbin/.wh.apk` whiteout, apk database and repositories present).
- **Verified** — `apk.static` exists at `/sbin/apk.static` in `apk-tools-static-3.0.7-r0`
  on both `x86_64` and `aarch64`, by downloading and listing both packages.
- **Verified** — the unrelated persistence `sed` on `entrypoint.py` still matches:
  `/opt/zoraxy/config` occurs twice in the 3.3.4 copy of that file.
- **Checked** — `bash -n`, shellcheck, hadolint, config.yaml schema, yamllint,
  markdownlint via `validate.sh zoraxy --vs-master`; no new findings.
- **Not verified** — the Docker build itself. No dockerd is available locally, so CI
  is the only gate on this change.

## Rollback

The change is two hunks in `zoraxy/Dockerfile` (the `ha_apk` stage and the one-line
`COPY --from=ha_apk`). Reverting both restores the previous file exactly; the add-on
then returns to failing to build against the current upstream image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed container build failures caused by the upstream image removing the Alpine package manager.
  * Restored package installation support in the final image, improving build reliability with current upstream images.

* **Chores**
  * Updated the add-on version to 3.3.3.1.
  * Added a changelog entry documenting the build fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->