### PR TITLE
fix(omni-tools): let the add-on stop by backgrounding nginx and running the entrypoint as PID 1

### DIFF
--- a/omni-tools/CHANGELOG.md
+++ b/omni-tools/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.1.1 (2026-09-07)
+- Fix the add-on refusing to stop: Home Assistant reported an Error status after a few seconds and the container kept running and serving the web UI. `cont-init.d/99-run.sh` started nginx in the foreground, and `ha_entrypoint.sh` runs every cont-init script in the foreground, so the entrypoint never reached the point where it installs the `terminate()` handler that forwards SIGTERM to the application on shutdown. The application is now started in the background, and `init: false` makes the entrypoint run as PID 1 so the orphaned process is reparented to it and receives that signal. Closes #3049.
+
 
 ## 0.6.1 (2025-11-18)
 - Added `env_vars` option to allow passing custom environment variables from the add-on configuration.

--- a/omni-tools/config.yaml
+++ b/omni-tools/config.yaml
@@ -5,6 +5,7 @@ description:
   Self-hosted collection of powerful web-based tools for everyday tasks.
   No ads, no tracking, just fast, accessible utilities right from your browser
 image: ghcr.io/alexbelgium/omni-tools-{arch}
+init: false
 map:
   - addon_config:rw
 name: Omni Tools
@@ -20,5 +21,5 @@ schema:
       value: str?
 slug: omni-tools
 url: https://github.com/alexbelgium/hassio-addons
-version: 0.6.1
+version: 0.6.1.1
 webui: "[PROTO:ssl]://[HOST]:[PORT:80]"

--- a/omni-tools/rootfs/etc/cont-init.d/99-run.sh
+++ b/omni-tools/rootfs/etc/cont-init.d/99-run.sh
@@ -7,4 +7,10 @@
 
 # Start omni-tools container content
 bashio::log.info "Starting application"
-/./docker-entrypoint.sh nginx -g "daemon off;" &> /proc/1/fd/1
+# Backgrounded on purpose. ha_entrypoint.sh runs every cont-init.d script in the
+# foreground, so launching nginx here in the foreground never lets it reach the
+# terminate() handler that forwards SIGTERM on shutdown -- the add-on then could
+# not be stopped at all (#3049). Backgrounded, this script returns, nginx is
+# reparented to the entrypoint as PID 1, and terminate() signals it directly.
+# Requires init: false in config.yaml, which is what makes the entrypoint PID 1.
+/./docker-entrypoint.sh nginx -g "daemon off;" &> /proc/1/fd/1 &


### PR DESCRIPTION
Closes #3049.

## The symptom

Stopping the add-on left Home Assistant showing an Error status after a few seconds, with the container still running and still serving the web UI.

## Root cause

`.templates/ha_entrypoint.sh` runs every `/etc/cont-init.d/*` script **sequentially in the foreground**, and only afterwards — and only when it is PID 1 — installs `trap terminate SIGTERM SIGINT`, the handler that forwards SIGTERM to the application on shutdown.

`omni-tools/rootfs/etc/cont-init.d/99-run.sh` started nginx in the foreground:

```sh
/./docker-entrypoint.sh nginx -g "daemon off;" &> /proc/1/fd/1
```

`&>` is a redirect, not a background operator, so that script never returned. Everything the entrypoint does afterwards was dead code for this add-on — including the only mechanism that would have signalled nginx on stop.

The reporter's log shows both halves of this. It prints `Starting custom scripts`, the branch the entrypoint takes when `$$ != 1`, and it never reaches `Everything started!`, which is printed once the cont-init loop completes.

The second half is why `$$ != 1`: `config.yaml` shipped no `init:` key, so Supervisor's default of `true` made Docker inject its own init as PID 1 and left `ha_entrypoint.sh` at PID 2 — where its `if $PID1` block, holding the trap, is skipped outright.

## The fix

Two lines, at the lowest mechanism level that works:

- append `&` to the launch in `99-run.sh`, so the script returns and the entrypoint reaches its trap;
- add `init: false` to `config.yaml`, so `ha_entrypoint.sh` runs as PID 1.

