### PR TITLE
fix(filebrowser_quantum): make Download save the file in the iOS companion app

### DIFF
--- a/filebrowser_quantum/CHANGELOG.md
+++ b/filebrowser_quantum/CHANGELOG.md
@@ -1,12 +1,14 @@
  
 ## 1.5.3.2 (2026-08-30)
-- Fix Download in the Home Assistant iOS companion app, where a file opened and
-  showed its content with no way to save it. FileBrowser downloads by clicking
-  a link that carries no `download` attribute, and the app's WKWebView only
-  turns a click into a real download when that attribute is present, so inside
-  the ingress panel the file was simply rendered. The ingress filter now adds
-  the attribute to the two download endpoints. Desktop browsers already
-  downloaded these and are unchanged, as is direct access on port 8071.
+- Fix Download in the Home Assistant iOS companion app (iOS 17 and later),
+  where a file opened and showed its content with no way to save it.
+  FileBrowser downloads by clicking a link that carries no `download`
+  attribute, and the app's WKWebView only turns a click into a real download
+  when that attribute is present, so inside the ingress panel the file was
+  simply rendered. The ingress filter now adds the attribute to FileBrowser's
+  own download link. "Open file" still opens, and the public-share sidebar's
+  own download button is not covered. Desktop browsers already downloaded
+  these and are unchanged, as is direct access on port 8071.
  
 ## 1.5.3.1 (2026-08-29)
 - Fix "open parent directory" in Tools -> File Size Analyzer under Home

--- a/filebrowser_quantum/CHANGELOG.md
+++ b/filebrowser_quantum/CHANGELOG.md
@@ -1,4 +1,13 @@
  
+## 1.5.3.2 (2026-08-30)
+- Fix Download in the Home Assistant iOS companion app, where a file opened and
+  showed its content with no way to save it. FileBrowser downloads by clicking
+  a link that carries no `download` attribute, and the app's WKWebView only
+  turns a click into a real download when that attribute is present, so inside
+  the ingress panel the file was simply rendered. The ingress filter now adds
+  the attribute to the two download endpoints. Desktop browsers already
+  downloaded these and are unchanged, as is direct access on port 8071.
+ 
 ## 1.5.3.1 (2026-08-29)
 - Fix "open parent directory" in Tools -> File Size Analyzer under Home
   Assistant ingress. FileBrowser opened the parent folder in a new tab, which

--- a/filebrowser_quantum/config.yaml
+++ b/filebrowser_quantum/config.yaml
@@ -118,4 +118,4 @@ schema:
 slug: filebrowser_quantum
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "1.5.3.1"
+version: "1.5.3.2"

--- a/filebrowser_quantum/rootfs/etc/nginx/servers/ingress.conf
+++ b/filebrowser_quantum/rootfs/etc/nginx/servers/ingress.conf
@@ -54,9 +54,18 @@ server {
        # its content with no way to save it. Adding the attribute makes the same
        # click a real download. Desktop browsers already downloaded these and
        # are unaffected, and an empty value keeps the filename the server sends
-       # in Content-Disposition. Matched on the two exact download endpoints, so
-       # no other link in the app is touched.
-       sub_filter "window.__pwaDeferredPrompt = null;" "window.__pwaDeferredPrompt = null;(function(){var o=window.open;window.open=function(u,n,f){try{var b=(window.globalVars||{}).baseURL;if(u&&n==='_blank'&&!f&&b){if(b.slice(-1)!=='/')b+='/';var t=new URL(u,location.href);if((t.protocol==='http:'||t.protocol==='https:')&&t.origin===location.origin&&(t.pathname.indexOf(b+'files/')===0||t.pathname.indexOf(b+'public/share/')===0)){location.assign(t.href);return window}}}catch(e){}return o.apply(window,arguments)};var c=HTMLAnchorElement.prototype.click;HTMLAnchorElement.prototype.click=function(){try{var b=(window.globalVars||{}).baseURL;if(b&&this.href&&!this.hasAttribute('download')){if(b.slice(-1)!=='/')b+='/';var t=new URL(this.href,location.href);if(t.origin===location.origin&&(t.pathname===b+'api/resources/download'||t.pathname===b+'public/api/resources/download')){this.download=''}}}catch(e){}return c.apply(this,arguments)}})();";
+       # in Content-Disposition. Matched on the two exact download endpoints,
+       # minus inline=true: the "no preview available" fallback renders an
+       # "Open file" link on the same endpoint with that parameter
+       # (views/files/Preview.vue), and it is meant to open, not save. Only
+       # programmatic clicks pass through here -- a person clicking a link never
+       # calls HTMLAnchorElement.prototype.click -- so this reaches
+       # FileBrowser's own hidden download anchor and nothing a user clicks.
+       #
+       # Not covered: the public-share sidebar downloads with window.open()
+       # rather than an anchor, and the app's download manager is gated on
+       # iOS 17 (WebViewController+WebKitDelegates.swift).
+       sub_filter "window.__pwaDeferredPrompt = null;" "window.__pwaDeferredPrompt = null;(function(){var o=window.open;window.open=function(u,n,f){try{var b=(window.globalVars||{}).baseURL;if(u&&n==='_blank'&&!f&&b){if(b.slice(-1)!=='/')b+='/';var t=new URL(u,location.href);if((t.protocol==='http:'||t.protocol==='https:')&&t.origin===location.origin&&(t.pathname.indexOf(b+'files/')===0||t.pathname.indexOf(b+'public/share/')===0)){location.assign(t.href);return window}}}catch(e){}return o.apply(window,arguments)};var c=HTMLAnchorElement.prototype.click;HTMLAnchorElement.prototype.click=function(){try{var b=(window.globalVars||{}).baseURL;if(b&&this.href&&!this.hasAttribute('download')){if(b.slice(-1)!=='/')b+='/';var t=new URL(this.href,location.href);if(t.origin===location.origin&&t.searchParams.get('inline')!=='true'&&(t.pathname===b+'api/resources/download'||t.pathname===b+'public/api/resources/download')){this.download=''}}}catch(e){}return c.apply(this,arguments)}})();";
   }
 
 }

