### PR TITLE
Switch bentopdf to upstream's Simple Mode build (v2.8.8) and add updater.json.

### DIFF
--- a/bentopdf/CHANGELOG.md
+++ b/bentopdf/CHANGELOG.md
@@ -1,7 +1,20 @@
+## 2.8.8 (03-09-2026)
+
+- Now builds upstream's Simple Mode release instead of the standard one. It leaves out the bentopdf.com marketing pages (nav bar, hero, features, FAQ, footer). Both builds carry the same 130 tool pages and the same LibreOffice WebAssembly payload, so the served payload just gets smaller: about 228 MB, down from about 258 MB.
+- Breaking: you can no longer reach the marketing UI, and there is no way to bring it back.
+- Upstream BentoPDF is now v2.8.8: <https://github.com/alam00000/bentopdf/releases/tag/v2.8.8>
+- That includes the v2.8.7 security fixes (GHSA-wh78-rcw2-hhg9, GHSA-5xjf-rr5x-pcfj, GHSA-cx8x-7rrr-r9x8), which cover every version through v2.8.6
+- Version mismatch fixed. The image built upstream 2.8.2 while reporting 2.8.4; `ARG BUILD_VERSION` now matches `version`
+- Added `updater.json` so `addons_updater` now tracks upstream releases automatically
+
 ## 2.8.4 (24-04-2026)
+
 - Minor bugs fixed
+
 ## 2.8.2 (07-04-2026)
+
 - Minor bugs fixed
+
 # Changelog
 
 ## 2.8.2

--- a/bentopdf/Dockerfile
+++ b/bentopdf/Dockerfile
@@ -1,13 +1,19 @@
 # Global build args — must be declared before the first FROM to be usable in FROM instructions
 ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.23
-ARG BUILD_VERSION=2.8.2
+ARG BUILD_VERSION=2.8.8
+# Upstream BentoPDF release to fetch. Tracked separately from BUILD_VERSION so
+# the add-on can carry a local patch counter (e.g. 2.8.8.1) without breaking the
+# release URLs, which only exist for real upstream tags.
+ARG BUILD_UPSTREAM=2.8.8
 
-# Stage 1: Download and extract the BentoPDF dist release (includes bundled WASM)
+# Stage 1: Download and extract the BentoPDF Simple Mode dist release (includes
+# bundled WASM). Simple Mode drops the bentopdf.com marketing UI and keeps every
+# PDF tool, so it is the only build shipped here.
 FROM alpine:3.21 AS dist
-ARG BUILD_VERSION
+ARG BUILD_UPSTREAM
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl unzip \
-    && curl -fsSL "https://github.com/alam00000/bentopdf/releases/download/v${BUILD_VERSION}/dist-${BUILD_VERSION}.zip" \
+    && curl -fsSL "https://github.com/alam00000/bentopdf/releases/download/v${BUILD_UPSTREAM}/dist-simple-${BUILD_UPSTREAM}.zip" \
        -o /tmp/bentopdf.zip \
     && unzip /tmp/bentopdf.zip -d /tmp/dist
 

--- a/bentopdf/README.md
+++ b/bentopdf/README.md
@@ -104,6 +104,12 @@ A privacy-first PDF toolkit running entirely in your browser — no uploads, no 
 
 No other configuration is needed. Drop your files in and go.
 
+### Simple Mode build
+
+Upstream publishes two builds per release, and this add-on uses the Simple Mode one. It leaves out the bentopdf.com marketing pages: nav bar, hero, features, FAQ and footer.
+
+You still get all 130 tool pages and the same LibreOffice WebAssembly payload as the standard build. Dropping those pages also cuts the served payload to about 228 MB, down from about 258 MB.
+
 ---
 
 ## Privacy

--- a/bentopdf/config.yaml
+++ b/bentopdf/config.yaml
@@ -2,7 +2,7 @@ name: "BentoPDF"
 slug: bentopdf
 image: ghcr.io/alexbelgium/bentopdf-{arch}
 description: "Privacy-first PDF toolkit. 50+ tools, all processing client-side in the browser. Files never leave your device."
-version: "2.8.4"
+version: "2.8.8"
 url: "https://github.com/alexbelgium/hassio-addons/tree/master/bentopdf"
 arch:
   - amd64

--- a/bentopdf/updater.json
+++ b/bentopdf/updater.json
@@ -1,0 +1,9 @@
+{
+  "last_update": "2026-09-03",
+  "repository": "alexbelgium/hassio-addons",
+  "slug": "bentopdf",
+  "source": "github",
+  "upstream_repo": "alam00000/bentopdf",
+  "upstream_version": "2.8.8",
+  "github_beta": false
+}


### PR DESCRIPTION
Prompted by feedback in alexbelgium/hassio-addons#3007 and ToledoEM/hassio-addons-repository#55.

Changes:
- Dockerfile now pulls dist-simple-${BUILD_UPSTREAM}.zip instead of the standard dist zip. Simple Mode drops the bentopdf.com marketing pages (nav bar, hero, features, FAQ, footer) but keeps all 130 tool pages and the LibreOffice WASM payload. Image size drops from about 258 MB to about 228 MB.
- Split BUILD_VERSION and BUILD_UPSTREAM in the Dockerfile, so a local patch counter can be added later without touching the upstream release URL.
- Fixed a version mismatch: the image was built from upstream 2.8.2 while config.yaml reported 2.8.4. Both now point at 2.8.8.
- Bumped config.yaml version to 2.8.8.
- **Added bentopdf/updater.json (source: github, upstream_repo: alam00000/bentopdf). Didn't exist before, so version bumps were manual.**
- Added a README section on the Simple Mode build and its size savings.
- Updated CHANGELOG.md.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the BentoPDF 2.8.8 Simple Mode build.
  - Retains all 130 PDF tools while reducing the served payload from approximately 258 MB to 228 MB.
  - Added automatic release update tracking.

- **Improvements**
  - Incorporates upstream security fixes.
  - Removed marketing-focused pages, including the navigation bar, hero, features, FAQ, and footer, for a more streamlined experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->