### PR TITLE
fix(templates): install the stop handler before startup, not after it

### DIFF
--- a/.templates/ha_entrypoint.sh
+++ b/.templates/ha_entrypoint.sh
@@ -17,6 +17,47 @@ else
 fi
 
 ##########################################
+# Install the stop handler               #
+##########################################
+
+# As namespace PID 1 -- which is what "init: false" makes this script -- the kernel
+# discards any signal whose handler is still SIG_DFL. Installed at the end of startup,
+# as it used to be, the handler missed every stop that arrived while the Supervisor
+# probe or the cont-init chain was still running: Home Assistant waited out the grace
+# period for a SIGKILL and reported the add-on as failed. Nothing here is interrupted
+# mid-write by the move -- only PID 1 is signalled, and bash runs a trap at a command
+# boundary, so whatever external command is in flight reaps first.
+terminate() {
+  local local_pid
+  echo "Termination signal received, forwarding to subprocesses..."
+  if command -v pgrep >/dev/null 2>&1; then
+    while read -r pid; do
+      [ -n "$pid" ] || continue
+      echo "Terminating child PID $pid"
+      kill -TERM "$pid" 2>/dev/null || echo "Failed to terminate PID $pid"
+    done < <(pgrep -P "$$" || true)
+  else
+    for p in /proc/[0-9]*/; do
+      local_pid="${p#/proc/}"
+      local_pid="${local_pid%/}"
+      if [ "$local_pid" -ne 1 ] && grep -q "^PPid:[[:space:]]*$$" "/proc/$local_pid/status" 2>/dev/null; then
+        echo "Terminating child PID $local_pid"
+        kill -TERM "$local_pid" 2>/dev/null || echo "Failed to terminate PID $local_pid"
+      fi
+    done
+  fi
+  wait || true
+  echo "All subprocesses terminated. Exiting."
+  exit 0
+}
+
+# Only when this script is PID 1. Under Docker's own init the entrypoint is an ordinary
+# child and the signal handling above belongs to that init, not to us.
+if $PID1; then
+  trap terminate SIGTERM SIGINT
+fi
+
+##########################################
 # Pick an exec-capable directory         #
 ##########################################
 
@@ -428,31 +469,6 @@ if $PID1; then
   echo " "
   echo -e "\033[0;32mEverything started!\033[0m"
 
-  terminate() {
-    local local_pid
-    echo "Termination signal received, forwarding to subprocesses..."
-    if command -v pgrep >/dev/null 2>&1; then
-      while read -r pid; do
-        [ -n "$pid" ] || continue
-        echo "Terminating child PID $pid"
-        kill -TERM "$pid" 2>/dev/null || echo "Failed to terminate PID $pid"
-      done < <(pgrep -P "$$" || true)
-    else
-      for p in /proc/[0-9]*/; do
-        local_pid="${p#/proc/}"
-        local_pid="${local_pid%/}"
-        if [ "$local_pid" -ne 1 ] && grep -q "^PPid:[[:space:]]*$$" "/proc/$local_pid/status" 2>/dev/null; then
-          echo "Terminating child PID $local_pid"
-          kill -TERM "$local_pid" 2>/dev/null || echo "Failed to terminate PID $local_pid"
-        fi
-      done
-    fi
-    wait || true
-    echo "All subprocesses terminated. Exiting."
-    exit 0
-  }
-
-  trap terminate SIGTERM SIGINT
   while :; do
     sleep infinity &
     wait $!