--- a/filebrowser_quantum/rootfs/etc/nginx/servers/ingress.conf
+++ b/filebrowser_quantum/rootfs/etc/nginx/servers/ingress.conf
@@ -13,34 +13,50 @@ server {
        proxy_read_timeout 30m;
        proxy_pass         %%protocol%%://backend%%subpath%%;
 
-       # Tools -> File Size Analyzer (and the other tool views) open a result's
-       # parent folder with window.open(<absolute url>, '_blank'), because
-       # goToItem() takes its newTab argument from the context menu's
-       # showLimitedOptions flag, which those views always set. Behind ingress
-       # that popup lands on the raw /api/hassio_ingress/<token>/ url with no
-       # Home Assistant frontend around it to keep the ingress session alive,
-       # so the new tab answers 401 instead of showing the folder. Turn that
-       # popup into a navigation of the panel itself.
+       # Two things the ingress panel needs that a plain browser tab does not.
+       # Both are injected into the page's existing nonce-carrying inline script
+       # rather than next to <div id="app">: FileBrowser sends
+       # script-src 'self' 'nonce-<random>', so a standalone inline <script>
+       # would be blocked. If upstream ever drops that
+       # window.__pwaDeferredPrompt line the filter stops matching and both
+       # behaviours revert, which is the state before either fix.
        #
-       # The context menu's "go to item" action, which search results and the
-       # tool views also offer, hardcodes the same new tab and is fixed too.
+       # 1. Opening a folder. The tool views (Tools -> File Size Analyzer and
+       # the others) always set the context menu's showLimitedOptions flag, and
+       # openParentFolder() hands that same flag to goToItem() as its newTab
+       # argument, so the folder is opened with window.open(<url>, '_blank').
+       # Behind ingress that popup lands on the raw /api/hassio_ingress/<token>/
+       # url with no Home Assistant frontend around it to keep the ingress
+       # session alive, so the new tab answers 401 instead of showing the
+       # folder. Turn it into a navigation of the panel itself. The context
+       # menu's "go to item" action, offered by search results and the tool
+       # views, hardcodes the same new tab and is fixed with it.
        #
        # Scoped to the two prefixes goToItem() builds, "files/" and
        # "public/share/", so the window.open calls that download or preview a
        # file (they go to api/resources/download) keep their own tab: sending
-       # an inline raw file to location.assign would replace the whole app.
-       # A link out of the add-on keeps its own tab as well, unless a user
-       # points a sidebar link (or a link inside a file open in the editor) at
-       # this same instance's files/ or public/share/ route, which then also
-       # opens in the panel. Same shape as the komga add-on's ingress filter.
+       # an inline raw file to location.assign would replace the whole app. A
+       # link out of the add-on keeps its own tab as well, unless a user points
+       # a sidebar link -- or a link inside a file open in the editor -- at this
+       # same instance's files/ or public/share/ route. Same shape as the komga
+       # add-on's ingress filter.
        #
-       # Injected into the page's existing nonce-carrying inline script rather
-       # than next to <div id="app">: FileBrowser sends
-       # script-src 'self' 'nonce-<random>', so a standalone inline <script>
-       # would be blocked. If upstream ever drops that
-       # window.__pwaDeferredPrompt line the filter simply stops matching and
-       # the popup behaviour returns, which is the pre-fix state.
-       sub_filter "window.__pwaDeferredPrompt = null;" "window.__pwaDeferredPrompt = null;(function(){var o=window.open;window.open=function(u,n,f){try{var b=(window.globalVars||{}).baseURL;if(u&&n==='_blank'&&!f&&b){if(b.slice(-1)!=='/')b+='/';var t=new URL(u,location.href);if((t.protocol==='http:'||t.protocol==='https:')&&t.origin===location.origin&&(t.pathname.indexOf(b+'files/')===0||t.pathname.indexOf(b+'public/share/')===0)){location.assign(t.href);return window}}}catch(e){}return o.apply(window,arguments)}})();";
+       # 2. Download. FileBrowser downloads a file by building an <a> with no
+       # download attribute, clicking it, and letting the attachment response do
+       # the rest. The Home Assistant iOS companion app is a WKWebView, and a
+       # download happens there only when WebKit turns a navigation *action*
+       # into a WKDownload, which is what the download attribute does -- the app
+       # hands that to its own download manager
+       # (WebViewController+WebKitDelegates.swift, navigationAction:didBecome
+       # download:). Its response policy delegate returns .allow for every
+       # sub-frame and never returns .download, so a plain attachment navigation
+       # inside the ingress panel is just rendered: a text file opens and shows
+       # its content with no way to save it. Adding the attribute makes the same
+       # click a real download. Desktop browsers already downloaded these and
+       # are unaffected, and an empty value keeps the filename the server sends
+       # in Content-Disposition. Matched on the two exact download endpoints, so
+       # no other link in the app is touched.
+       sub_filter "window.__pwaDeferredPrompt = null;" "window.__pwaDeferredPrompt = null;(function(){var o=window.open;window.open=function(u,n,f){try{var b=(window.globalVars||{}).baseURL;if(u&&n==='_blank'&&!f&&b){if(b.slice(-1)!=='/')b+='/';var t=new URL(u,location.href);if((t.protocol==='http:'||t.protocol==='https:')&&t.origin===location.origin&&(t.pathname.indexOf(b+'files/')===0||t.pathname.indexOf(b+'public/share/')===0)){location.assign(t.href);return window}}}catch(e){}return o.apply(window,arguments)};var c=HTMLAnchorElement.prototype.click;HTMLAnchorElement.prototype.click=function(){try{var b=(window.globalVars||{}).baseURL;if(b&&this.href&&!this.hasAttribute('download')){if(b.slice(-1)!=='/')b+='/';var t=new URL(this.href,location.href);if(t.origin===location.origin&&(t.pathname===b+'api/resources/download'||t.pathname===b+'public/api/resources/download')){this.download=''}}}catch(e){}return c.apply(this,arguments)}})();";
   }
 
 }


