### PR TITLE
fix(filebrowser_quantum): keep the no-preview Download and Open file links inside the ingress panel

### DIFF
--- a/filebrowser_quantum/CHANGELOG.md
+++ b/filebrowser_quantum/CHANGELOG.md
@@ -1,4 +1,15 @@
  
+## 1.5.3.3 (2026-08-31)
+- Complete the iOS companion app fix from 1.5.3.2. The "no preview available"
+  screen -- what you get for a `.zip`, `.bin` or anything else FileBrowser
+  cannot render -- offers its Download and "Open file" buttons as new-tab
+  links, and so does the share list in settings. The app hands every new tab
+  to an external browser, which carries no ingress session, so those answered
+  401. They now stay in the panel when running in the companion app, and open
+  a new tab as before in a normal browser. Download also saves the file
+  instead of displaying it, which 1.5.3.2 only fixed for the download button
+  in the file list.
+ 
 ## 1.5.3.2 (2026-08-30)
 - Fix Download in the Home Assistant iOS companion app (iOS 17 and later),
   where a file opened and showed its content with no way to save it.

--- a/filebrowser_quantum/CHANGELOG.md
+++ b/filebrowser_quantum/CHANGELOG.md
@@ -5,10 +5,13 @@
   cannot render -- offers its Download and "Open file" buttons as new-tab
   links, and so does the share list in settings. The app hands every new tab
   to an external browser, which carries no ingress session, so those answered
-  401. They now stay in the panel when running in the companion app, and open
-  a new tab as before in a normal browser. Download also saves the file
-  instead of displaying it, which 1.5.3.2 only fixed for the download button
-  in the file list.
+  401. Those two buttons and the settings share links now stay in the panel
+  when running in the companion app, and open a new tab as before in a normal
+  browser -- as does a cmd/ctrl/shift-click anywhere, which is left alone.
+  Download also saves the file instead of displaying it, which 1.5.3.2 only
+  fixed for the download button in the file list. Links the app opens without
+  a link element, such as the public-share sidebar download, are still
+  affected.
  
 ## 1.5.3.2 (2026-08-30)
 - Fix Download in the Home Assistant iOS companion app (iOS 17 and later),

--- a/filebrowser_quantum/config.yaml
+++ b/filebrowser_quantum/config.yaml
@@ -118,4 +118,4 @@ schema:
 slug: filebrowser_quantum
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "1.5.3.2"
+version: "1.5.3.3"