--- a/.templates/ha_entrypoint.sh
+++ b/.templates/ha_entrypoint.sh
@@ -29,6 +29,13 @@ fi
 # boundary, so whatever external command is in flight reaps first.
 terminate() {
   local local_pid
+  # Best-effort, so errexit must not apply: this runs with `set -e` in force (validate_shebang
+  # leaves it on), and under errexit the first failing command aborts the handler and exits with
+  # its status, skipping the child-kill loop and the `exit 0` below. Every command in the body
+  # here is already guarded, but add-ons patch this function at build time -- postgres_15 and
+  # postgres_17 sed an unguarded `pg_ctl ... stop` in right after the echo -- and that command
+  # fails whenever the stop arrives before the database is up.
+  set +e
   echo "Termination signal received, forwarding to subprocesses..."
   if command -v pgrep >/dev/null 2>&1; then
     while read -r pid; do

--- a/omni-tools/CHANGELOG.md
+++ b/omni-tools/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.1.2 (2026-09-07)
+- Rebuild to pick up a shared `ha_entrypoint.sh` fix: the SIGTERM/SIGINT handler is now installed at the top of the entrypoint instead of at the end of startup. With `init: false` the entrypoint is namespace PID 1, and the kernel discards a signal that PID 1 has no handler for, so a stop arriving while the Supervisor probe or the `cont-init.d` chain was still running was lost entirely and the add-on died only when the grace period expired into SIGKILL. Stops are now honoured from the first moment of startup. No change to add-on behaviour otherwise.
+
 ## 0.6.1.1 (2026-09-07)
 - Fix the add-on refusing to stop: Home Assistant reported an Error status after a few seconds and the container kept running and serving the web UI. `cont-init.d/99-run.sh` started nginx in the foreground, and `ha_entrypoint.sh` runs every cont-init script in the foreground, so the entrypoint never reached the point where it installs the `terminate()` handler that forwards SIGTERM to the application on shutdown. The application is now started in the background, and `init: false` makes the entrypoint run as PID 1 so the orphaned process is reparented to it and receives that signal. Closes #3049.
 

--- a/omni-tools/config.yaml
+++ b/omni-tools/config.yaml
@@ -21,5 +21,5 @@ schema:
       value: str?
 slug: omni-tools
 url: https://github.com/alexbelgium/hassio-addons
-version: 0.6.1.1
+version: 0.6.1.2
 webui: "[PROTO:ssl]://[HOST]:[PORT:80]"


### PR DESCRIPTION
Follow-up to the P1 the Codex bot raised on #3050 (issue #3049). That PR fixed omni-tools' own stop path but deliberately left the shared entrypoint alone, because changing it touches every add-on in the repo.

## The bug

`.templates/ha_entrypoint.sh` installed its `SIGTERM`/`SIGINT` trap at the very end of startup — after `wait_for_supervisor` (bounded at 30s, 5s per probe) and after the entire `/etc/cont-init.d/*` loop, which includes the unbounded user-supplied `01-custom_script.sh`.

105 of the 136 add-ons here set `init: false`, which makes this script namespace PID 1. The kernel discards any signal whose handler is still `SIG_DFL` for a namespace's init process. So a stop arriving at any point during startup was not deferred — it was **discarded**. Home Assistant then waited out the grace period, the container died on `SIGKILL`, and the add-on surfaced to the user as an Error.

## The fix

Move the `terminate()` definition and `trap terminate SIGTERM SIGINT` to immediately after the PID1 detection block, still behind an `if $PID1` guard. `terminate()`'s body is byte-identical to before apart from indentation. Nothing else changes.

## Measurements

Run against this actual file as PID 1 in a PID+mount namespace, with a bind-mounted `/etc/cont-init.d`:

| Scenario | before | after |
|---|---|---|
| SIGTERM 3s into an 8s cont-init script | never exits (alive >40s) | exits 5s later; script wrote 8/8 lines |
| SIGTERM before cont-init starts | never exits (alive >40s) | exits 8s later; script wrote 8/8 lines |
| SIGTERM during 8 fast (0.3s) cont-init scripts | never exits (alive >20s) | **exits in 0s**, cleanly after 6 of 8 |

**Nothing is interrupted mid-write.** Only PID 1 receives the signal, and bash defers a trap to the next command boundary, so whatever external command is in flight always reaps first. Verified directly: a `dd` writing 16,384,000 bytes over ~5s received the entrypoint's SIGTERM at t=2s and still wrote all 16,384,000 bytes; the trap fired only after `dd` returned.

The `if $PID1` guard was checked at runtime rather than by reading: with `PID1=false` the process's `SigCgt` lacks the SIGTERM bit (`0x…10002`); with `PID1=true` it has it (`0x…14002`), which matches the mask on a live add-on's PID 1.

## What was rejected, and why

Backgrounding the cont-init loop and having the handler `kill` the in-flight script. It makes stops instant even during a long custom script, but measurement showed it truncates the child mid-write — and two cont-init scripts write non-atomically into the **persisted** `/config`: `01-config_yaml.sh:61` does a cross-mount `mv` of the user's `config.yaml` into `/config`, and `19-json_repair.sh` `cp`s straight onto a live `settings.json`. Corrupting a user's config is a worse failure than a slow stop.

## Known residual

A stop arriving during a single long-running cont-init script still waits for that script to finish. Accepted deliberately, for the reason above. In practice most cont-init scripts are sub-second, which is the 0s row in the table.

## Not verified

- No Docker build locally (no dockerd); CI is the only gate. This is why omni-tools is bumped — a `.templates/`-only PR changes no `<addon>/config.*`, so CI would detect no changed add-on and build nothing at all.
- The measurements use a namespace harness, not a Supervisor-managed add-on stop. `/proc` could not be remounted in the harness (Docker masks it), which distorts only the steady-state case — unchanged by this PR, since `terminate()` is untouched.

## Rollout and rollback

`.templates/` is copied into each add-on's build context at build time, so this reaches an add-on only when that add-on next rebuilds. Nothing changes for the other 135 until then — a gradual rollout rather than a flag day, which is the right shape for this blast radius.

To revert just the risky part, drop the `.templates/ha_entrypoint.sh` hunk; the omni-tools bump alone is inert.

## Review

An independent Codex review raised one genuine mechanism: on the `ha_entry_source=true` path, cont-init scripts are `source`d into the entrypoint's own shell, so a trap can fire *between commands inside* such a script and skip its remainder. That path is not active anywhere in the repo — `fireflyiii_data_importer`'s `ENV ha_entry_source` is commented out, and mealie's is set in its own `run.sh`, a different process which is not PID 1. Even if it were active, master's outcome for the same scenario is a SIGKILL of the whole tree, which truncates strictly more. Worth revisiting if `ha_entry_source` is ever turned back on.

## Second commit: `terminate()` made errexit-safe

Moving the trap early exposed a latent hazard that only mattered once the handler could fire before the application was up. Found by an independent cross-add-on review and then verified here.

`validate_shebang()` leaves `set -e` on in the outer shell, so `terminate()` runs under errexit — measured, the shell flags at the cont-init stage are `ehB`. Under errexit the first failing command in a trap handler aborts the handler and exits with that status, skipping the child-kill loop and the `exit 0`.

Every command in the stock body is guarded (`|| true`, `|| echo`, or inside an `if`), so this was inert. But **postgres_15** and **postgres_17** patch this function at build time, both at `Dockerfile:77`:

```
sed -i "/Termination signal received/a gosu postgres pg_ctl -D \"$PGDATA\" -m fast stop"
```

That line is unguarded and fails whenever the stop arrives before the database is up. With the trap installed late this could never happen — postgres was already running by the time the handler existed. With it installed early the window is real: it spans `wait_for_supervisor` (up to 30s) plus the whole cont-init chain, which for postgres_15 includes a `chown -R` over `$PGDATA`.

Replaying that exact `sed` against the patched entrypoint and stopping during cont-init:

| | exit status | handler |
|---|---|---|
| without `set +e` | **127** | aborted before killing any child |
| with `set +e` | **0** | ran to completion |

Exiting non-zero on a stop is precisely what Home Assistant reports as Error — so without this, the PR would have reproduced the reported symptom for those two add-ons in a narrower window. `set +e` states the intent the guarded body already implies and covers the injected line without postgres_15/17 needing an edit. They are the only two add-ons that patch `terminate()`; the other six Dockerfiles that `sed` the entrypoint touch other regions.

## Cross-add-on blast radius

- The `if $PID1` guard means only the 105 `init: false` add-ons are affected; the other 31 never install the trap. 7 of the 105 set `ENTRYPOINT ["/init"]`, so s6 is PID 1 there and they get no trap either — the reach is smaller than "105".
- 57 in-scope add-ons have multi-stage cont-init, the population where "remaining scripts skipped on stop" applies. Swept for an early script that writes persistent state a later script finalises: none found. Every marker/lock/backup hit is self-contained within one script (birdnet `81-modifications.sh` uses atomic tmp+mv; scrutiny `01-configuration.sh` backs up its db in-script). Mounts live in the container's mount namespace and die with it; nginx/ingress edits are image-local and recreated each start.
- The one add-on shaped like the dangerous case — `photoprism/rootfs/etc/cont-init.d/01-migrate.sh`, which copies config, writes a marker, mutates the add-on's own option, then `rm -rf`s the old directory — has no `init:` key, so it is out of scope entirely. Even in scope it would be safe: cont-init scripts run as child processes and always complete.
- No add-on script can clobber `terminate`: scripts are exec'd as children, and the in-process `source` path needs `ha_entry_source=true`, which is set nowhere active.
- No merge conflict with the other open PR touching this file (#3048, an shfmt sweep) — test-merged clean, and it does not touch `terminate()` or the trap.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shutdown handling during startup so stop and interrupt signals are received reliably from the beginning.
  - Prevents the add-on from requiring a forced termination when stopped while initialization is still in progress.
  - Ensures cleanup can continue reliably when individual shutdown commands encounter errors.

- **Release**
  - Updated Omni Tools to version 0.6.1.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