### PR DESCRIPTION
Fixes Download in the **Home Assistant iOS companion app**, where a file opens and shows its
content with no way to save it. Version 1.5.3.2.

Reported after 1.5.3.1 landed. It is **not** a regression from that release: the reporter rolled
back to 1.5.3, which predates the `sub_filter` entirely, and saw identical behaviour. It is also
not ingress-vs-direct in general — it is desktop-vs-iOS-app. Downloads work in any desktop browser
and on the same phone over direct access on port 8071.

## Root cause

FileBrowser downloads a file by building an `<a>`, setting `href`, and clicking it — with **no
`download` attribute** (`frontend/src/api/resources.js`, `download()`); the attachment response is
expected to do the rest. That code is unchanged from v1.5.0-stable through v1.5.4-stable.

The companion app is a `WKWebView`, and a download happens there only when WebKit turns a
navigation *action* into a `WKDownload` — which is exactly what the `download` attribute does. The
app then hands it to its own download manager
([`WebViewController+WebKitDelegates.swift`](https://github.com/home-assistant/iOS/blob/master/Sources/App/Frontend/WebView/WebViewController/WebViewController+WebKitDelegates.swift),
`webView(_:navigationAction:didBecome download:)` → `DownloadManagerViewModel`). Its response
policy delegate is the only other route, and it opts out of sub-frames outright:

```swift
guard navigationResponse.isForMainFrame else {
    // we don't need to modify the response if it's for a sub-frame
    decisionHandler(.allow)
    return
}
```

It never returns `.download` anywhere. So inside the ingress panel — a sub-frame — a plain
attachment navigation is just allowed through and rendered, and a text file opens inline. Desktop
browsers download it because they honour `Content-Disposition` on ordinary navigations; WKWebView
in a sub-frame does not.

## The change

The ingress filter added in #3026 gains a second, equally scoped shim: wrap
`HTMLAnchorElement.prototype.click`, and when the anchor points at one of FileBrowser's two exact
download endpoints (`<baseURL>api/resources/download`, `<baseURL>public/api/resources/download`),
is same-origin, and does not already carry the attribute, set `download=""` before the real click.

- Matched on **exact pathnames**, not prefixes, so the preview endpoint, SPA routes and links out
  of the add-on are untouched.
- **`inline=true` excluded.** The "no preview available" fallback
  (`frontend/src/views/files/Preview.vue`) renders an "Open file" link on the *same* endpoint with
  that parameter, and it is meant to open, not save. Caught in review — a pathname-only match
  would have turned opening a file into downloading it.
- Only **programmatic** clicks pass through this seam: a person clicking a link never calls
  `HTMLAnchorElement.prototype.click`, so it reaches FileBrowser's own hidden download anchor and
  nothing a user clicks.
- Anchors that already set `download` are left alone — that is FileBrowser's own chunked-download
  path, which supplies its own filename.
- An empty value keeps the filename the server sends in `Content-Disposition`.
- Ingress vhost only; `direct.conf` on port 8071 is untouched.

## Verified

- In the running app, inside an ingress-shaped iframe: the attribute is applied to exactly the two
  download endpoints (`download=""`) and to nothing else — preview endpoint, SPA route and
  cross-origin download URL all come back `null`. Both halves of the filter are installed and the
  1.5.3.1 parent-folder fix still matches its two prefixes and still does not match download URLs.
- **The seam, measured rather than asserted:** with a counter wrapped around the shimmed prototype
  method, a programmatic `a.click()` enters it and the anchor gains `download=""`; a genuine mouse
  click on an "Open file"-style link, rendered into the page and clicked with the automation's real
  pointer, leaves the counter at **0** and the anchor without the attribute.
- 13 behavioural assertions on the new shim plus the 13 existing ones on the `window.open` half,
  including: `inline=true` stays a navigation on both endpoints while `inline=false` still
  downloads; an anchor that already sets `download` keeps its filename; a longer path under the
  endpoint is untouched; the click always still happens; a missing `globalVars` does not throw.
- `nginx -t` passes; the anchor string still appears exactly once in the shipped
  `public/index.html`.
- The reproduction is the real `filebrowser` binary and `http/dist` from
  `gtstef/filebrowser:latest` (v1.5.4-stable), behind this add-on's rendered `ingress.conf`, behind
  a second nginx stripping the `/api/hassio_ingress/<token>` prefix the way Supervisor does.

## Not verified

- **The iOS behaviour itself.** I have no iOS device. The mechanism is read from Home Assistant's
  own source, quoted above, but that a download now reaches `DownloadManagerViewModel` in the app
  is **Assumed** until the reporter confirms it on their phone. So is the filename that WebKit's
  `suggestedFilename` ends up using for archives and non-ASCII names.
- **That a desktop download still completes.** The Browser pane used for testing makes
  `<a download>` clicks inert, so after this change the click produces no server request there
  where it previously produced a navigation. The attribute is verified to be set correctly and
  nothing throws; the download itself was not observed landing. `download` on a same-origin URL is
  universally honoured, so this is low risk, but it was not exercised.
- No Docker build locally — CI is the gate.

## Known gaps

- The public-share **sidebar** download calls `window.open()` rather than clicking an anchor
  (`components/sidebar/Links.vue`), so it does not go through this seam and is not fixed. Covering
  it would mean converting a `window.open` into a synthetic anchor click — a larger behavioural
  change that deserves its own testing.
- The app's download manager is gated on **iOS 17 and later**
  (`if #available(iOS 17.0, *)`); on older versions the resulting `WKDownload` is not handled.

## Known trade-off

When the download endpoint answers with an error (an expired ingress session, say), the browser
previously navigated and showed it. With `download` set it will instead save the error body as a
file. Worse error UX in that case, in exchange for downloads working at all on iOS.

## Rollback

The `HTMLAnchorElement.prototype.click` half of the `sub_filter` line in
`filebrowser_quantum/rootfs/etc/nginx/servers/ingress.conf`, and its numbered comment block.
Removing it leaves 1.5.3.1's parent-folder fix intact.


## Review

Reviewed independently by Codex (gpt-5.6-sol) reading the diff, the upstream source, the shipped
bundle and Home Assistant's iOS, frontend and Supervisor sources. It confirmed the diagnosis and
found no smaller native route into the app's download manager (the registered script handlers are
auth, external bus, theme, logging and restoration only; the external-bus command set has no
download command; the `WKUIDelegate` path launches a browser instead). It found one real defect —
the `inline=true` "Open file" link sharing the endpoint — which is fixed above, and two overstated
claims, now narrowed.

It also proposed a capturing `click` listener on `document` instead of wrapping the prototype. I
kept the prototype seam: the listener is less invasive as a global side effect but *more* invasive
behaviourally, since it catches user clicks as well — which is precisely what creates the "Open
file" regression it warned about. The measurement above shows the prototype seam never sees a user
click at all.
