### PR TITLE
feat(baikal): update to Baikal 0.12.1 and track sabre-io releases

### DIFF
--- a/baikal/CHANGELOG.md
+++ b/baikal/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.12.1 (2026-09-03)
+- Update to Baikal 0.12.1 from 0.10.1 (changelog : https://github.com/sabre-io/Baikal/releases). This includes the 0.12.1 fix for an XSS vulnerability that let an authenticated user take over the admin interface by renaming a calendar
+- ⚠ After the update, open the Baikal web admin once : Baikal asks to confirm the upgrade before it serves calendars again
+- The application is now taken from the release published by sabre-io instead of from the ckulka/baikal-docker image, which stopped at 0.10.1. The base image still provides nginx, php-fpm and msmtp. Automatic version tracking is enabled again, following sabre-io/Baikal
+- The Baikal application files in the addon data folder are now replaced on every start instead of being kept. Calendars, contacts, users and the Baikal configuration are untouched ; any manual edit made inside the application folders themselves is lost
+
 - The Home Assistant project has deprecated support for the armv7, armhf and i386 architectures. Support wil be fully dropped in the upcoming Home Assistant 2025.12 release
 
 ## 0.10.1-hafix4 (2025-11-18)

--- a/baikal/CHANGELOG.md
+++ b/baikal/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.12.1 (2026-09-03)
-- Update to Baikal 0.12.1 from 0.10.1 (changelog : https://github.com/sabre-io/Baikal/releases). This includes the 0.12.1 fix for an XSS vulnerability that let an authenticated user take over the admin interface by renaming a calendar
+
+- Update to Baikal 0.12.1 from 0.10.1 (changelog : <https://github.com/sabre-io/Baikal/releases>). This includes the 0.12.1 fix for an XSS vulnerability that let an authenticated user take over the admin interface by renaming a calendar
 - ⚠ After the update, open the Baikal web admin once : Baikal asks to confirm the upgrade before it serves calendars again
 - The application is now taken from the release published by sabre-io instead of from the ckulka/baikal-docker image, which stopped at 0.10.1. The base image still provides nginx, php-fpm and msmtp. Automatic version tracking is enabled again, following sabre-io/Baikal
 - The Baikal application files in the addon data folder are now replaced on every start instead of being kept. Calendars, contacts, users and the Baikal configuration are untouched ; any manual edit made inside the application folders themselves is lost

--- a/baikal/Dockerfile
+++ b/baikal/Dockerfile
@@ -16,7 +16,19 @@
 
 ARG BUILD_FROM
 ARG BUILD_VERSION
-ARG BUILD_UPSTREAM="0.10.1+hafix"
+ARG BUILD_UPSTREAM="0.12.1"
+
+# ckulka/baikal-docker, which builds the base image, stopped publishing new
+# Baikal versions at 0.10.1 : the base image is used for its runtime only
+# (nginx, php-fpm, msmtp) and the application comes from the release published
+# by sabre-io itself
+FROM alpine:3.21 AS baikal
+ARG BUILD_UPSTREAM
+RUN apk add --no-cache curl unzip \
+    && curl -f -s -S -L -o /tmp/baikal.zip "https://github.com/sabre-io/Baikal/releases/download/${BUILD_UPSTREAM}/baikal-${BUILD_UPSTREAM}.zip" \
+    && unzip -q /tmp/baikal.zip -d / \
+    && rm /tmp/baikal.zip
+
 FROM ${BUILD_FROM}
 
 ##################
@@ -27,6 +39,24 @@ FROM ${BUILD_FROM}
 ENV S6_CMD_WAIT_FOR_SERVICES=1 \
     S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
     S6_SERVICES_GRACETIME=0
+
+# Ship the Baikal release instead of the one bundled in the base image
+RUN rm -rf /var/www/baikal
+COPY --from=baikal --chown=nginx:nginx /baikal /var/www/baikal
+
+# Home Assistant asks for an expanded time range, and Baikal stores
+# cal:calendar-timezone as a bare timezone name rather than as the VTIMEZONE
+# object sabre/dav expects, so sabre/dav raises a ParseException and answers
+# 500 (sabre-io/Baikal#1241 and sabre-io/dav#1318, both still open). Read the
+# value as a timezone name instead. The two checks turn a release that moved
+# this code into a failed build rather than into an addon that Home Assistant
+# cannot read.
+# hadolint ignore=SC2016
+RUN \
+    DAVPLUGIN="/var/www/baikal/vendor/sabre/dav/lib/CalDAV/Plugin.php" \
+    && sed -i '/^                \/\/ This property contains a VCALENDAR with a single$/,/^                \$vtimezoneObj->destroy();$/c\                $calendarTimeZone = new DateTimeZone($tzResult[$tzProp]);' "$DAVPLUGIN" \
+    && grep -qxF '                $calendarTimeZone = new DateTimeZone($tzResult[$tzProp]);' "$DAVPLUGIN" \
+    && ! grep -qxF '                $calendarTimeZone = $vtimezoneObj->VTIMEZONE->getTimeZone();' "$DAVPLUGIN"
 
 # Image specific modifications
 # hadolint ignore=SC2015, SC2013, SC2086

--- a/baikal/README.md
+++ b/baikal/README.md
@@ -33,7 +33,9 @@ _Thanks to everyone having starred my repo! To star it click on the image below,
 ---
 
 [Baikal](https://sabre.io/baikal/) is a lightweight CalDAV+CardDAV server. It offers an extensive web interface with easy management of users, address books and calendars. It is fast and simple to install and only needs a basic php capable server. The data can be stored in a MySQL or a SQLite database.
-It is based on the docker image : https://github.com/ckulka/baikal-docker
+It ships the release published by [sabre-io](https://github.com/sabre-io/Baikal/releases), running on the nginx and php-fpm image built by https://github.com/ckulka/baikal-docker.
+
+After an update of Baikal itself, open the web admin once : Baikal asks to confirm the upgrade before it serves calendars again. Calendars, contacts, users and the Baikal configuration are kept, but a manual edit made inside the application folders themselves is replaced on every start.
 
 ## Configuration
 

--- a/baikal/README.md
+++ b/baikal/README.md
@@ -33,7 +33,7 @@ _Thanks to everyone having starred my repo! To star it click on the image below,
 ---
 
 [Baikal](https://sabre.io/baikal/) is a lightweight CalDAV+CardDAV server. It offers an extensive web interface with easy management of users, address books and calendars. It is fast and simple to install and only needs a basic php capable server. The data can be stored in a MySQL or a SQLite database.
-It ships the release published by [sabre-io](https://github.com/sabre-io/Baikal/releases), running on the nginx and php-fpm image built by https://github.com/ckulka/baikal-docker.
+It ships the release published by [sabre-io](https://github.com/sabre-io/Baikal/releases), running on the nginx and php-fpm image built by <https://github.com/ckulka/baikal-docker>.
 
 After an update of Baikal itself, open the web admin once : Baikal asks to confirm the upgrade before it serves calendars again. Calendars, contacts, users and the Baikal configuration are kept, but a manual edit made inside the application folders themselves is replaced on every start.
 

--- a/baikal/build.json
+++ b/baikal/build.json
@@ -1,6 +1,6 @@
 {
     "build_from": {
-        "aarch64": "ghcr.io/mralucarddante/baikal-docker-hass:latest",
-        "amd64": "ghcr.io/mralucarddante/baikal-docker-hass:latest"
+        "aarch64": "ckulka/baikal:nginx-php8.2",
+        "amd64": "ckulka/baikal:nginx-php8.2"
     }
 }

--- a/baikal/config.yaml
+++ b/baikal/config.yaml
@@ -84,5 +84,5 @@ schema:
 slug: baikal
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: 0.10.1-hafix4
+version: "0.12.1"
 webui: "[PROTO:ssl]://[HOST]:[PORT:80]"

--- a/baikal/rootfs/etc/cont-init.d/90-run.sh
+++ b/baikal/rootfs/etc/cont-init.d/90-run.sh
@@ -1,7 +1,21 @@
 #!/bin/bash
+set -e
 
-# Copy data
-cp -rnf /var/www/baikal/* /data/
+# Baikal keeps its database in Specific and its configuration in config. The
+# release ships both as empty folders, so they are created here rather than
+# copied, and are then left alone : they hold the user's data
+mkdir -p /data/config /data/Specific/db
+
+# Everything else is application code, and is replaced on every start so that a
+# rebuilt image actually replaces the code that is served
+for item in /var/www/baikal/*; do
+    name="$(basename "$item")"
+    case "$name" in
+        Specific | config) continue ;;
+    esac
+    rm -rf "/data/$name"
+    cp -rf "$item" /data/
+done
 
 # Fix permissions
 chown -R nginx:nginx /data

--- a/baikal/updater.json
+++ b/baikal/updater.json
@@ -1,9 +1,9 @@
 {
-  "github_exclude": "+",
-  "last_update": "26-04-2025",
+  "github_beta": "false",
+  "last_update": "2026-09-03",
   "repository": "alexbelgium/hassio-addons",
   "slug": "baikal",
   "source": "github",
-  "upstream_repo": "ckulka/baikal-docker",
-  "upstream_version": "0.10.1"
+  "upstream_repo": "sabre-io/Baikal",
+  "upstream_version": "0.12.1"
 }


### PR DESCRIPTION
Closes #3038 — the add-on shipped Baikal 0.10.1 (Nov 2024) while upstream is at 0.12.1 (Aug 2026), and its updater was pointed at a repository that has stopped moving.

## Why it was stuck

- The base image was `ghcr.io/mralucarddante/baikal-docker-hass:latest`. That repository was **archived on 2026-04-10** and its last release is 0.10.1. It was `FROM ckulka/baikal:0.10.1-nginx-php8.2` plus a whole patched `vendor/sabre/dav/lib/CalDAV/Plugin.php`.
- `ckulka/baikal-docker` itself still has `ENV VERSION 0.10.1` in its Dockerfiles, and its newest versioned Docker Hub tags are `0.10.1-*`. There is no maintained Baikal 0.12 image anywhere.
- `updater.json` tracked `ckulka/baikal-docker`, so even with the bot running, there was nothing newer to find.

## What changed

- **The base image now provides the runtime only** (nginx, php-fpm, msmtp, sqlite3), and the application comes from the release published by sabre-io. `build.json` moves from the archived fork to `ckulka/baikal:nginx-php8.2` — the PHP 8.2 variant, because Baikal 0.11 dropped PHP 8.1 and 0.12.1 requires `^8.2`. That tag is multi-arch for both declared architectures.
- **A first build stage downloads `baikal-${BUILD_UPSTREAM}.zip`**, mirroring the pattern `bentopdf` already uses in this repo. There is a single version literal in the Dockerfile, `ARG BUILD_UPSTREAM`, which is what `addons_updater` rewrites.
- **The Home Assistant timezone fix is applied as the single hunk it actually is** instead of as a whole forked file. Home Assistant asks for an expanded time range, Baikal stores `cal:calendar-timezone` as a bare timezone name rather than the VTIMEZONE object sabre/dav expects, and sabre/dav answers 500 (sabre-io/Baikal#1241 and sabre-io/dav#1318, both still open, so it is still needed). Two `grep` assertions fail the build if a future sabre/dav moves that code, rather than shipping an add-on Home Assistant cannot read.
- **`90-run.sh` now refreshes the application on every start.** `/data` holds the application *and* the user data, and the old `cp -rnf` was no-clobber — so on an existing install a rebuilt image would have kept serving the old code from `/data` forever. `Specific/` (database) and `config/` (baikal.yaml) are skipped and only created if absent; everything else is replaced. `set -e` was added so a failed refresh stops the add-on instead of starting nginx over a half-copied tree.
- **`updater.json` now tracks `sabre-io/Baikal`**, so the weekly bot can bump this add-on again. The `github_exclude: "+"` filter is gone; it existed to skip ckulka's `+hafix` tags and sabre-io has none.
- `version` → `0.12.1`. 0.12.1 fixes an XSS vulnerability that let an authenticated user take over the admin interface by renaming a calendar.

## Verified

- The 0.12.1 release zip was downloaded and unpacked: top level is exactly `Core LICENSE README.md Specific config html vendor`, and `config/` and `Specific/db/` are empty placeholder folders — hence the `mkdir -p` rather than a copy.
- `vendor/sabre/dav/lib/CalDAV/Plugin.php` in that zip is byte-identical to sabre-io/dav 4.7.1.
- The `sed` was run against that real file with GNU sed 4.9: 1011 → 1004 lines, and the result is byte-identical to the fork's proven `Plugin.php` except for the `::class` modernisations sabre/dav 4.7.1 made on its own. The file has three similar VTIMEZONE blocks, at 28-, 16- and 12-space indentation; both anchors are pinned to the 16-space one, which is the only one the fork patched.
- Zero of the 1309 files in the release contain the string `/var/www/baikal`, so the existing path-rewrite loop has nothing to damage in the new tree.
- The `90-run.sh` loop was exercised on a fixture: code files replaced, a file removed upstream deleted, user data in `config/` and `Specific/db/` preserved.
- `validate.sh baikal --vs-master`: shellcheck, hadolint, `bash -n` and config schema clean; no lint finding added by this diff.
- Codex reviewed the plan and then the diff; no release-blocking finding.

## Not verified

- **The Docker build has not run** — dockerd is unavailable in my environment, CI is the only gate.
- Baikal 0.12.1 has **not** been exercised at runtime here. The overlay is sound on paper (the release carries its own `vendor/`, PHP 8.2 meets its requirement, the nginx vhost and docroot are unchanged) but nothing has served a calendar yet.

## Known trade-offs

- `ckulka/baikal:nginx-php8.2` is a floating tag last pushed 2025-11-30, and ckulka's build is currently failing (their issue #316). It is the freshest runtime available — four months newer than the pinned `0.10.1-nginx-php8.2` — but it is not a durable security base for a publicly reachable CalDAV server. Owning the runtime Dockerfile is the real fix and is deliberately out of scope here.
- The application tree in `/data` is now replaced on every start, so a manual edit made inside `Core/`, `html/` or `vendor/` is lost. Calendars, contacts, users and `baikal.yaml` are not affected.
- **Users must open the Baikal web admin once after updating**: `Core/Frameworks/Baikal/Framework.php` compares `configured_version` with `BAIKAL_VERSION` and redirects to the upgrade wizard. This is documented in the CHANGELOG and the README.
- If a future sabre/dav release moves the patched block, the bot's auto-update commit will produce a red build on master. That is deliberate — shipping the add-on without the patch is worse — but worth knowing.

## Rollback

The riskiest hunk is the `90-run.sh` refresh loop. Reverting only that file restores the old no-clobber behaviour; the image would still contain 0.12.1 but existing installs would keep running their `/data` copy. A full revert of the PR returns the add-on to the archived fork at 0.10.1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated Baikal to version 0.12.1 from the official upstream release.
  * Application files are replaced automatically when the add-on starts, while calendars, contacts, users, and configuration are preserved.
  * Automatic upstream version tracking now follows official Baikal releases.

* **Bug Fixes**
  * Fixed an XSS vulnerability that could allow an authenticated user to take over the administration interface by renaming a calendar.

* **Documentation**
  * Added upgrade guidance, including the required one-time web administration confirmation before calendars are served.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->