### PR TITLE
ci(triage): catch a malformed credential, not just a revoked one

### DIFF
--- a/.github/workflows/on_issues_ai_triage.yaml
+++ b/.github/workflows/on_issues_ai_triage.yaml
@@ -363,13 +363,22 @@ jobs:
           }
 
           # Did the run die because the Claude credential is bad? The action
-          # reports this uselessly — a revoked token surfaces as "--json-schema
-          # was provided but Claude did not return structured_output", which
-          # points at the schema and not at auth. The execution file carries the
-          # truth: api_retry / result objects with error "authentication_failed"
-          # and a 401. Same array guard and fail-closed posture as above; an
-          # unrecognised shape simply is not an auth failure and falls through
-          # to the generic branch.
+          # reports this uselessly — the failure surfaces as "--json-schema was
+          # provided but Claude did not return structured_output", which points
+          # at the schema and not at auth. The execution file carries the truth.
+          #
+          # A bad credential shows up in more than one shape, and both have been
+          # seen in production within a week:
+          #   * revoked token  -> error "authentication_failed", HTTP 401
+          #   * malformed token -> error "invalid_request", api_error_status
+          #     null, and the reason only in the SDK's message text ("Invalid
+          #     Authorization header value from CLAUDE_CODE_OAUTH_TOKEN: it
+          #     contains a line break at character 62").
+          # Matching only the first shape reported the second as a generic
+          # workflow fault, so the text marker is checked too — but only on an
+          # object the SDK itself flagged as an API error, so an issue body that
+          # merely mentions the secret's name cannot fake one. A false positive
+          # would change only the message: this branch exits 1 either way.
           hit_auth_failure() {
             [ -n "${EXECUTION_FILE:-}" ] && [ -s "${EXECUTION_FILE:-}" ] || return 1
             jq -e '(type == "array") and
@@ -377,8 +386,24 @@ jobs:
                        (type == "object") and
                        (((.error? // "") == "authentication_failed") or
                         ((.error_status? // 0) == 401) or
-                        ((.api_error_status? // 0) == 401)))' \
+                        ((.api_error_status? // 0) == 401) or
+                        (((.is_api_error_message? // false) == true) and
+                         (tostring | test("CLAUDE_CODE_OAUTH_TOKEN|Invalid auth token")))))' \
                "$EXECUTION_FILE" >/dev/null 2>&1
+          }
+
+          # The SDK's own words are far more useful than anything this script
+          # can infer — "it contains a line break at character 62" names the
+          # exact defect. Surface it verbatim when present.
+          auth_failure_detail() {
+            [ -n "${EXECUTION_FILE:-}" ] && [ -s "${EXECUTION_FILE:-}" ] || return 0
+            jq -r 'if type == "array" then
+                     [ .[]? | select(type == "object")
+                            | select((.is_api_error_message? // false) == true)
+                            | tostring
+                            | capture("(?<m>Invalid Authorization header value[^\"]*|Invalid auth token[^\"]*)")
+                            | .m ] | first // ""
+                   else "" end' "$EXECUTION_FILE" 2> /dev/null || true
           }
 
           # GATE 1 — did the action itself run? This is checked BEFORE looking
@@ -405,7 +430,8 @@ jobs:
             # goes quiet while each run still fails in a way that reads like a
             # per-issue problem. Say plainly what is wrong and what to do.
             if hit_auth_failure; then
-              echo "::error::CLAUDE_CODE_OAUTH_TOKEN is rejected (HTTP 401 / authentication_failed). This is NOT a problem with issue #$ISSUE — every AI workflow is down until the credential is replaced. Regenerate it with 'claude setup-token' and update the CLAUDE_CODE_OAUTH_TOKEN secret in the CR_PAT environment. Set the AI_DISABLED repo variable to 'true' to silence these runs meanwhile."
+              DETAIL=$(auth_failure_detail)
+              echo "::error::CLAUDE_CODE_OAUTH_TOKEN is being rejected${DETAIL:+ — $DETAIL}. This is NOT a problem with issue #$ISSUE: every AI workflow is down until the credential is fixed. Regenerate with 'claude setup-token' and re-enter the secret in the CR_PAT environment as a SINGLE line with no line break or trailing newline. Set the AI_DISABLED repo variable to 'true' to silence these runs meanwhile."
               exit 1
             fi
 

--- a/.github/workflows/on_issues_ai_triage.yaml
+++ b/.github/workflows/on_issues_ai_triage.yaml
@@ -362,6 +362,25 @@ jobs:
                "$EXECUTION_FILE" >/dev/null 2>&1
           }
 
+          # Did the run die because the Claude credential is bad? The action
+          # reports this uselessly — a revoked token surfaces as "--json-schema
+          # was provided but Claude did not return structured_output", which
+          # points at the schema and not at auth. The execution file carries the
+          # truth: api_retry / result objects with error "authentication_failed"
+          # and a 401. Same array guard and fail-closed posture as above; an
+          # unrecognised shape simply is not an auth failure and falls through
+          # to the generic branch.
+          hit_auth_failure() {
+            [ -n "${EXECUTION_FILE:-}" ] && [ -s "${EXECUTION_FILE:-}" ] || return 1
+            jq -e '(type == "array") and
+                   any(.[]?;
+                       (type == "object") and
+                       (((.error? // "") == "authentication_failed") or
+                        ((.error_status? // 0) == 401) or
+                        ((.api_error_status? // 0) == 401)))' \
+               "$EXECUTION_FILE" >/dev/null 2>&1
+          }
+
           # GATE 1 — did the action itself run? This is checked BEFORE looking
           # at the payload, because the action can fail *after* having written
           # a valid structured output: the object would sail through the shape
@@ -379,6 +398,16 @@ jobs:
           # explicit exit 1 the job would report success.
           if [ "${CLASSIFY_OUTCOME:-}" = "failure" ]; then
             restore_needs_info
+
+            # Checked before anything else, because it is the one failure with
+            # a specific remedy and it takes down every tier at once — tier 1
+            # cannot label, so tier 2's batch is empty and the whole pipeline
+            # goes quiet while each run still fails in a way that reads like a
+            # per-issue problem. Say plainly what is wrong and what to do.
+            if hit_auth_failure; then
+              echo "::error::CLAUDE_CODE_OAUTH_TOKEN is rejected (HTTP 401 / authentication_failed). This is NOT a problem with issue #$ISSUE — every AI workflow is down until the credential is replaced. Regenerate it with 'claude setup-token' and update the CLAUDE_CODE_OAUTH_TOKEN secret in the CR_PAT environment. Set the AI_DISABLED repo variable to 'true' to silence these runs meanwhile."
+              exit 1
+            fi
 
             # ...with one exception. Exhausting the turn budget is NOT a
             # workflow fault: the action ran fine and this particular issue was


### PR DESCRIPTION
Follow-up to #3034, which merged a few hours ago. The token was replaced at 08:25 — and the runs at 08:26 **still failed**, with an error that gate did not recognise.

## What is actually wrong now (not fixable in code)

```
Invalid auth token · Fix external auth token · Invalid Authorization header value from
CLAUDE_CODE_OAUTH_TOKEN: it contains a line break at character 62 (110 characters on 2 lines).
```

The replacement secret was stored **across two lines**. The token is 110 characters with a newline at character 62 — a paste that wrapped, or a value piped in with an embedded newline.

**Fix:** re-enter `CLAUDE_CODE_OAUTH_TOKEN` in the **CR_PAT** environment as a single unbroken line. If setting it from a shell, avoid anything that appends or preserves a newline:

```bash
printf '%s' "$TOKEN" | gh secret set CLAUDE_CODE_OAUTH_TOKEN --env CR_PAT --repo alexbelgium/hassio-addons
```

Note this is progress, not a regression: authentication is now *reached* (`Actor type: User`, git auth configured) and rejected on the header's shape, where before the token was revoked outright.

## What this PR fixes: #3034's gate missed it

#3034 keyed on the revoked-token shape — `error: "authentication_failed"`, HTTP 401. Today's failure carries neither:

```json
"error": "invalid_request",
"api_error_status": null
```

so it fell through to the generic *"usually a workflow-level fault"* message — precisely the unhelpful output #3034 existed to replace. Two shapes of the same underlying problem surfaced within a week:

| shape | signal | seen |
|---|---|---|
| revoked | `authentication_failed`, 401 | 2026-08-25 → 08-30 |
| malformed | `invalid_request`, reason only in the message text | 2026-08-31 |

Detection now also matches the text marker (`CLAUDE_CODE_OAUTH_TOKEN` / `Invalid auth token`), but **only on an object the SDK itself flagged** with `is_api_error_message: true`. An issue body that merely mentions the secret's name cannot fake one — and a false positive would change only the wording, since this branch exits 1 either way.

The SDK's own phrasing is more useful than anything this script could infer — *"a line break at character 62"* names the exact defect — so it is now quoted verbatim in the annotation, and the remedy explicitly says to re-enter the secret as a **single line**.

## Verification

**Verified** — replayed both real execution-file shapes captured from production:

| case | result |
|---|---|
| today's malformed token | credential error, **with the SDK's verbatim reason** |
| 08-30 revoked token | credential error (unchanged from #3034) |
| `max_turns` on automated retry | still escalates to `ai:needs-human`, exit 0 |
| generic action failure | unchanged generic message |
| issue text mentioning `CLAUDE_CODE_OAUTH_TOKEN` | **not** misreported — falls through to generic |

`shellcheck` clean, workflow YAML parses.

**Not verified** — the annotation in a live run; that needs a failing credential, which is currently every run until the secret is re-entered.

## Rollback

Two helper functions and one branch in `GATE 1`. Reverting to #3034's version restores the narrower 401-only detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI workflow error handling by detecting rejected or malformed authentication credentials.
  * Added clearer error messages identifying credential failures and indicating when AI workflows are unavailable.
  * Authentication issues are now reported before unrelated execution-limit errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->