### PR TITLE
fix(lint): make the Unicode-space regex actually match Unicode spaces

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           set -euo pipefail
           CHANGED_FILES=$(git diff --name-only "$DIFF_RANGE")
-          UNICODE_SPACES_REGEX=$'[\\u00A0\\u2002\\u2003\\u2007\\u2008\\u2009\\u202F\\u205F\\u3000\\u200B]'
+          UNICODE_SPACES_REGEX='[\x{00A0}\x{2002}\x{2003}\x{2007}\x{2008}\x{2009}\x{202F}\x{205F}\x{3000}\x{200B}]'
           for file in $CHANGED_FILES; do
             if [ -f "$file" ]; then
               MIME_TYPE=$(file --mime-type -b "$file")
@@ -89,7 +89,7 @@ jobs:
       - name: Fix non-printable Unicode spaces in all text files
         run: |
           set -euo pipefail
-          UNICODE_SPACES_REGEX=$'[\\u00A0\\u2002\\u2003\\u2007\\u2008\\u2009\\u202F\\u205F\\u3000\\u200B]'
+          UNICODE_SPACES_REGEX='[\x{00A0}\x{2002}\x{2003}\x{2007}\x{2008}\x{2009}\x{202F}\x{205F}\x{3000}\x{200B}]'
           find . -type f ! -path "./.git/*" | while read -r file; do
             MIME_TYPE=$(file --mime-type -b "$file")
             if [[ "$MIME_TYPE" == text/* ]]; then


### PR DESCRIPTION
## What failed

[Run 33284124107](https://github.com/alexbelgium/hassio-addons/actions/runs/33284124107) — `Lint workflows` / `lint-autofix`, step **Use 4 spaces in shell scripts**, exit code 1. The same job also failed on the two previous scheduled runs (32607552903, 31916920758), so this has been broken for at least three weeks.

`shfmt` reported parse errors in roughly seventy shell scripts:

```
./browser_chromium/rootfs/etc/cont-init.d/90-ingress.sh:10:40: LitWord cannot be followed by a word
./obsidian_syncserver_ssl/run.sh:16:16: "${ stmts;}" is a mksh feature; tried parsing as bash
```

Those files parse cleanly on a pristine checkout, so nothing was wrong with the scripts.

## Root cause

The preceding step, **Fix non-printable Unicode spaces in all text files**, corrupted them. Its regex was:

```bash
UNICODE_SPACES_REGEX=$'[\\u00A0\\u2002\\u2003\\u2007\\u2008\\u2009\\u202F\\u205F\\u3000\\u200B]'
perl -CSD -pe "s/$UNICODE_SPACES_REGEX/ /g" "$file" > "$file.tmp" && mv "$file.tmp" "$file"
```

Two things go wrong in sequence. The doubled backslash means bash's `$'...'` quoting emits the literal text ` `, not the character U+00A0. And Perl has no `\u` codepoint escape — in Perl `\u` titlecases the following character — so the character class collapses to the plain set `0 2 3 5 7 8 9 A B F`.

The step therefore replaced those digits and letters with spaces in **every text file in the repository**, while replacing none of the Unicode spaces it was written to remove. Reproduced directly:

```
$ printf 'PASSWORD_FILE="${ADDON_DIR}/admin_password"\n' | perl -CSD -pe "s/$UNICODE_SPACES_REGEX/ /g"
P SSWORD_ ILE="${ DDON_DIR}/admin_password"
```

That `${ ` is exactly the mksh-valsub error `shfmt` reported.

The failure was load-bearing: `shfmt` exiting 1 stopped the job before **Create New Pull Request If Needed**, which is the only reason the corrupted tree was never committed to master.

## The fix

Use Perl's own `\x{...}` escape inside a plain single-quoted string, so the class holds the ten intended code points and nothing else. Applied to both jobs (`lint-changes` and `lint-autofix`), which carried identical copies of the line.

## Verified

Extracted the step body from the edited workflow with a YAML parser and ran it verbatim against a sample of the repo:

- It rewrites only genuine occurrences — the U+202F in `postgres_15/rootfs/etc/cont-init.d/99-run.sh` and in `birdnet-pi/DOCS.md` — and leaves every other byte untouched.
- `shfmt v3.12.0 -w -i 4 -ci -bn -sr` over all `*.sh` and `run` files in the repo then exits 0 with no parse errors.

Repo-wide, only three tracked files contain any of the ten code points, so the corrected step is a small change in practice.

## Not verified

The scheduled job itself has not run with this change. CI on this PR exercises `lint-changes` (the same corrected line, over changed files only), not `lint-autofix`.

## Expected side effect

Once the scheduled job gets past this step it will finally reach **Create New Pull Request If Needed**. `shfmt` currently wants to reformat 192 files that have accumulated while the job was broken, so expect one large `Github bot: fix linting issues nobuild` PR on the next Sunday run. That is the job working as designed, not a regression — but it is worth reviewing rather than merging blind.

## Rollback

Single commit, one file, two lines: `git revert` it. That restores the previous behaviour, which is the failing job — no add-on is affected either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic formatting for Unicode whitespace characters.
  * Ensured whitespace cleanup works consistently across changed files and the full codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->