### PR TITLE
birdnet-go-dev: add merge-prs.sh --check to catch build-breaking PR conflicts

### DIFF
--- a/birdnet-go-dev/merge-prs.sh
+++ b/birdnet-go-dev/merge-prs.sh
@@ -34,7 +34,16 @@ while [ "$#" -gt 0 ]; do
     case "$1" in
         --check) CHECK_ONLY=1 ;;
         -*) echo "unknown option: $1" >&2; exit 64 ;;
-        *) TARGET_DIR="$1" ;;
+        *)
+            # Last-one-wins would silently clone into the wrong directory if a caller ever
+            # appended an argument; the pre-flag script used "${1}", so refuse rather than
+            # quietly change which operand counts.
+            if [ -n "${TARGET_DIR}" ]; then
+                echo "usage: merge-prs.sh [--check] <target-dir>" >&2
+                exit 64
+            fi
+            TARGET_DIR="$1"
+            ;;
     esac
     shift
 done
@@ -55,16 +64,46 @@ log() { echo ">>> $*"; }
 # Conflicting PRs collected in --check mode: "number|scope|files|title".
 conflicting=()
 
+LOCKFILE="frontend/package-lock.json"
+
+# The single place that decides whether a conflicted merge is still acceptable.
+# package-lock.json is generated content and stacked PRs can carry an older copy even when
+# their source changes merge cleanly, so keep the lockfile already assembled on the base side
+# — but only when it is the sole conflict. Any source conflict stays fatal.
+# Returns 0 when it resolved and committed such a merge, 1 when the conflict is real.
+# BOTH the real merge and the --check probe must go through here: when only the real merge
+# applied the policy, the probe called a PR "conflicts-with=main" that the build would have
+# merged fine, and printed the opposite remediation to the true one.
+resolve_sole_lockfile() {
+    local dir="$1"
+    local -a conflicted
+    mapfile -t conflicted < <(git -C "${dir}" diff --name-only --diff-filter=U)
+    if [ "${#conflicted[@]}" -ne 1 ] || [ "${conflicted[0]}" != "${LOCKFILE}" ]; then
+        return 1
+    fi
+    log "Resolving generated ${LOCKFILE} conflict using the base tree"
+    git -C "${dir}" checkout --ours -- "${LOCKFILE}" || return 1
+    git -C "${dir}" add "${LOCKFILE}" || return 1
+    git -C "${dir}" commit --no-edit > /dev/null || return 1
+}
+
 # Does ${1} merge cleanly onto the pristine upstream-synced main? Probed in a
 # throwaway worktree so the accumulated tree is left untouched. Tells apart a PR
 # that is simply stale against main (fixable inside that PR's own branch) from
 # one that only clashes with another open PR (needs a cross-PR decision).
 merges_onto_main() {
-    local sha="$1" probe rc=0
-    probe="$(mktemp -d)/probe"
+    local sha="$1" tmpdir probe rc=0
+    tmpdir="$(mktemp -d)"
+    probe="${tmpdir}/probe"
     git worktree add --quiet --detach "${probe}" "${MAIN_SYNCED}"
-    git -C "${probe}" merge --no-edit --no-ff -m probe "${sha}" >/dev/null 2>&1 || rc=1
-    git worktree remove --force "${probe}" >/dev/null 2>&1 || true
+    if ! git -C "${probe}" merge --no-edit --no-ff -m probe "${sha}" > /dev/null 2>&1; then
+        # Same policy as the real merge, or this misclassifies a lockfile-only clash.
+        resolve_sole_lockfile "${probe}" > /dev/null 2>&1 || rc=1
+    fi
+    git worktree remove --force "${probe}" > /dev/null 2>&1 || true
+    # worktree remove only takes the child back; without this the mktemp parent is left behind
+    # on every checked conflict.
+    rmdir "${tmpdir}" > /dev/null 2>&1 || true
     return "${rc}"
 }
 
@@ -115,16 +154,8 @@ for entry in "${prs[@]}"; do
     if ! git merge --no-edit --no-ff -m "Merge PR #${number}: ${title}" "${sha}"; then
         mapfile -t conflicted_files < <(git diff --name-only --diff-filter=U)
 