--- a/filebrowser_quantum/rootfs/etc/nginx/servers/ingress.conf
+++ b/filebrowser_quantum/rootfs/etc/nginx/servers/ingress.conf
@@ -61,30 +61,46 @@ server {
        #     ingress session cookie, so Home Assistant answers 401.
        #
        # One capturing click listener covers both, and covers the hidden anchor
-       # too: a programmatic .click() dispatches through the document exactly
-       # like a real one, and the capture phase runs before the link is
-       # followed. It replaces an earlier wrapper around
-       # HTMLAnchorElement.prototype.click, which reached the hidden anchor but
-       # not the two the user clicks.
+       # too: a programmatic .click() on an anchor that is in the document
+       # dispatches through it exactly like a real one -- same event, button 0,
+       # no modifiers -- and the capture phase runs before the link is followed.
+       # It replaces an earlier wrapper around HTMLAnchorElement.prototype.click,
+       # which reached the hidden anchor but not the two the user clicks. The
+       # wrapper would also have caught a click on a *detached* anchor, which
+       # this cannot; both of FileBrowser's download paths append theirs to the
+       # body first (api/resources.js), so nothing is lost today.
+       #
+       # Only unmodified primary clicks are touched. A cmd/ctrl/shift-click is
+       # an explicit request for a separate context and is left alone, which
+       # matters on desktop and in the Mac Catalyst app.
        #
        # Downloads gain the attribute everywhere -- desktop browsers already
-       # saved these, and an empty value keeps the filename the server sends in
-       # Content-Disposition. Matched on the two exact download endpoints minus
+       # saved these on a plain click, and an empty value keeps the filename the
+       # server sends in Content-Disposition. One behaviour does change there:
+       # if the endpoint answers with an error the body is saved as a file
+       # instead of being shown, because the decision is made before the
+       # response exists. Matched on the two exact download endpoints minus
        # inline=true, which is the fallback's "Open file" link and is meant to
        # open rather than save.
        #
        # Dropping target="_blank" is limited to the companion app, identified by
        # the Mobile/HomeAssistant marker it appends to the user agent
-       # (HAAPI.swift, applicationNameForUserAgent). In a real browser a new tab
-       # is the better behaviour and is left alone; in the app it is a 401. It
-       # applies to any same-origin link below the add-on's own base path, which
-       # is the "Open file" button, the share links in settings
-       # (views/settings/Shares.vue) and any sidebar link pointing back at this
-       # instance. Links to other origins keep their new tab.
+       # (HAAPI.swift, applicationNameForUserAgent -- it covers iPhone, iPad and
+       # Mac Catalyst). In a real browser a new tab is the better behaviour and
+       # is left alone; in the app it is a 401. It applies to any same-origin
+       # link below the add-on's own base path, which in practice is the
+       # "Open file" button and the share links in settings
+       # (views/settings/Shares.vue). Links to other origins keep their new tab,
+       # and only an exact target="_blank" is matched, so named windows, _parent
+       # and _top are untouched.
        #
-       # Not covered: the public-share sidebar downloads with window.open()
-       # rather than an anchor (components/sidebar/Links.vue).
-       sub_filter "window.__pwaDeferredPrompt = null;" "window.__pwaDeferredPrompt = null;(function(){var o=window.open;window.open=function(u,n,f){try{var b=(window.globalVars||{}).baseURL;if(u&&n==='_blank'&&!f&&b){if(b.slice(-1)!=='/')b+='/';var t=new URL(u,location.href);if((t.protocol==='http:'||t.protocol==='https:')&&t.origin===location.origin&&(t.pathname.indexOf(b+'files/')===0||t.pathname.indexOf(b+'public/share/')===0)){location.assign(t.href);return window}}}catch(e){}return o.apply(window,arguments)};document.addEventListener('click',function(e){try{var a=e.target&&e.target.closest?e.target.closest('a'):null;if(!a||!a.href)return;var b=(window.globalVars||{}).baseURL;if(!b)return;if(b.slice(-1)!=='/')b+='/';var t=new URL(a.href,location.href);if(t.origin!==location.origin)return;if(!a.hasAttribute('download')&&t.searchParams.get('inline')!=='true'&&(t.pathname===b+'api/resources/download'||t.pathname===b+'public/api/resources/download')){a.download='';a.removeAttribute('target');return}if(a.target==='_blank'&&t.pathname.indexOf(b)===0&&navigator.userAgent.indexOf('Mobile/HomeAssistant')!==-1){a.removeAttribute('target')}}catch(err){}},true)})();";
+       # Not covered, and still 401 in the app: anything the app opens with
+       # window.open() rather than an anchor, which is the public-share sidebar
+       # download and absolute sidebar links (components/sidebar/Links.vue); and
+       # links inside a document FileBrowser renders in its own iframe -- the
+       # pdf viewer, the srcdoc markdown/html preview, OnlyOffice -- because a
+       # listener on this document never sees another document's clicks.
+       sub_filter "window.__pwaDeferredPrompt = null;" "window.__pwaDeferredPrompt = null;(function(){var o=window.open;window.open=function(u,n,f){try{var b=(window.globalVars||{}).baseURL;if(u&&n==='_blank'&&!f&&b){if(b.slice(-1)!=='/')b+='/';var t=new URL(u,location.href);if((t.protocol==='http:'||t.protocol==='https:')&&t.origin===location.origin&&(t.pathname.indexOf(b+'files/')===0||t.pathname.indexOf(b+'public/share/')===0)){location.assign(t.href);return window}}}catch(e){}return o.apply(window,arguments)};document.addEventListener('click',function(e){try{if(e.button||e.metaKey||e.ctrlKey||e.shiftKey||e.altKey)return;var a=e.target&&e.target.closest?e.target.closest('a'):null;if(!a||!a.href)return;var b=(window.globalVars||{}).baseURL;if(!b)return;if(b.slice(-1)!=='/')b+='/';var t=new URL(a.href,location.href);if(t.origin!==location.origin)return;if(!a.hasAttribute('download')&&t.searchParams.get('inline')!=='true'&&(t.pathname===b+'api/resources/download'||t.pathname===b+'public/api/resources/download')){a.download='';a.removeAttribute('target');return}if(a.target==='_blank'&&t.pathname.indexOf(b)===0&&navigator.userAgent.indexOf('Mobile/HomeAssistant')!==-1){a.removeAttribute('target')}}catch(err){}},true)})();";
   }
 
 }

