### PR TITLE
fix(wger): set the database env vars the upstream image stopped shipping

### DIFF
--- a/wger/CHANGELOG.md
+++ b/wger/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.6.4 (04-09-2026)
+## 2.6.4 (2026-09-04)
 
 - Fix the add-on failing to start on a fresh install with `django.core.exceptions.ImproperlyConfigured: Set the DJANGO_DB_ENGINE environment variable`. The upstream `wger/server` image stopped shipping database defaults, and `settings/main.py` reads `DJANGO_DB_ENGINE` and `DJANGO_DB_DATABASE` with no fallback, so the add-on now sets them explicitly to sqlite at `/data/database.sqlite` — the same location the previous startup rewrite produced, so existing databases keep working.
 - Set `DJANGO_PERFORM_MIGRATIONS=True`, as upstream's own docker deployment does, so an existing database gets new migrations applied when the add-on is rebuilt against a newer upstream release.

--- a/wger/CHANGELOG.md
+++ b/wger/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.6.4 (04-09-2026)
+
+- Fix the add-on failing to start on a fresh install with `django.core.exceptions.ImproperlyConfigured: Set the DJANGO_DB_ENGINE environment variable`. The upstream `wger/server` image stopped shipping database defaults, and `settings/main.py` reads `DJANGO_DB_ENGINE` and `DJANGO_DB_DATABASE` with no fallback, so the add-on now sets them explicitly to sqlite at `/data/database.sqlite` — the same location the previous startup rewrite produced, so existing databases keep working.
+- Set `DJANGO_PERFORM_MIGRATIONS=True`, as upstream's own docker deployment does, so an existing database gets new migrations applied when the add-on is rebuilt against a newer upstream release.
+- Drop the startup rewrite of the database path in the Python settings: upstream no longer hardcodes `/home/wger/db/database.sqlite` anywhere, so the rewrite silently did nothing and only logged a warning.
+- ⚠ MAJOR CHANGE : switch to the new config logic from homeassistant. Your configuration file will have migrated from /config/addons_config/wger to a folder only accessible from my Filebrowser addon called /addon_configs/xxx-wger. This avoids the addon to mess with your homeassistant configuration folder, and allows to backup the options. Migration is automatic only for a config.yaml sitting at the default /config/addons_config/wger/config.yaml. If you had pointed CONFIG_LOCATION somewhere else inside the homeassistant config folder, or had a custom script at /homeassistant/addons_autoscripts/wger.sh, move the file to /addon_configs/xxx-wger/ by hand and update the option. Please be sure to update all your links ! For more information, see here : https://developers.home-assistant.io/blog/2023/11/06/public-addon-config/
+
 ## 2.6.3 (2026-08-01)
 
 - Version renamed from `2.6-dev-3`, which Home Assistant could not order and therefore could not reliably offer as an update: every number of the previous version is kept, as a section of its own. The addon itself and the upstream version it tracks are unchanged

--- a/wger/Dockerfile
+++ b/wger/Dockerfile
@@ -28,9 +28,14 @@ ENV S6_CMD_WAIT_FOR_SERVICES=1 \
     S6_SERVICES_GRACETIME=0
 
 
+# The upstream image no longer ships database defaults; settings/main.py reads
+# DJANGO_DB_ENGINE and DJANGO_DB_DATABASE with no fallback, so they must be set here
 ENV SYNC_EXERCISES_ON_STARTUP=True \
     DOWNLOAD_EXERCISE_IMAGES_ON_STARTUP=True \
     FROM_EMAIL='wger Workout Manager <wger@example.com>' \
+    DJANGO_DB_ENGINE="django.db.backends.sqlite3" \
+    DJANGO_DB_DATABASE="/data/database.sqlite" \
+    DJANGO_PERFORM_MIGRATIONS=True \
     DJANGO_MEDIA_ROOT="/data/media" \
     DJANGO_STATIC_ROOT="/data/static"
 

--- a/wger/config.yaml
+++ b/wger/config.yaml
@@ -5,12 +5,13 @@ description: manage your personal workouts, weight and diet plans
 image: ghcr.io/alexbelgium/wger-{arch}
 map:
   - share:rw
-  - config:rw
+  - addon_config:rw
+  - homeassistant_config:rw
   - ssl:ro
 name: Wger
 options:
   env_vars: []
-  CONFIG_LOCATION: /config/addons_config/wger/config.yaml
+  CONFIG_LOCATION: /config/config.yaml
 ports:
   80/tcp: 9927
 ports_description:
@@ -23,5 +24,5 @@ schema:
 slug: wger
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "2.6.3"
+version: "2.6.4"
 webui: "[PROTO:ssl]://[HOST]:[PORT:80]"

--- a/wger/rootfs/etc/cont-init.d/90-run.sh
+++ b/wger/rootfs/etc/cont-init.d/90-run.sh
@@ -51,20 +51,6 @@ migrate_database() {
     fi
 }
 
-############################
-# Change database location #
-############################
-echo "... set database path"
-mapfile -t SETTINGS_FILES < <(grep -rl --include='*.py' '/home/wger/db/database.sqlite' /home 2> /dev/null || true)
-
-if [ "${#SETTINGS_FILES[@]}" -gt 0 ]; then
-    for settings_file in "${SETTINGS_FILES[@]}"; do
-        sed -i "s|/home/wger/db/database.sqlite|/data/database.sqlite|g" "$settings_file"
-    done
-else
-    bashio::log.warning "Unable to find Python settings containing database path under /home, skipping rewrite"
-fi
-
 #####################
 # Adapt directories #
 #####################


