### PR TITLE
fix(wger): declare the database in the environment (wger 2.7 dropped the sqlite fallback)

### DIFF
--- a/wger/CHANGELOG.md
+++ b/wger/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.6.4 (2026-09-05)
+
+- Fix the add-on failing to start with `ImproperlyConfigured: Set the DJANGO_DB_ENGINE environment variable`: wger 2.7 removed the implicit sqlite fallback from its settings, so the database is now declared explicitly through `DJANGO_DB_ENGINE` / `DJANGO_DB_DATABASE`, still pointing at the persistent `/data/database.sqlite`
+- Replace the misleading "Unable to find Python settings containing database path" warning with an informational message, as wger no longer hardcodes that path
+
 ## 2.6.3 (2026-08-01)
 
 - Version renamed from `2.6-dev-3`, which Home Assistant could not order and therefore could not reliably offer as an update: every number of the previous version is kept, as a section of its own. The addon itself and the upstream version it tracks are unchanged

--- a/wger/Dockerfile
+++ b/wger/Dockerfile
@@ -34,6 +34,18 @@ ENV SYNC_EXERCISES_ON_STARTUP=True \
     DJANGO_MEDIA_ROOT="/data/media" \
     DJANGO_STATIC_ROOT="/data/static"
 
+# wger 2.7 dropped the implicit sqlite fallback in settings/main.py, so the
+# database has to be declared through the environment or Django aborts with
+# "Set the DJANGO_DB_ENGINE environment variable".
+# USER/PASSWORD/HOST/PORT are ignored by the sqlite backend; they are set
+# because wger 2.6 read them without a default, so both base images boot.
+ENV DJANGO_DB_ENGINE="django.db.backends.sqlite3" \
+    DJANGO_DB_DATABASE="/data/database.sqlite" \
+    DJANGO_DB_USER="" \
+    DJANGO_DB_PASSWORD="" \
+    DJANGO_DB_HOST="" \
+    DJANGO_DB_PORT="5432"
+
 USER root
 
 RUN echo "wger ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \

--- a/wger/config.yaml
+++ b/wger/config.yaml
@@ -23,5 +23,5 @@ schema:
 slug: wger
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "2.6.3"
+version: "2.6.4"
 webui: "[PROTO:ssl]://[HOST]:[PORT:80]"

--- a/wger/rootfs/etc/cont-init.d/90-run.sh
+++ b/wger/rootfs/etc/cont-init.d/90-run.sh
@@ -62,7 +62,9 @@ if [ "${#SETTINGS_FILES[@]}" -gt 0 ]; then
         sed -i "s|/home/wger/db/database.sqlite|/data/database.sqlite|g" "$settings_file"
     done
 else
-    bashio::log.warning "Unable to find Python settings containing database path under /home, skipping rewrite"
+    # Expected on wger >= 2.7: the settings no longer hardcode a database path,
+    # it is taken from DJANGO_DB_DATABASE instead (set in the Dockerfile)
+    bashio::log.info "Settings do not hardcode a database path, using DJANGO_DB_DATABASE=${DJANGO_DB_DATABASE:-/data/database.sqlite}"
 fi
 
 #####################

--- a/wger/rootfs/etc/cont-init.d/90-run.sh
+++ b/wger/rootfs/etc/cont-init.d/90-run.sh
@@ -63,8 +63,11 @@ if [ "${#SETTINGS_FILES[@]}" -gt 0 ]; then
     done
 else
     # Expected on wger >= 2.7: the settings no longer hardcode a database path,
-    # it is taken from DJANGO_DB_DATABASE instead (set in the Dockerfile)
-    bashio::log.info "Settings do not hardcode a database path, using DJANGO_DB_DATABASE=${DJANGO_DB_DATABASE:-/data/database.sqlite}"
+    # it comes from the environment instead. Which variable wins is decided by
+    # wger, not here: PS_DATABASE_URI takes precedence over the DJANGO_DB_*
+    # defaults set in the Dockerfile, so no single one is named, and no value
+    # is logged (PS_DATABASE_URI carries credentials).
+    bashio::log.info "Settings do not hardcode a database path, the database is taken from the environment"
 fi
 
 #####################


### PR DESCRIPTION
## Root cause

`wger/Dockerfile:19` builds from **`wger/server:latest`**, unpinned. Upstream released **wger 2.7 on 2026-09-03**, which changed `settings/main.py`:

```diff
 if os.environ.get('PS_DATABASE_URI'):
     DATABASES = {'default': env.db_url('PS_DATABASE_URI')}
-elif os.environ.get('DJANGO_DB_ENGINE'):
+else:
     DATABASES = {
         'default': {
             'ENGINE': env.str('DJANGO_DB_ENGINE'),
             'NAME': env.str('DJANGO_DB_DATABASE'),
-        }
-    }
-else:
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': env.str('DJANGO_DB_DATABASE', '/home/wger/db/database.sqlite'),
         }
     }
```
(<https://github.com/wger-project/wger/compare/2.6...2.7>, `settings/main.py`)

The implicit sqlite fallback is gone. `DJANGO_DB_ENGINE` is now read unconditionally at **`settings/main.py:69`** — which matches the reporter's traceback frame exactly (`File "/home/wger/src/settings/main.py", line 69`; on 2.6 that same line sits behind the `elif os.environ.get('DJANGO_DB_ENGINE')` guard and cannot raise, so the failing image is 2.7).

The add-on never set those variables. It relied on the old hardcoded default instead: `wger/rootfs/etc/cont-init.d/90-run.sh:58-66` grepped the settings for the literal `/home/wger/db/database.sqlite` and rewrote it to `/data/database.sqlite`. In 2.7 that literal no longer exists, which is why the reported log contains `WARNING: Unable to find Python settings containing database path under /home, skipping rewrite` immediately before the crash.

Net effect: nothing in this repo changed, but every fresh install / rebuild now pulls wger 2.7 and dies with `ImproperlyConfigured: Set the DJANGO_DB_ENGINE environment variable`.

## The change

- **`wger/Dockerfile`** — declare the database through the environment, keeping the same persistent path the add-on already used:
  ```
  DJANGO_DB_ENGINE="django.db.backends.sqlite3"
  DJANGO_DB_DATABASE="/data/database.sqlite"
  DJANGO_DB_USER/PASSWORD/HOST="" , DJANGO_DB_PORT="5432"
  ```
  The last four are ignored by Django's sqlite backend; they are set because wger **2.6** read them without a default in its `elif` branch, so the image boots whether `wger/server:latest` resolves to 2.6 or 2.7.
- **`wger/rootfs/etc/cont-init.d/90-run.sh:65`** — the sed fallback is now a no-op on 2.7, so its `WARNING` becomes an `INFO` naming the path actually in use. Behaviour is unchanged; only the log line differs.
- `CHANGELOG.md` + `config.yaml` version bump.

**Existing data is preserved.** On the 2.6-based image the sed rewrite put the database at `/data/database.sqlite`; `DJANGO_DB_DATABASE` points at that exact path, so upgrading installs keep their database. Users who need Postgres can still override any of these via the `env_vars` option.

## Version bump note

`updater.json` has `upstream_version: 2.6-dev`, so this is not a literal `U` / `U.N` match. Per `CHANGELOG.md`, `2.6.3` is the renamed `2.6-dev-3` — the trailing component *is* the local patch counter — so this bumps `2.6.3` -> `2.6.4`. Upstream tags are `2.6` / `2.7`, never `2.6.x`, so no future upstream identifier is burned. `updater.json` is untouched. Flagging it here in case you'd rather it went out differently.

## Verification

- `shellcheck -x wger/rootfs/etc/cont-init.d/90-run.sh` — clean.
- Upstream diff read directly from `wger-project/wger` at tags `2.6` and `2.7`; the reported traceback line number matches 2.7's `main.py:69` and does not match 2.6's.
- **Not** verified by running the add-on — I have no Home Assistant instance here. The Docker build in `onpr_check-pr.yaml` is the real check, plus a fresh install by the reporter.

## Not in scope

The reporter also asks about the config file location. This add-on uses the legacy `config:rw` mapping, for which `/config/addons_config/wger/config.yaml` is the correct default; moving it to `addon_config:rw` (the `/addon_configs/<slug>` scheme 90 other add-ons here use) is a separate migration with user-data implications and is not bundled into this hotfix.

Closes #3043

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated database configuration to support wger 2.7 while preserving compatibility with wger 2.6.
  * Replaced a misleading database-path warning with an informational message when configuration is supplied through environment variables.
  * Added explicit SQLite database settings to improve upgrade compatibility and ensure the add-on continues using its existing database.

* **Maintenance**
  * Updated the wger add-on to version 2.6.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->