-        # package-lock.json is generated content and stacked PRs can carry an
-        # older copy even when their source changes merge cleanly. Keep the
-        # lockfile already assembled from upstream and earlier PRs, but only
-        # when it is the sole conflict. Any source conflict remains fatal.
-        if [ "${#conflicted_files[@]}" -eq 1 ] \
-            && [ "${conflicted_files[0]}" = "frontend/package-lock.json" ]; then
-            log "Resolving generated frontend/package-lock.json conflict using the accumulated tree"
-            git checkout --ours -- frontend/package-lock.json
-            git add frontend/package-lock.json
-            git commit --no-edit
+        if resolve_sole_lockfile .; then
+            : # generated lockfile only - the merge is committed and the build continues
         else
             echo "!!! Merge conflict while merging PR #${number} (${title})." >&2
             if [ "${#conflicted_files[@]}" -gt 0 ]; then

--- a/birdnet-go-dev/merge-prs.sh
+++ b/birdnet-go-dev/merge-prs.sh
@@ -11,6 +11,15 @@
 # stamping) is written to the directory given as $1 so the Docker build can
 # compile it.
 #
+# With --check the script does not build anything: it performs the exact same
+# merge sequence, skips (instead of failing on) every conflicting PR, and prints
+# one "!!! CONFLICT pr=#N conflicts-with=... files=... " line per offender before
+# exiting 2. Use it to find conflicts *before* a build burns on them. This is a
+# different question from GitHub's `mergeable` field, which compares a PR against
+# its own base ref - for a stacked PR that base is another feature branch (often
+# stale, sometimes belonging to a closed PR), so GitHub can report CLEAN for a PR
+# that does not merge onto main at all.
+#
 # Environment:
 #   BIRDNET_FORK       owner/repo of the fork           (default alexbelgium/birdnet-go)
 #   BIRDNET_UPSTREAM   owner/repo of the upstream        (default tphakala/birdnet-go)
@@ -19,7 +28,17 @@
 #
 set -euo pipefail
 
-TARGET_DIR="${1:?usage: merge-prs.sh <target-dir>}"
+CHECK_ONLY="${MERGE_PRS_CHECK:-0}"
+TARGET_DIR=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --check) CHECK_ONLY=1 ;;
+        -*) echo "unknown option: $1" >&2; exit 64 ;;
+        *) TARGET_DIR="$1" ;;
+    esac
+    shift
+done
+: "${TARGET_DIR:?usage: merge-prs.sh [--check] <target-dir>}"
 
 FORK="${BIRDNET_FORK:-alexbelgium/birdnet-go}"
 UPSTREAM="${BIRDNET_UPSTREAM:-tphakala/birdnet-go}"
@@ -32,6 +51,22 @@ API_URL="https://api.github.com/repos/${FORK}/pulls?state=open&per_page=100"
 GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
 
 log() { echo ">>> $*"; }
+
+# Conflicting PRs collected in --check mode: "number|scope|files|title".
+conflicting=()
+
+# Does ${1} merge cleanly onto the pristine upstream-synced main? Probed in a
+# throwaway worktree so the accumulated tree is left untouched. Tells apart a PR
+# that is simply stale against main (fixable inside that PR's own branch) from
+# one that only clashes with another open PR (needs a cross-PR decision).
+merges_onto_main() {
+    local sha="$1" probe rc=0
+    probe="$(mktemp -d)/probe"
+    git worktree add --quiet --detach "${probe}" "${MAIN_SYNCED}"
+    git -C "${probe}" merge --no-edit --no-ff -m probe "${sha}" >/dev/null 2>&1 || rc=1
+    git worktree remove --force "${probe}" >/dev/null 2>&1 || true
+    return "${rc}"
+}
 
 git config --global user.email "addon-builder@users.noreply.github.com"
 git config --global user.name "BirdNET-Go Addon Builder"
@@ -47,6 +82,7 @@ git remote add upstream "${UPSTREAM_URL}"
 git fetch --no-tags upstream main
 # --no-ff keeps an explicit sync commit; a no-op when main is already current.
 git merge --no-edit --no-ff upstream/main
+MAIN_SYNCED="$(git rev-parse HEAD)"
 
 log "Querying open non-draft PRs from ${FORK}"
 auth_header=()
@@ -94,12 +130,36 @@ for entry in "${prs[@]}"; do
             if [ "${#conflicted_files[@]}" -gt 0 ]; then
                 printf '!!! Conflicting file: %s\n' "${conflicted_files[@]}" >&2
             fi
-            echo "!!! Resolve the conflict in the fork or pause this PR, then rebuild." >&2
             git merge --abort || true
+
+            if [ "${CHECK_ONLY}" = "1" ]; then
+                scope="accumulated"
+                merges_onto_main "${sha}" || scope="main"
+                conflicting+=("${number}|${scope}|${conflicted_files[*]:-}|${title}")
+                log "check mode: skipping PR #${number}, continuing with the rest"
+                continue
+            fi
+
+            echo "!!! Resolve the conflict in the fork or pause this PR, then rebuild." >&2
             exit 1
         fi
     fi
 done