### PR DESCRIPTION
Fixes #3043.

## What was measured

I pulled the OCI image config for `docker.io/wger/server:latest` (amd64 digest `sha256:6ae3c1c0…52b31`) from Docker Hub. Its **complete** `Env` list is:

```
PATH, DEBIAN_FRONTEND, LANG, LANGUAGE, LC_ALL, PYTHONDONTWRITEBYTECODE,
PYTHONUNBUFFERED, APP_BUILD_COMMIT, APP_BUILD_DATE, PYTHONPATH,
DJANGO_SETTINGS_MODULE=settings.main
```

No `DJANGO_DB_*` at all. Upstream `settings/main.py:69-70` reads `DJANGO_DB_ENGINE` and `DJANGO_DB_DATABASE` with **no default**, so every fresh install died at import time with `ImproperlyConfigured: Set the DJANGO_DB_ENGINE environment variable`. I grepped every `env.*` call in that file: those two are the only ones read unconditionally without a default — `SECRET_KEY`, `SITE_URL`, `WGER_PORT` and `DJANGO_DEBUG` all default, and the other no-default reads sit behind `if` guards (`ENABLE_EMAIL`, `DJANGO_CACHE_BACKEND`, `AWS_*`).

The add-on used to get the database path by rewriting the literal `/home/wger/db/database.sqlite` inside upstream's Python settings at startup. That string no longer exists upstream, which is the `WARNING: Unable to find Python settings containing database path under /home, skipping rewrite` line in the reporter's log.

## What changed

- **`Dockerfile`** — set `DJANGO_DB_ENGINE=django.db.backends.sqlite3` and `DJANGO_DB_DATABASE=/data/database.sqlite`. `/data` is the add-on's persistent volume and is exactly where the old rewrite redirected the database, so an existing install keeps its data at the same path.
- **`Dockerfile`** — set `DJANGO_PERFORM_MIGRATIONS=True`, as upstream's own `config/prod.env` does. `wger bootstrap` runs `migrate` only `if not database_initialised()`, so without this an existing database silently gets no new migrations when the image is rebuilt against a newer upstream release.
- **`90-run.sh`** — delete the settings rewrite. It is now provably a no-op, and editing someone else's installed Python at runtime was a level deeper than this needed to be.
- **`config.yaml`** — move to the modern add-on config location (`addon_config:rw` + `homeassistant_config:rw`, `CONFIG_LOCATION: /config/config.yaml`), matching the 90 add-ons in this repo that already did. `homeassistant_config:rw` is required, not cosmetic: `.templates/01-config_yaml.sh:59` performs an `mv` out of `/homeassistant/addons_config/<slug>/`, which needs write access there.

User overrides still win — `90-run.sh` rewrites `/data/env.sh` from `/.env` after the `export -p` snapshot, so an `env_vars` entry (or `PS_DATABASE_URI` for postgres) takes precedence over these Dockerfile defaults.

## Not verified

- **The Docker build.** No dockerd locally; CI is the only gate.
- **That the add-on actually starts.** Nothing here was run against a live container. `validate.sh wger --vs-master` passes (`bash -n`, shellcheck, hadolint, config.yaml, no new lint findings), which is a parse-and-lint check, not a behavioural one. The reasoning that the two env vars are sufficient rests on the image config blob and the upstream source above, not on an observed boot.
- **The config-location migration on a real host.** It relies on the shared template behaving as its code reads.

## Known left out

- A hand-set `CONFIG_LOCATION` pointing somewhere other than the default `/config/addons_config/wger/config.yaml` is **not** migrated — the template only moves that exact path. The reporter is in this case (they had `/config/app_configs/…`). Documented in the CHANGELOG rather than coded around.
- A custom script at `/homeassistant/addons_autoscripts/wger.sh` is not migrated either; `01-custom_script.sh` has no legacy-path move. Also documented.
- `WGER_USE_GUNICORN=True`. The add-on still runs Django's development server behind nginx, which is not upstream's recommended production topology. Deliberately not bundled with a startup fix.
- No pre-migration sqlite backup. Home Assistant's own add-on backup already snapshots `/data`.

## Review

Reviewed independently by Codex (`gpt-5.6-sol`). It endorsed the mechanism and argued the Dockerfile is the right level for these defaults. Its objections and my responses: `homeassistant_config:ro` — rejected, the template's `mv` needs write; add a log line naming the database — rejected, `migrate_database()` already logs it; `/data/env.sh` may hold stale values — wrong, it is written with `>` and truncated every boot; add a pre-migration backup — rejected as complexity defending an undemonstrated case; verify nginx targets 8000 — confirmed, both nginx files use `127.0.0.1:8000`, matching upstream's `${WGER_PORT:-8000}`. Its one accepted point was the unmigrated custom `CONFIG_LOCATION`, which produced a CHANGELOG wording change and no code.

## Rollback

The riskiest hunk is the `config.yaml` map change, and it reverts alone:

```bash
git revert --no-commit <sha> -- wger/config.yaml
```

That restores `config:rw` and the old `CONFIG_LOCATION` default while keeping the startup fix. The Dockerfile and `90-run.sh` hunks are independent of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed fresh-install startup failures by ensuring the add-on uses its persistent SQLite database.
  - Database migrations now run automatically when the add-on is rebuilt.
  - Existing databases are preserved, with legacy database locations migrated when applicable.

- **Improvements**
  - Updated configuration storage to use the Home Assistant add-on configuration location.
  - Existing default configurations are migrated automatically to the new location.
  - Updated the add-on to version 2.6.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->