Together: the script returns, the entrypoint installs `terminate()`, the exiting script orphans nginx, nginx is reparented to PID 1 (the entrypoint), and `terminate()`'s `pgrep -P "$$"` finds it as a **direct** child and SIGTERMs it.

Backgrounding the launch from `cont-init.d` is what 24 other add-ons in this repository already do — `autobrr` runs a bare `nginx &`. (Counted by matching a trailing `&` while excluding `&&` and `&>`; zero false positives in the matched lines.)

## What was measured

- In a live add-on container on this host running the same entrypoint (`claude_desktop`, which does set `init: false`), PID 1 is `bash /ha_entrypoint.sh` with `sleep infinity` as a direct child — it reached the trap-and-sleep block.
- Reproduced locally: with a **foreground** cont-init launch, the entrypoint dies on SIGTERM and the application **survives as an orphan**, never signalled. With the launch **backgrounded**, the entrypoint reaches `Everything started!` — the trap is installed — and the orphan reparents to PID 1.
- Every add-on here that uses `services.d` (32 of them) also sets `init: false`. There are no exceptions; `services.d` does not start at all without it.
- The upstream `docker-entrypoint.sh` ends in `exec "$@"`, checked against the nginx source, and the reporter's log carries that script's verbatim messages (`Configuration complete; ready for start up`). So nginx's master process — not an intermediate shell — is the process orphaned to PID 1, which is what makes `pgrep -P "$$"` find nginx itself.
- The shipped AppArmor profile needs no change.

## Rejected alternative

An earlier draft moved the launch into `services.d/omni-tools/run`. It was reverted: `ha_entrypoint.sh` runs each `services.d/*/run` inside a restart subshell, so the application becomes a **grandchild** of PID 1 while `terminate()` enumerates direct children only. Reproduced — the application survives that path unsignalled. It was also the larger change, and it buys restart supervision nobody asked for.

## Not verified

- The Docker build. dockerd does not run in this environment; CI is the only gate.
- The stop itself, on a real install. Confirming it needs a PID namespace, which this environment does not permit creating, so the final link — that the orphan's new parent is the entrypoint rather than some other PID 1 — rests on `init: false` establishing that, which was observed directly in another add-on's container but not in this one.

## Risk and rollback

`init: false` is the riskier of the two hunks: it changes what runs as PID 1, dropping Docker's init and its generic zombie reaping. nginx reaps its own workers, and 32 add-ons here already run this way.

This trades one failure mode for another, deliberately. Previously a *failed* nginx let the cont-init loop finish and the entrypoint exit, so the container stopped and the failure was visible. Now the entrypoint sleeps forever regardless, so if nginx dies the add-on stays up looking healthy while serving nothing — this add-on ships no `HEALTHCHECK`. That is the same behaviour as the 105 other `init: false` add-ons here, and the reported bug is certain while an nginx crash is hypothetical, but it is a real regression and not a free win. Starting the app under `services.d` would have bought supervision instead, at the cost of the stop fix itself — see the rejected alternative above.

`init: false` also introduces a startup window, raised as a P1 by the Codex review bot and confirmed. As namespace PID 1 the entrypoint has no SIGTERM handler until `.templates/ha_entrypoint.sh:455`, which is after `wait_for_supervisor` and the whole `cont-init.d` loop, and Linux discards a signal PID 1 has no handler for. A stop arriving inside that window is dropped until Docker's SIGKILL. In the reporter's log that window is about two seconds; the 30-second `HA_SUPERVISOR_WAIT` ceiling is only reached when the Supervisor is unreachable, which is not a state in which anyone is pressing Stop. It replaces a *permanent* inability to stop with a transient one, the 104 other `init: false` add-ons here already have exactly this window, and closing it means editing the shared entrypoint template — repo-wide blast radius, filed separately rather than folded in here.

The two hunks cannot be rolled back independently — backgrounding without `init: false` leaves the trap unreachable at PID 2, and `init: false` without backgrounding leaves the cont-init loop blocked. Roll back the commit as a whole.

## Out of scope

Roughly twenty other add-ons launch a blocking process from `cont-init.d` with no `init: false` and so share this shape — `filebrowser`, `filebrowser_quantum`, `binance-trading-bot`, `inadyn`, `seafile`, `signalk`, `tandoor_recipes` and others. None was individually verified and none is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