--- a/filebrowser_quantum/rootfs/etc/nginx/servers/ingress.conf
+++ b/filebrowser_quantum/rootfs/etc/nginx/servers/ingress.conf
@@ -41,31 +41,50 @@ server {
        # same instance's files/ or public/share/ route. Same shape as the komga
        # add-on's ingress filter.
        #
-       # 2. Download. FileBrowser downloads a file by building an <a> with no
-       # download attribute, clicking it, and letting the attachment response do
-       # the rest. The Home Assistant iOS companion app is a WKWebView, and a
-       # download happens there only when WebKit turns a navigation *action*
-       # into a WKDownload, which is what the download attribute does -- the app
-       # hands that to its own download manager
-       # (WebViewController+WebKitDelegates.swift, navigationAction:didBecome
-       # download:). Its response policy delegate returns .allow for every
-       # sub-frame and never returns .download, so a plain attachment navigation
-       # inside the ingress panel is just rendered: a text file opens and shows
-       # its content with no way to save it. Adding the attribute makes the same
-       # click a real download. Desktop browsers already downloaded these and
-       # are unaffected, and an empty value keeps the filename the server sends
-       # in Content-Disposition. Matched on the two exact download endpoints,
-       # minus inline=true: the "no preview available" fallback renders an
-       # "Open file" link on the same endpoint with that parameter
-       # (views/files/Preview.vue), and it is meant to open, not save. Only
-       # programmatic clicks pass through here -- a person clicking a link never
-       # calls HTMLAnchorElement.prototype.click -- so this reaches
-       # FileBrowser's own hidden download anchor and nothing a user clicks.
+       # 2. Saving and opening a file. FileBrowser downloads by clicking an <a>
+       # that carries no download attribute -- a hidden one it builds itself
+       # (api/resources.js), and two visible ones in the "no preview available"
+       # fallback (views/files/Preview.vue), which are also target="_blank".
+       # Neither works in the Home Assistant companion app:
+       #
+       #   - A download happens in its WKWebView only when WebKit turns a
+       #     navigation *action* into a WKDownload, which is what the download
+       #     attribute does; the app hands that to its own download manager
+       #     (WebViewController+WebKitDelegates.swift, navigationAction:didBecome
+       #     download:, iOS 17+). Its response policy delegate returns .allow for
+       #     every sub-frame and never returns .download, so a plain attachment
+       #     navigation in the ingress panel is just rendered: the file opens and
+       #     shows its content with no way to save it.
+       #   - target="_blank" is worse. The app has no navigationAction policy
+       #     delegate, so every new-window request reaches createWebViewWith,
+       #     which hands the url to an external browser. That browser carries no
+       #     ingress session cookie, so Home Assistant answers 401.
+       #
+       # One capturing click listener covers both, and covers the hidden anchor
+       # too: a programmatic .click() dispatches through the document exactly
+       # like a real one, and the capture phase runs before the link is
+       # followed. It replaces an earlier wrapper around
+       # HTMLAnchorElement.prototype.click, which reached the hidden anchor but
+       # not the two the user clicks.
+       #
+       # Downloads gain the attribute everywhere -- desktop browsers already
+       # saved these, and an empty value keeps the filename the server sends in
+       # Content-Disposition. Matched on the two exact download endpoints minus
+       # inline=true, which is the fallback's "Open file" link and is meant to
+       # open rather than save.
+       #
+       # Dropping target="_blank" is limited to the companion app, identified by
+       # the Mobile/HomeAssistant marker it appends to the user agent
+       # (HAAPI.swift, applicationNameForUserAgent). In a real browser a new tab
+       # is the better behaviour and is left alone; in the app it is a 401. It
+       # applies to any same-origin link below the add-on's own base path, which
+       # is the "Open file" button, the share links in settings
+       # (views/settings/Shares.vue) and any sidebar link pointing back at this
+       # instance. Links to other origins keep their new tab.
        #
        # Not covered: the public-share sidebar downloads with window.open()
-       # rather than an anchor, and the app's download manager is gated on
-       # iOS 17 (WebViewController+WebKitDelegates.swift).
-       sub_filter "window.__pwaDeferredPrompt = null;" "window.__pwaDeferredPrompt = null;(function(){var o=window.open;window.open=function(u,n,f){try{var b=(window.globalVars||{}).baseURL;if(u&&n==='_blank'&&!f&&b){if(b.slice(-1)!=='/')b+='/';var t=new URL(u,location.href);if((t.protocol==='http:'||t.protocol==='https:')&&t.origin===location.origin&&(t.pathname.indexOf(b+'files/')===0||t.pathname.indexOf(b+'public/share/')===0)){location.assign(t.href);return window}}}catch(e){}return o.apply(window,arguments)};var c=HTMLAnchorElement.prototype.click;HTMLAnchorElement.prototype.click=function(){try{var b=(window.globalVars||{}).baseURL;if(b&&this.href&&!this.hasAttribute('download')){if(b.slice(-1)!=='/')b+='/';var t=new URL(this.href,location.href);if(t.origin===location.origin&&t.searchParams.get('inline')!=='true'&&(t.pathname===b+'api/resources/download'||t.pathname===b+'public/api/resources/download')){this.download=''}}}catch(e){}return c.apply(this,arguments)}})();";
+       # rather than an anchor (components/sidebar/Links.vue).
+       sub_filter "window.__pwaDeferredPrompt = null;" "window.__pwaDeferredPrompt = null;(function(){var o=window.open;window.open=function(u,n,f){try{var b=(window.globalVars||{}).baseURL;if(u&&n==='_blank'&&!f&&b){if(b.slice(-1)!=='/')b+='/';var t=new URL(u,location.href);if((t.protocol==='http:'||t.protocol==='https:')&&t.origin===location.origin&&(t.pathname.indexOf(b+'files/')===0||t.pathname.indexOf(b+'public/share/')===0)){location.assign(t.href);return window}}}catch(e){}return o.apply(window,arguments)};document.addEventListener('click',function(e){try{var a=e.target&&e.target.closest?e.target.closest('a'):null;if(!a||!a.href)return;var b=(window.globalVars||{}).baseURL;if(!b)return;if(b.slice(-1)!=='/')b+='/';var t=new URL(a.href,location.href);if(t.origin!==location.origin)return;if(!a.hasAttribute('download')&&t.searchParams.get('inline')!=='true'&&(t.pathname===b+'api/resources/download'||t.pathname===b+'public/api/resources/download')){a.download='';a.removeAttribute('target');return}if(a.target==='_blank'&&t.pathname.indexOf(b)===0&&navigator.userAgent.indexOf('Mobile/HomeAssistant')!==-1){a.removeAttribute('target')}}catch(err){}},true)})();";
   }
 
 }

