### PR TITLE
ci(triage): name the real fault when the Claude credential is rejected

### DIFF
--- a/.github/workflows/on_issues_ai_triage.yaml
+++ b/.github/workflows/on_issues_ai_triage.yaml
@@ -362,6 +362,25 @@ jobs:
                "$EXECUTION_FILE" >/dev/null 2>&1
           }
 
+          # Did the run die because the Claude credential is bad? The action
+          # reports this uselessly — a revoked token surfaces as "--json-schema
+          # was provided but Claude did not return structured_output", which
+          # points at the schema and not at auth. The execution file carries the
+          # truth: api_retry / result objects with error "authentication_failed"
+          # and a 401. Same array guard and fail-closed posture as above; an
+          # unrecognised shape simply is not an auth failure and falls through
+          # to the generic branch.
+          hit_auth_failure() {
+            [ -n "${EXECUTION_FILE:-}" ] && [ -s "${EXECUTION_FILE:-}" ] || return 1
+            jq -e '(type == "array") and
+                   any(.[]?;
+                       (type == "object") and
+                       (((.error? // "") == "authentication_failed") or
+                        ((.error_status? // 0) == 401) or
+                        ((.api_error_status? // 0) == 401)))' \
+               "$EXECUTION_FILE" >/dev/null 2>&1
+          }
+
           # GATE 1 — did the action itself run? This is checked BEFORE looking
           # at the payload, because the action can fail *after* having written
           # a valid structured output: the object would sail through the shape
@@ -379,6 +398,16 @@ jobs:
           # explicit exit 1 the job would report success.
           if [ "${CLASSIFY_OUTCOME:-}" = "failure" ]; then
             restore_needs_info
+
+            # Checked before anything else, because it is the one failure with
+            # a specific remedy and it takes down every tier at once — tier 1
+            # cannot label, so tier 2's batch is empty and the whole pipeline
+            # goes quiet while each run still fails in a way that reads like a
+            # per-issue problem. Say plainly what is wrong and what to do.
+            if hit_auth_failure; then
+              echo "::error::CLAUDE_CODE_OAUTH_TOKEN is rejected (HTTP 401 / authentication_failed). This is NOT a problem with issue #$ISSUE — every AI workflow is down until the credential is replaced. Regenerate it with 'claude setup-token' and update the CLAUDE_CODE_OAUTH_TOKEN secret in the CR_PAT environment. Set the AI_DISABLED repo variable to 'true' to silence these runs meanwhile."
+              exit 1
+            fi
 
             # ...with one exception. Exhausting the turn budget is NOT a
             # workflow fault: the action ran fine and this particular issue was


### PR DESCRIPTION
## The pipeline is down, and this PR does not fix it

Every AI workflow has been failing since **~2026-08-25**. Root cause, from the execution log of the 08-30 run on #3031:

```json
"result": "Failed to authenticate. API Error: 401 OAuth access token has been revoked.",
"error": "authentication_failed",
"api_error_status": 401,
"terminal_reason": "api_error"
```

**`CLAUDE_CODE_OAUTH_TOKEN` has been revoked** (secret last updated 2026-07-24). Only you can fix that:

```
claude setup-token
```
then update `CLAUDE_CODE_OAUTH_TOKEN` in the **CR_PAT** environment. Nothing in this PR restores service.

## What this PR does fix: why it took six days to notice

The failure was visible only as a red run with a misleading message. The action reports:

> `--json-schema was provided but Claude did not return structured_output. Result subtype: success`

which points at the schema, not at auth. `Apply verdict` then added its generic *"usually a workflow-level fault … left untouched for a retry"*. Neither says "your credential is dead", and the failure reads as per-issue when the real scope is every tier at once:

| tier | observed | actual |
|---|---|---|
| tier 1 triage | red runs on individual issues | cannot classify anything |
| catch-up | dispatches fine, then 3 red runs/night | same auth failure downstream |
| tier 2 sweep | **reports success daily** | `Analyse and fix` skipped — empty batch, because tier 1 never labels |

That middle row is the trap: the sweep is green every day while doing nothing, because its input depends on a tier that cannot run.

`GATE 1` now checks the execution file for `authentication_failed` / HTTP 401 **before** the max-turns branch, and says what is wrong and what to do — including `AI_DISABLED=true` to silence the nightly red runs until the token is replaced.

Same array guard and fail-closed posture as the existing `hit_max_turns`: an unrecognised shape is simply not an auth failure and falls through to the generic branch. Control flow is otherwise unchanged — this path already exited 1 without touching labels, which is correct for a systemic fault.

## Blast radius while it has been down

Contained, because issue volume is low: **3 untriaged issues eligible for catch-up, 2 opened since the outage**. No wrongful escalations — the generic branch never applied `ai:needs-human`, so nothing was quarantined by the outage. The 4 `ai:needs-info` threads are intact; a reporter reply during the outage restores the label and fails red rather than losing the thread.

Once the token is replaced, the catch-up drains the backlog at 5/day with no manual intervention.

## Verification

**Verified** — replayed the exact execution-file shape captured from the live 08-30 failure:

| case | result |
|---|---|
| real auth shape, `issues` path | exit 1, names the token and the remedy |
| real auth shape, catch-up dispatch | exit 1, same message |
| `max_turns` on automated retry | still escalates to `ai:needs-human`, not misread as auth |
| generic failure, no execution file | unchanged generic message |
| generic failure, non-auth execution file | unchanged generic message |
| confident verdict / no-verdict first look | unchanged |

`shellcheck` clean, workflow YAML parses.

**Not verified** — the message appearing in a live run, which requires a failing credential to reproduce. It will be exercised the next time auth breaks; until the token is replaced, that is every run.

## Rollback

One helper function plus one branch in `GATE 1`. Deleting both restores the previous generic message; no other behaviour depends on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of authentication failures during automated issue triage.
  * Authentication errors now provide a specific credential-remediation message instead of a generic failure notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->