### PR TITLE
fix(calibre-web): document the optional features, drop the dead calibre install

### DIFF
--- a/calibre_web/CHANGELOG.md
+++ b/calibre_web/CHANGELOG.md
@@ -1,4 +1,8 @@
  
+## 0.6.27.3 (2026-08-30)
+- Doc: explain in the README that Calibre-Web's optional extras (metadata, kobo, gdrive, gmail, goodreads, ldap, oauth, comics) are already installed by the LinuxServer base image, that `pip install calibreweb[...]` inside the container is useless and not persistent, and that the cover fields on the Edit Metadata page are gated on `Enable Uploads` plus the user's `Upload` permission (https://github.com/alexbelgium/hassio-addons/issues/1143)
+- Fix: remove the Dockerfile step that claimed to install the Calibre binaries into `/opt/calibre`. There is no `wget` in the image, so the command failed silently and left the layer empty; the binaries are and were provided at start by the default `linuxserver/mods:universal-calibre` docker mod
+
 ## 0.6.27.2 (2026-08-23)
 - Fix: trust the whole supervisor network range for the ingress auth header instead of the addon's own address, which changes across restarts. The list is only written when that range is missing, so an entry added in the calibre-web admin page is no longer erased on every start (https://github.com/alexbelgium/hassio-addons/pull/3010)
 

--- a/calibre_web/Dockerfile
+++ b/calibre_web/Dockerfile
@@ -35,11 +35,9 @@ RUN \
     && echo '#!/bin/sh' > /usr/bin/xdg-desktop-menu && chmod +x /usr/bin/xdg-desktop-menu \
     && echo '#!/bin/sh' > /usr/bin/xdg-mime && chmod +x /usr/bin/xdg-mime
 
-# Install calibre binaries (provides calibredb required for book downloads)
-# hadolint ignore=DL4006
-RUN \
-    wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sh /dev/stdin install_dir=/opt/calibre
-ENV PATH="/opt/calibre:${PATH}"
+# The calibre binaries (calibredb, ebook-convert, ebook-meta) are installed at start by the
+# linuxserver/mods:universal-calibre docker mod, which config.yaml sets as the default DOCKER_MODS.
+# The xdg-* stubs above keep its calibre_postinstall step quiet.
 
 # Global LSIO modifications
 COPY ha_lsio.sh /ha_lsio.sh

--- a/calibre_web/Dockerfile
+++ b/calibre_web/Dockerfile
@@ -35,8 +35,8 @@ RUN \
     && echo '#!/bin/sh' > /usr/bin/xdg-desktop-menu && chmod +x /usr/bin/xdg-desktop-menu \
     && echo '#!/bin/sh' > /usr/bin/xdg-mime && chmod +x /usr/bin/xdg-mime
 
-# The calibre binaries (calibredb, ebook-convert, ebook-meta) are installed at start by the
-# linuxserver/mods:universal-calibre docker mod, which config.yaml sets as the default DOCKER_MODS.
+# By default the calibre binaries (calibredb, ebook-convert, ebook-meta) are installed at start by
+# the linuxserver/mods:universal-calibre docker mod, set as the default DOCKER_MODS in config.yaml.
 # The xdg-* stubs above keep its calibre_postinstall step quiet.
 
 # Global LSIO modifications

--- a/calibre_web/README.md
+++ b/calibre_web/README.md
@@ -97,6 +97,18 @@ This addon supports mounting both local drives and remote SMB shares:
 - **Local drives**: See [Mounting Local Drives in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Mounting-Local-Drives-in-Addons)
 - **Remote shares**: See [Mounting Remote Shares in Addons](https://github.com/alexbelgium/hassio-addons/wiki/Mounting-remote-shares-in-Addons)
 
+### Optional Calibre-Web features
+
+Calibre-Web documents optional extras that a manual installation adds with `pip install calibreweb[metadata]` and similar. **You do not need to install anything here**: the LinuxServer base image this add-on builds on installs Calibre-Web's `requirements.txt` *and* its full `optional-requirements.txt`, so the gdrive, gmail, goodreads, ldap, oauth, metadata, comics and kobo dependencies are all present already. Running `pip install calibreweb[...]` inside the container does not enable anything - it pulls a second, unused copy of Calibre-Web from PyPI, and it is discarded anyway because the Supervisor recreates the container on every restart.
+
+Optional features are switched on in the Calibre-Web web interface, not in the add-on options, under `Admin` -> `Basic Configuration` -> `Feature Configuration` (for example `Enable Uploads`, `Enable Kobo sync`, `Use Goodreads`).
+
+**Book covers.** The `Fetch Cover from URL` and `Upload Cover from Local Disk` fields only appear on a book's `Edit Metadata` page when `Enable Uploads` is ticked in `Feature Configuration` **and** the logged-in user has the `Upload` permission (`Admin` -> the user -> `Upload`). A missing python package is not what hides them.
+
+**Conversion and metadata embedding** need the Calibre command-line binaries (`ebook-convert`, `ebook-meta`, `calibredb`). Those are installed at start by the `linuxserver/mods:universal-calibre` docker mod, which is the shipped default of the `DOCKER_MODS` option. If you set `DOCKER_MODS` yourself, keep `linuxserver/mods:universal-calibre` in the list (mods are separated by `|`) or those binaries disappear.
+
+**Any other python package** can be installed from the add-on's custom script (see the section below); `pip` there points at Calibre-Web's own virtualenv. Such a script runs on every start, and it has to: nothing installed into the container survives a restart.
+
 ### Custom Scripts and Environment Variables
 
 This addon supports custom scripts and environment variables:

--- a/calibre_web/README.md
+++ b/calibre_web/README.md
@@ -99,15 +99,15 @@ This addon supports mounting both local drives and remote SMB shares:
 
 ### Optional Calibre-Web features
 
-Calibre-Web documents optional extras that a manual installation adds with `pip install calibreweb[metadata]` and similar. **You do not need to install anything here**: the LinuxServer base image this add-on builds on installs Calibre-Web's `requirements.txt` *and* its full `optional-requirements.txt`, so the gdrive, gmail, goodreads, ldap, oauth, metadata, comics and kobo dependencies are all present already. Running `pip install calibreweb[...]` inside the container does not enable anything - it pulls a second, unused copy of Calibre-Web from PyPI, and it is discarded anyway because the Supervisor recreates the container on every restart.
+Calibre-Web documents optional extras that a manual installation adds with `pip install calibreweb[metadata]` and similar. **You do not need to install anything here**: the LinuxServer base image this add-on builds on installs Calibre-Web's `requirements.txt` *and* its full `optional-requirements.txt` into the application's virtualenv, so the gdrive, gmail, goodreads, ldap, oauth, metadata, comics and kobo dependencies are all present already. Running `pip install calibreweb[...]` inside the container is not a supported way to enable them: it installs the PyPI distribution of Calibre-Web over an installation that already has those dependencies, and it can disturb the versions the base image pinned. It is also thrown away, because the Supervisor recreates the add-on container on restart.
 
 Optional features are switched on in the Calibre-Web web interface, not in the add-on options, under `Admin` -> `Basic Configuration` -> `Feature Configuration` (for example `Enable Uploads`, `Enable Kobo sync`, `Use Goodreads`).
 
-**Book covers.** The `Fetch Cover from URL` and `Upload Cover from Local Disk` fields only appear on a book's `Edit Metadata` page when `Enable Uploads` is ticked in `Feature Configuration` **and** the logged-in user has the `Upload` permission (`Admin` -> the user -> `Upload`). A missing python package is not what hides them.
+**Book covers.** The `Fetch Cover from URL` and `Upload Cover from Local Disk` fields only appear on a book's `Edit Metadata` page when `Enable Uploads` is ticked in `Feature Configuration` **and** the logged-in user has the `Upload` permission (`Admin` -> the user -> `Upload`). A missing Python package is not what hides them.
 
-**Conversion and metadata embedding** need the Calibre command-line binaries (`ebook-convert`, `ebook-meta`, `calibredb`). Those are installed at start by the `linuxserver/mods:universal-calibre` docker mod, which is the shipped default of the `DOCKER_MODS` option. If you set `DOCKER_MODS` yourself, keep `linuxserver/mods:universal-calibre` in the list (mods are separated by `|`) or those binaries disappear.
+**Conversion, metadata embedding and the other Calibre integrations** use command-line binaries such as `ebook-convert`, `ebook-meta` and `calibredb`. Those are installed at start by the `linuxserver/mods:universal-calibre` docker mod, which is the shipped default of the `DOCKER_MODS` option. If you set `DOCKER_MODS` yourself, keep `linuxserver/mods:universal-calibre` in the list (mods are separated by `|`) or those binaries disappear.
 
-**Any other python package** can be installed from the add-on's custom script (see the section below); `pip` there points at Calibre-Web's own virtualenv. Such a script runs on every start, and it has to: nothing installed into the container survives a restart.
+**Other compatible Python packages** can be installed from the add-on's custom script (see the section below); `pip` there points at Calibre-Web's own virtualenv. Such a script runs on every start, and it has to, since the container's writable layer does not persist.
 
 ### Custom Scripts and Environment Variables
 

--- a/calibre_web/config.yaml
+++ b/calibre_web/config.yaml
@@ -116,5 +116,5 @@ schema:
 slug: calibre-web
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/calibre_web
-version: "0.6.27.2"
+version: "0.6.27.3"
 video: true


### PR DESCRIPTION
Closes https://github.com/alexbelgium/hassio-addons/issues/1143

The issue asks how to add Calibre-Web's optional extras (`metadata`, `kobo`, ...) to the add-on, the reporter having tried `pip install calibreweb[option]` inside the container and seen nothing happen. The answer is that they are already installed, so this PR documents that instead of adding a mechanism. While tracing where the Calibre binaries come from, the Dockerfile step that claims to install them turned out to be a silent no-op, so it is removed too.

## What was measured

No local Docker daemon, so this was established by pulling the published OCI images from ghcr.io and listing layer contents.

**The optional extras are already installed.** The LinuxServer base image runs `pip install -U --no-cache-dir --find-links ... -r requirements.txt -r optional-requirements.txt` into its `/lsiopy` virtualenv. Listing the `.dist-info` directories in that layer of `lscr.io/linuxserver/calibre-web:amd64-latest` shows the whole optional set present: `scholarly`, `rarfile`, `markdown2`, `html2text`, `beautifulsoup4`, `faust_cchardet`, `py7zr`, `mutagen`, `pycountry` (the `metadata` extra), `jsonschema` (`kobo`), `python_ldap` + `flask_simpleldap` (`ldap`), `flask_dance` + `sqlalchemy_utils` (`oauth`), `PyDrive2` + `google_api_python_client` + `gevent` (`gdrive`), `google_auth_oauthlib` (`gmail`), `goodreads` + `levenshtein`, `comicapi` + `natsort` (`comics`).

**What actually hides the reporter's cover fields** is Calibre-Web's own gating, not a missing package. In the 0.6.27 source, `cps/templates/book_edit.html:131` wraps both `Fetch Cover from URL` and `Upload Cover from Local Disk` in `{% if current_user.role_upload() and g.allow_upload %}` — that is `Enable Uploads` in Feature Configuration (`cps/templates/config_edit.html:111-112`) plus the user's own `Upload` permission. The README now says so.

**The Dockerfile's Calibre install has never installed anything.** In the published `ghcr.io/alexbelgium/calibre_web-amd64:latest` (BUILD_VERSION 0.6.27.2) I mapped every non-empty history entry to its layer digest; the layer for that `RUN` decompresses to exactly 1024 bytes, an empty tar. Scanning every layer in the image, the only `opt/` entry anywhere is the empty `opt/` directory inherited from the base layer. There is no `/opt/calibre`.

The cause is that the image has no `wget` — grepping all layers for `(^|/)(wget|curl)$` finds only `usr/bin/curl`. So in

```
RUN wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sh /dev/stdin install_dir=/opt/calibre
```

`wget` exits 127, the pipe closes immediately, `sh /dev/stdin` reads an empty script and exits 0, and the pipeline's status is `sh`'s — so the `RUN` "succeeds" having done nothing.

## What changed

- `README.md` — a new `Optional Calibre-Web features` section: the extras ship installed; `pip install calibreweb[...]` in the container is unsupported, can disturb the base image's pinned versions, and does not persist; optional features are toggled in Calibre-Web's own Feature Configuration; the cover fields need `Enable Uploads` **and** the `Upload` permission; the Calibre binaries come from the default `universal-calibre` docker mod, which must be kept if `DOCKER_MODS` is overridden.
- `Dockerfile` — the dead `wget | sh` step, its `# hadolint ignore=DL4006`, and `ENV PATH="/opt/calibre:${PATH}"` are removed, replaced by a comment recording where the binaries really come from. **This removes a silent no-op; it does not swap one Calibre installation for another.** The three `xdg-*` stubs above it are kept — they exist to quiet the mod's `calibre_postinstall`.
- `config.yaml` / `CHANGELOG.md` — version 0.6.27.2 → 0.6.27.3 (`updater.json`'s `upstream_version` is `0.6.27`, so the local patch counter increments).

## Why delete rather than repair

Repairing the line with `curl` would make it worse, not better. Calibre's installer then reaches `check_for_libEGL()`, `check_for_libOpenGl()`, `check_for_libxcb_cursor()` and `check_for_recent_freetype()`, each of which raises `SystemExit` when the library is absent — and the `universal-calibre` mod apt-installs `libgl1`, `libglx-mesa0`, `libxdamage1` and friends precisely *because* they are missing from this image. So a repair would most likely turn a silent no-op into a hard CI build failure, and on success would add roughly a gigabyte of a second Calibre alongside the mod's `/app/calibre`, with two `ebook-convert` binaries competing on `PATH`.

## Not verified

- **The Docker build.** No dockerd locally; CI is the only gate.
- **Runtime behaviour.** Calibre-Web is not installed on the host I have, so nothing here was exercised in a running container. The image claims come from the published layers, the Calibre-Web claims from the 0.6.27 release tarball.
- Removing `/opt/calibre` from `PATH` is reasoned, not observed: the directory does not exist in the image, and `/lsiopy/bin` (which carries `python`/`pip`, with `VIRTUAL_ENV=/lsiopy`) simply becomes the first entry.

## Considered and rejected

Documenting `linuxserver/mods:universal-package-install` with `INSTALL_PIP_PACKAGES` via the `env_vars` option. On a running add-on from this repo built from the same templates, `/run/s6/container_environment` holds only image-provided values — no add-on option and no `env_vars` entry — even though those values do reach `/etc/environment`, `/.env` and the service environment via the export block `00-global_var.sh` injects into the existing `run` files at cont-init time. A mod's `run` script is fetched by `init-mods` after that injection, so it would see neither. The README points at the custom-script mechanism instead.

## Rollback

Each hunk reverts alone. The riskiest is the Dockerfile deletion; to restore it exactly:

```
git revert --no-commit <sha> -- calibre_web/Dockerfile
```

Reverting it re-adds a step that is provably a no-op in the published image, so it changes nothing at runtime either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how optional Calibre-Web features are enabled and configured.
  * Documented that cover fields on the Edit Metadata page require uploads to be enabled and the appropriate permission.
  * Added guidance for installing additional Python packages through custom scripts.

* **Bug Fixes**
  * Improved Calibre command-line tool availability in the container.
  * Removed an ineffective build-time installation step for Calibre binaries.

* **Chores**
  * Updated the add-on version to 0.6.27.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->