--- a/filebrowser_quantum/rootfs/etc/nginx/servers/ingress.conf
+++ b/filebrowser_quantum/rootfs/etc/nginx/servers/ingress.conf
@@ -81,10 +81,16 @@ server {
        # instead of being shown, because the decision is made before the
        # response exists. Matched on the two exact download endpoints minus
        # inline=true, which is the fallback's "Open file" link and is meant to
-       # open rather than save.
+       # open rather than save. That branch drops target="_blank" in every
+       # browser too: with the attribute present a same-origin link downloads
+       # and never opens a tab (measured), so it changes nothing here, but it
+       # stops the companion app from taking its new-window path before it
+       # considers the download -- an ordering that cannot be tested from
+       # outside iOS.
        #
-       # Dropping target="_blank" is limited to the companion app, identified by
-       # the Mobile/HomeAssistant marker it appends to the user agent
+       # Dropping target="_blank" from links that are *not* downloads is limited
+       # to the companion app, identified by the Mobile/HomeAssistant marker it
+       # appends to the user agent
        # (HAAPI.swift, applicationNameForUserAgent -- it covers iPhone, iPad and
        # Mac Catalyst). In a real browser a new tab is the better behaviour and
        # is left alone; in the app it is a 401. It applies to any same-origin


### PR DESCRIPTION
Completes the iOS companion app fix from 1.5.3.2. Version 1.5.3.3. Only `filebrowser_quantum` is
touched.

## What was still broken

1.5.3.2 added the `download` attribute to the anchor `api/resources.js` builds and clicks itself.
But the **"no preview available"** screen — what you get for a `.zip`, `.bin`, or anything else
FileBrowser cannot render — offers its own **Download** and **Open file** buttons, and both are
`target="_blank"` (`frontend/src/views/files/Preview.vue:49,54`). So does the share list in
settings (`views/settings/Shares.vue:17`).

The companion app implements no `decidePolicyFor navigationAction`, so *every* new-window request
reaches `createWebViewWith`, which hands the URL to an external browser and returns nil
([`WebViewController+WebKitDelegates.swift:27-40`](https://github.com/home-assistant/iOS/blob/master/Sources/App/Frontend/WebView/WebViewController/WebViewController+WebKitDelegates.swift),
`Utils.swift:93`) — Safari, or a *private* tab if the user set that preference. Neither carries the
ingress session cookie, so Home Assistant answers 401. `window.open` and `target="_blank"` are the
same bug in different syntax, and 1.5.3.1/1.5.3.2 only covered the first.

## The change

The wrapper around `HTMLAnchorElement.prototype.click` is **replaced** by a single capturing
`click` listener — not added to. A programmatic `.click()` dispatches through the document exactly
like a real one, and the capture phase runs before the link is followed, so one listener reaches
the hidden anchor *and* the two buttons the user clicks, which the wrapper never saw. Net: one seam
instead of two, with strictly more coverage.

- **Downloads gain `download=""` everywhere.** Desktop browsers already saved these on a plain
  click; an empty value keeps the filename from `Content-Disposition`. Matched on the two exact
  download endpoints minus `inline=true`, which is the "Open file" link and is meant to open rather
  than save.
- **Only unmodified primary clicks are touched.** A cmd/ctrl/shift-click is an explicit request for
  a separate context and is left alone -- on desktop and in the Mac Catalyst app. A programmatic
  `.click()` reports `button: 0` with no modifiers (measured), so the hidden anchor is unaffected.
- **Dropping `target="_blank"` is limited to the companion app**, identified by the
  `Mobile/HomeAssistant` marker it appends to the user agent
  (`HAAPI.swift`, `applicationNameForUserAgent`). In a real browser a new tab is the better
  behaviour and is left exactly as it is. It applies to any same-origin link below the add-on's own
  base path, so it covers "Open file", the share links, and any sidebar link pointing back at this
  instance. Links to other origins keep their new tab.

## Verified

Against the **real** v1.5.5-stable binary and `http/dist` from `gtstef/filebrowser:latest`, behind
this add-on's rendered `ingress.conf`, behind a second nginx stripping the
`/api/hassio_ingress/<token>` prefix the way Supervisor does, inside an unsandboxed iframe. The two
buttons were driven with the automation's **real mouse pointer**, not synthetic events:

| | desktop UA | companion-app UA |
|---|---|---|
| Download button | `download=""`, target dropped | `download=""`, target dropped |
| Open file (`inline=true`) | untouched, keeps `_blank` | target dropped, **not** made a download |
| Share link | untouched, keeps `_blank` | target dropped |
| Link to another origin | keeps `_blank` | keeps `_blank` |
| **Ctrl-click** on Download | untouched, keeps `_blank` | untouched, keeps `_blank` |

Regression checks in the same session: the hidden download anchor from 1.5.3.2 still gains
`download=""` (so replacing the prototype wrapper lost nothing), and 1.5.3.1's `window.open` shim
is still installed, still matches the two SPA route prefixes, and still does not match download
URLs.

Also 27 node assertions across both user-agent modes, and `nginx -t`.

**Upstream moved during this work:** `gtstef/filebrowser:latest` now resolves to **v1.5.5-stable**
(amd64 `sha256:08a6fed3…`), where 1.5.3.2 was built from v1.5.4-stable. All of the above was
verified against v1.5.5, and the `sub_filter` anchor still occurs exactly once in its shipped
`public/index.html`. Note this rebuild therefore ships an upstream version bump as well.

## Known limits

- **Not covered, still 401 in the app:** anything opened with `window.open()` rather than an anchor
  -- the public-share sidebar download and absolute sidebar links
  (`components/sidebar/Links.vue:465,481`) -- and links inside a document FileBrowser renders in its
  own iframe (the PDF viewer, the `srcdoc` markdown/HTML preview, OnlyOffice), because a listener on
  this document never sees another document's clicks.
- **Detached anchors** are not reached, where the previous prototype wrapper would have been. Both
  shipped download paths append theirs to the body before clicking (`api/resources.js:528,619`), so
  nothing is lost today.
- **Error responses** are now saved as a file rather than shown, because the decision is made before
  the response exists. Same trade-off as 1.5.3.2, now also on the visible Download button.

## Not verified

- **The iOS behaviour itself** — no device here. The user-agent gate was exercised by overriding
  `navigator.userAgent` in the live app, which proves the branch is taken, not that the app then
  behaves as its source says it will. Confirmation has to come from a phone.
- No Docker build locally; CI is the gate.

## Rollback

The single `sub_filter` line and its comment block in
`filebrowser_quantum/rootfs/etc/nginx/servers/ingress.conf`. Reverting the listener back to the
1.5.3.2 prototype wrapper restores that release's behaviour exactly.


## Review

Reviewed independently by Codex (gpt-5.6-sol) against the diff, the upstream source, the shipped
v1.5.5 bundle and the Home Assistant iOS sources. It confirmed the user-agent marker is correct and
covers iPhone, iPad and Mac Catalyst, that no feature-detectable alternative exists, that named
windows / `_parent` / `_top` are untouched, and that filename handling is sound for archives and
non-ASCII names.

It found one real defect -- the listener ran for modified clicks too, turning a deliberate
cmd/ctrl-click on Download into a download -- now fixed and verified with a real ctrl-click in the
running app. Its other findings were overclaims in my comments and changelog rather than code
faults: detached anchors, sidebar links that use `window.open`, and iframe-internal documents. All
three are now stated accurately above and in the conf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file downloads and “Open file” actions in the Home Assistant iOS companion panel.
  * Downloads now save files directly instead of opening in a new tab.
  * Improved handling for downloads initiated without standard link elements, including public-share sidebar downloads.
  * Preserved modified-click behavior and new-tab behavior in standard browsers.
  * Improved handling of same-origin download and share links while retaining expected behavior for unsupported iframe scenarios.

* **Chores**
  * Updated the add-on to version 1.5.3.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->