+
+if [ "${CHECK_ONLY}" = "1" ]; then
+    if [ "${#conflicting[@]}" -eq 0 ]; then
+        log "CHECK OK: every open non-draft PR merges into the combined build tree"
+        exit 0
+    fi
+    echo "!!! CHECK FAILED: ${#conflicting[@]} PR(s) would break the add-on build" >&2
+    for entry in "${conflicting[@]}"; do
+        IFS='|' read -r number scope files title <<<"${entry}"
+        echo "!!! CONFLICT pr=#${number} conflicts-with=${scope} files=${files} title=${title}" >&2
+    done
+    echo "!!! conflicts-with=main     -> the PR is stale against main; merge main into its branch and resolve there." >&2
+    echo "!!! conflicts-with=accumulated -> the PR only clashes with another open PR; decide which one owns the hunk." >&2
+    exit 2
+fi
 
 log "Merged HEAD: $(git rev-parse --short HEAD)"
 log "Source tree ready at ${TARGET_DIR}"


### PR DESCRIPTION
## Problem

[Builder run 34101694542](https://github.com/alexbelgium/hassio-addons/actions/runs/34101694542/job/101677881780) failed with:

```
!!! Merge conflict while merging PR #57 (feat(dashboard): mobile summary ...).
!!! Conflicting file: frontend/src/lib/desktop/features/dashboard/components/DetectionCard.svelte
```

At that moment `gh pr list --json mergeable` reported **every** open fork PR as `MERGEABLE`, so the nightly sync routine saw nothing to fix and bumped the version anyway.

The two are asking different questions:

- GitHub computes `mergeable` against a PR's **own base ref**. PR #57's base is `claude/dashboard-mobile-improvements`, the branch of PR **#56, which is closed and was never merged** — a frozen ref. Merging #57 into that stale branch is clean, and says nothing useful.
- `merge-prs.sh` merges every open non-draft PR head onto **upstream-synced `main`**, in number order, into one accumulated tree.

So a stacked PR can read `CLEAN` on GitHub and still kill the build. Verified locally: #57 conflicts with `main` directly on one line of `DetectionCard.svelte`.

## Change

Adds a `--check` mode (also `MERGE_PRS_CHECK=1`) to `birdnet-go-dev/merge-prs.sh`. It replays the identical merge sequence, but skips past a conflicting PR instead of stopping at the first one, and reports all offenders:

```
!!! CONFLICT pr=#57 conflicts-with=main files=frontend/.../DetectionCard.svelte title=feat(dashboard): mobile summary ...
```

`conflicts-with` is probed in a throwaway `git worktree` against the pristine synced `main`, which separates the two cases that need different fixes:

- `main` — the PR is just stale; merge `main` into its own branch and resolve there.
- `accumulated` — the PR merges onto `main` fine and only clashes with another open PR; no single branch owns the hunk, so it needs a human decision.

Exit codes: `0` clean, `2` conflicts found.

Build behaviour is unchanged — the flag is opt-in, and the default path still fails fast on the first conflict. No version bump for that reason.

## Verification

Ran against the live fork; correctly reproduces and classifies the failure that broke the build:

```
$ GH_TOKEN=... bash birdnet-go-dev/merge-prs.sh --check /tmp/birdnet-check
...
>>> Merging PR #57: feat(dashboard): mobile summary — full species list, wider charts, clearer sort
!!! Merge conflict while merging PR #57 (...)
!!! Conflicting file: frontend/src/lib/desktop/features/dashboard/components/DetectionCard.svelte
>>> check mode: skipping PR #57, continuing with the rest
>>> Merging PR #58: ...
>>> Merging PR #60: ...
!!! CHECK FAILED: 1 PR(s) would break the add-on build
!!! CONFLICT pr=#57 conflicts-with=main files=frontend/.../DetectionCard.svelte title=...
exit=2
```

PRs #58 and #60 are still exercised after #57 is skipped, so one run surfaces every conflict rather than one per rebuild.

The nightly `birdnet-go-update` routine has been updated to run this check before bumping the version, and to refuse the bump while it exits 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a check mode, available through a command-line flag or environment setting, for validating merge sequences without stopping at the first conflict.
  * Conflicting pull requests are skipped, classified by conflict source, and clearly reported.
  * Check mode returns a distinct failure status when conflicts are found.

* **Bug Fixes**
  * Improved command-line argument handling, including clearer handling of unknown options, missing target directories, and invalid extra arguments.
  * Improved temporary workspace cleanup during merge checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->