### PR TITLE
fix(mealie): build the frontend with pnpm and the upstream lockfile

### DIFF
--- a/mealie/CHANGELOG.md
+++ b/mealie/CHANGELOG.md
@@ -1,4 +1,8 @@
  
+## v3.25.1 (2026-09-05)
+- Update to latest version from mealie-recipes/mealie (changelog : https://github.com/mealie-recipes/mealie/releases)
+- Build the ingress frontend with pnpm and the upstream lockfile: upstream dropped frontend/yarn.lock in v3.24.0, so the previous yarn install resolved dependencies unpinned and the build broke on a vuetify release without "vuetify/labs/rules"
+ 
 ## v3.24.0 (2026-08-29)
 - Update to latest version from mealie-recipes/mealie (changelog : https://github.com/mealie-recipes/mealie/releases)
  

--- a/mealie/Dockerfile
+++ b/mealie/Dockerfile
@@ -15,24 +15,30 @@
 #################
 
 # Stage 1: Build Frontend with SUB_PATH
-FROM node:22 AS frontend-builder
+# Mirrors upstream docker/Dockerfile: node:24 + pnpm, installing from the
+# committed pnpm-lock.yaml. Upstream dropped frontend/yarn.lock in v3.24.0, so a
+# yarn install here resolved every dependency fresh and eventually picked a
+# vuetify release without "vuetify/labs/rules", breaking "nuxt generate".
+FROM node:24 AS frontend-builder
 
 # Set the SUB_PATH environment variable
 ARG SUB_PATH="/mealie/"
 ENV SUB_PATH=$SUB_PATH
 
-ENV MEALIE_VERSION="v3.24.0"
+ENV MEALIE_VERSION="v3.25.1"
+
+RUN npm install --global pnpm@11
 
 # Clone the Mealie repository to get the frontend source code
 WORKDIR /frontend
 # hadolint ignore=DL3003
 RUN mkdir -p /frontend/tempdir && cd /frontend/tempdir && \
-    git clone --branch "$MEALIE_VERSION" https://github.com/mealie-recipes/mealie.git . && \
-    cp -rf frontend/* /frontend && cd /frontend && rm -rf tempdir && \
-    yarn install --prefer-offline --frozen-lockfile --non-interactive --production=false --network-timeout 1000000
+    git clone --depth 1 --branch "$MEALIE_VERSION" https://github.com/mealie-recipes/mealie.git . && \
+    cp -a frontend/. /frontend/ && cd /frontend && rm -rf tempdir && \
+    pnpm install --frozen-lockfile
 
 # Build the frontend
-RUN yarn generate
+RUN pnpm generate
 
 # Stage 2: Build the Final Image
 FROM hkotel/mealie:latest

--- a/mealie/config.yaml
+++ b/mealie/config.yaml
@@ -114,4 +114,4 @@ schema:
 slug: mealie
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "v3.24.0"
+version: "v3.25.1"

--- a/mealie/updater.json
+++ b/mealie/updater.json
@@ -1,11 +1,11 @@
 {
   "github_beta": "true",
   "github_fulltag": "true",
-  "last_update": "2026-08-29",
+  "last_update": "2026-09-05",
   "paused": "false",
   "repository": "alexbelgium/hassio-addons",
   "slug": "mealie",
   "source": "github",
   "upstream_repo": "mealie-recipes/mealie",
-  "upstream_version": "v3.24.0"
+  "upstream_version": "v3.25.1"
 }


### PR DESCRIPTION
## What broke

The updater bump to `v3.25.1` failed to build and was auto-reverted
([run 33929705208](https://github.com/alexbelgium/hassio-addons/actions/runs/33929705208)).
Both architectures failed in the frontend builder stage:

```
WARN  [NUXT_B6005] Could not resolve vuetify/labs/rules used by the auto-import useRules.
ERROR [vite]: Rolldown failed to resolve import "vuetify/labs/rules" from
      "virtual:nuxt:.nuxt%2Fvuetify-nuxt-plugin.client.mjs"
error Command failed with exit code 1    ("yarn generate")
```

## Root cause

Upstream migrated `frontend/` from yarn to pnpm in **v3.24.0** and deleted
`frontend/yarn.lock`. Checked at each tag on raw.githubusercontent:

| tag | `frontend/yarn.lock` | `frontend/pnpm-lock.yaml` |
|---|---|---|
| v3.23.1 | 200 | 404 |
| v3.24.0 | 404 | 200 |
| v3.25.1 | 404 | 200 |

Our builder stage still ran `yarn install --frozen-lockfile`. With no lockfile present that
silently degraded to a fresh, unpinned resolution of every dependency. `frontend/package.json`
pins `"vuetify": "^4.1.2"`, so once a newer vuetify 4.x dropped the `vuetify/labs/rules` entry
point, `nuxt generate` failed. This also explains why v3.24.0 built fine on 2026-08-29 with the
same unpinned install and v3.25.1 did not: nothing in our tree changed, the resolved dependency
set did.

## The fix

Mirror upstream's own `docker/Dockerfile` frontend stage: `node:24`, a global `pnpm@11`, and
`pnpm install --frozen-lockfile` against the committed `pnpm-lock.yaml`, so the add-on builds the
dependency set upstream actually tests. Two smaller changes come with it:

- `cp -a frontend/.` instead of `cp -rf frontend/*`, so dotfiles such as `.nuxtignore` are copied.
  (They were silently dropped before; this is not what broke the build, but the glob was wrong.)
- `--depth 1` on the clone — only one tag is ever checked out.

`frontend/nuxt.config.ts` still reads `process.env.SUB_PATH` (lines 29, 83, 129), so the ingress
sub-path handling is unaffected. `frontend/pnpm-workspace.yaml` carries the `allowBuilds:` map
pnpm 11 needs to run dependency build scripts and is copied along with the rest of the tree.

Bumps the add-on to `v3.25.1`, the version the updater bot could not build.
`hkotel/mealie:latest` currently resolves to `v3.25.1`, so the backend in the final stage and the
frontend built here are the same release.

## Verified / not verified

- **Verified**: the lockfile migration and the tag-by-tag file presence above (HTTP status checks
  today); `pnpm@11` exists on the registry (11.25.0 latest); `pnpm-lock.yaml` is
  `lockfileVersion: '9.0'`, which pnpm 11 reads; `hkotel/mealie` has a `v3.25.1` tag.
- **Checked**: `validate.sh mealie --vs-master` passes — hadolint, shellcheck and the config
  schema are clean and the diff adds no new lint findings.
- **Not verified**: the Docker build itself. There is no dockerd on the maintenance host, so CI is
  the only gate for this.

## Rollback

The whole change is one commit touching only `mealie/`. `git revert` it, or revert
`mealie/Dockerfile` alone to go back to the yarn stage while keeping the version bump.

## Non-goal

`mealie/build.json` still pins the final stage to `hkotel/mealie:latest` rather than to
`MEALIE_VERSION`, so frontend and backend can in principle drift between a release and our next
rebuild. That is the repo-wide convention and is left alone here.

## Independent review

Codex (gpt-5.6-sol) reviewed the diff. It confirmed that `pnpm install --frozen-lockfile` needs no
`packageManager` field, that pnpm 11 reads `lockfileVersion: '9.0'`, that `allowBuilds` is the
pnpm ≥10.26 setting and is why pnpm 11 specifically is the right choice here, and that
`cp -a frontend/. /frontend/` copies contents without recursing into `tempdir`.

Its one reservation was that `npm install --global pnpm@11` floats across pnpm 11 releases.
Not taken: upstream floats it the same way, and pinning would drift from the pnpm version upstream
actually tests. The lockfile — not the pnpm version — is what pins the dependency tree, and that is
the thing that broke.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the Mealie add-on to upstream release v3.25.1.

- **Bug Fixes**
  - Improved frontend build reliability by using the upstream lockfile and pnpm-based installation.
  - Resolved dependency resolution issues that could prevent the frontend from building successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->