### PR TITLE
fix(filebrowser_quantum): navigate in place instead of opening a new tab under ingress

### DIFF
--- a/filebrowser_quantum/CHANGELOG.md
+++ b/filebrowser_quantum/CHANGELOG.md
@@ -1,4 +1,15 @@
  
+## 1.5.3.1 (2026-08-29)
+- Fix "open parent directory" in Tools -> File Size Analyzer under Home
+  Assistant ingress. FileBrowser opened the parent folder in a new tab, which
+  lands on the raw ingress URL with no Home Assistant frontend around it to
+  keep the ingress session alive, so the new tab answered 401 instead of
+  showing the folder. The ingress vhost now turns that popup into a navigation
+  of the panel itself. The same fix covers the other tool views and the "go to
+  item" action on search results, which open a new tab the same way. Download
+  and preview popups, links pointing out of the add-on, and direct access on
+  port 8071 are unchanged.
+ 
 ## 1.5.3 (2026-08-29)
 - Update to latest version from gtsteffaniak/filebrowser (changelog : https://github.com/gtsteffaniak/filebrowser/releases)
  

--- a/filebrowser_quantum/config.yaml
+++ b/filebrowser_quantum/config.yaml
@@ -118,4 +118,4 @@ schema:
 slug: filebrowser_quantum
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "1.5.3"
+version: "1.5.3.1"

--- a/filebrowser_quantum/rootfs/etc/nginx/servers/ingress.conf
+++ b/filebrowser_quantum/rootfs/etc/nginx/servers/ingress.conf
@@ -3,7 +3,7 @@ server {
 
     include /etc/nginx/includes/server_params.conf;
     include /etc/nginx/includes/proxy_params.conf;
-    
+
     client_max_body_size 0;
 
    location / {
@@ -12,6 +12,35 @@ server {
        proxy_send_timeout 30m;
        proxy_read_timeout 30m;
        proxy_pass         %%protocol%%://backend%%subpath%%;
+
+       # Tools -> File Size Analyzer (and the other tool views) open a result's
+       # parent folder with window.open(<absolute url>, '_blank'), because
+       # goToItem() takes its newTab argument from the context menu's
+       # showLimitedOptions flag, which those views always set. Behind ingress
+       # that popup lands on the raw /api/hassio_ingress/<token>/ url with no
+       # Home Assistant frontend around it to keep the ingress session alive,
+       # so the new tab answers 401 instead of showing the folder. Turn that
+       # popup into a navigation of the panel itself.
+       #
+       # The context menu's "go to item" action, which search results and the
+       # tool views also offer, hardcodes the same new tab and is fixed too.
+       #
+       # Scoped to the two prefixes goToItem() builds, "files/" and
+       # "public/share/", so the window.open calls that download or preview a
+       # file (they go to api/resources/download) keep their own tab: sending
+       # an inline raw file to location.assign would replace the whole app.
+       # A link out of the add-on keeps its own tab as well, unless a user
+       # points a sidebar link (or a link inside a file open in the editor) at
+       # this same instance's files/ or public/share/ route, which then also
+       # opens in the panel. Same shape as the komga add-on's ingress filter.
+       #
+       # Injected into the page's existing nonce-carrying inline script rather
+       # than next to <div id="app">: FileBrowser sends
+       # script-src 'self' 'nonce-<random>', so a standalone inline <script>
+       # would be blocked. If upstream ever drops that
+       # window.__pwaDeferredPrompt line the filter simply stops matching and
+       # the popup behaviour returns, which is the pre-fix state.
+       sub_filter "window.__pwaDeferredPrompt = null;" "window.__pwaDeferredPrompt = null;(function(){var o=window.open;window.open=function(u,n,f){try{var b=(window.globalVars||{}).baseURL;if(u&&n==='_blank'&&!f&&b){if(b.slice(-1)!=='/')b+='/';var t=new URL(u,location.href);if((t.protocol==='http:'||t.protocol==='https:')&&t.origin===location.origin&&(t.pathname.indexOf(b+'files/')===0||t.pathname.indexOf(b+'public/share/')===0)){location.assign(t.href);return window}}}catch(e){}return o.apply(window,arguments)}})();";
   }
 
 }


### PR DESCRIPTION
## What was reported

In File Browser Quantum's **Tools → File Size Analyzer**, "open parent directory"
opens a new tab instead of navigating inside the current page. Under Home
Assistant ingress that new tab does not work.

## Root cause (upstream, not this repo)

Traced in the upstream source at `v1.5.4-stable`, which is what
`gtstef/filebrowser:latest` currently ships (verified from the image's own
`version.Version` string):

- `frontend/src/views/tools/SizeViewer.vue:622` passes `showLimitedOptions: true`
  to the context menu.
- `frontend/src/components/ContextMenu.vue:930` `openParentFolder()` calls
  `url.goToItem(item.source, parentPath, {}, this.showLimitedOptions)` — the
  fourth positional argument of `goToItem` is `newTab`.
- `frontend/src/utils/url.js:272` `goToItem()` therefore takes its
  `window.open(absoluteUrl, '_blank')` branch.

The same is visible in the shipped minified bundle:

```
...;window.open(l,"_blank");return}if(n===void 0){Ii.replace({path:o});...
```

Behind ingress that popup lands on the raw `/api/hassio_ingress/<token>/…` URL
with no Home Assistant frontend around it to keep the ingress session alive, so
the new tab is answered before FileBrowser is reached instead of showing the
folder. The same `newTab = true` path is hardcoded in `ContextMenu.goToItem()`
(`ContextMenu.vue:549`), which search results and the other tool views offer, so
that action had the identical bug.

There is no upstream setting for this: `backend/common/settings/structs.go`'s
frontend config has no new-tab preference, and `newTab` exists only as a
positional argument to `goToItem`. Nothing in `99-run.sh` can reach it.

## What changed

One `sub_filter` in the **ingress vhost only**, which turns that popup into a
navigation of the panel itself. This is the same mechanism the `komga` add-on
already uses for the same class of ingress problem
(`komga/rootfs/etc/nginx/servers/ingress.conf`).

Two deliberate choices:

- **Scoped to the two path prefixes `goToItem()` builds** — `files/` and
  `public/share/`. The other `window.open` call sites are downloads and raw
  previews (`api/resources/download`) and links out of the add-on; sending an
  inline raw file to `location.assign` would replace the whole app, so those
  keep their own tab.
- **Injected into the page's existing nonce-carrying inline script**, not next
  to `<div id="app">`. FileBrowser sends
  `script-src 'self' 'nonce-<random>' …` (`backend/http/static.go:52`), so a
  standalone inline `<script>` would be blocked by CSP. The anchor
  (`window.__pwaDeferredPrompt = null;`) sits on the line right after
  `window.globalVars` is assigned, so `globalVars.baseURL` is available.

`direct.conf` (port 8071) is untouched — there is no ingress session there and
new tabs work normally.

No new nginx directives were needed for the filter to see uncompressed HTML: the
shared `proxy_params.conf` already sets `proxy_set_header Accept-Encoding "";`,
and the backend only gzips JSON payloads over 10 KB (`middleware.go` `renderJSON`),
never the HTML template.

## Verified

- **nginx end to end**: real nginx running this vhost in front of a stub upstream
  serving the *actual* shipped `public/index.html` (extracted from
  `gtstef/filebrowser:latest`) as `text/html` with the real CSP header. The shim
  is injected exactly once, inside the nonce'd script; the CSP header passes
  through unchanged; a `.js` response passes through untouched.
- **`nginx -t`** passes; `nginx -V` and Alpine's nginx APKBUILD both confirm
  `--with-http_sub_module`, which the add-on's Alpine-based image provides.
- **13 behavioural assertions on the shim** (node): `files/` and `public/share/`
  navigate in place; `api/resources/download`, `public/api/…`, cross-origin
  links, a named popup with a feature string, the near-miss prefix
  `filesomething/`, and a `blob:` URL all fall through to the native
  `window.open`; a `baseURL` without a trailing slash still matches; a missing
  `globalVars` falls through without throwing.
- **Independent review by Codex** (gpt-5.6-sol) reading the diff, the upstream
  source and the shipped bundle: no blocking issue, no simpler config-based
  alternative, anchor and scope confirmed. Its one substantive note was that the
  changelog's "external links are unchanged" was not literally universal — a
  sidebar link (or a link inside a file open in the editor) pointing at *this
  same instance's* `files/`/`public/share/` route will also open in the panel.
  The wording is now qualified and the collision documented in the conf.

## Not verified

- **No Docker build and no browser test against a real add-on under real
  ingress** — there is no dockerd on the machine this was prepared on, so CI is
  the only build gate, and the end-to-end check above stops at the nginx/HTML
  layer. The shim's behaviour is covered by the node assertions, not by a
  browser.

## Failure mode and rollback

If a future upstream release drops the `window.__pwaDeferredPrompt = null;`
line, `sub_filter` simply stops matching and the popup behaviour returns — the
pre-fix state, not a broken page.

Rollback is the `sub_filter` line and its comment block in
`filebrowser_quantum/rootfs/etc/nginx/servers/ingress.conf`; nothing else in the
diff is behavioural.

Worth reporting upstream as well, since the underlying `showLimitedOptions` →
`newTab` conflation affects every reverse-proxied deployment, not just ingress.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation from the File Size Analyzer and search results when running under Home Assistant ingress.
  * Parent folders, tool views, and item links now open within the current panel instead of redirecting to an inaccessible raw URL.
  * Download and preview popups, external links, and direct access remain unchanged.

* **Chores**
  * Updated the add-on version to 1.5.3.1 and documented the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->