### PR TITLE
docs(birdnet-go-dev): document the first-daily-consensus setting

### DIFF
--- a/birdnet-go-dev/CHANGELOG.md
+++ b/birdnet-go-dev/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 20260909.7 (10-09-2026)
+- Correct the "first daily detection consensus" README section (review feedback on PR #3056): a merged-upstream setting stays in the build rather than disappearing, every attempt for a species is held back until one is accepted rather than only the first, and the "known to every active bird model" exemption is scoped per audio source, matching the implementation.
 ## 20260909.6 (10-09-2026)
 - Document the fork-only "first daily detection consensus" setting (alexbelgium/birdnet-go#63): requires a second model to confirm each bird species' first detection of the day. Off by default; no behaviour change unless enabled.
 ## 20260909.5 (09-09-2026)

--- a/birdnet-go-dev/CHANGELOG.md
+++ b/birdnet-go-dev/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 20260909.6 (10-09-2026)
+- Document the fork-only "first daily detection consensus" setting (alexbelgium/birdnet-go#63): requires a second model to confirm each bird species' first detection of the day. Off by default; no behaviour change unless enabled.
 ## 20260909.5 (09-09-2026)
 - Minor bugs fixed
 ## 20260909.4 (09-09-2026)

--- a/birdnet-go-dev/README.md
+++ b/birdnet-go-dev/README.md
@@ -67,11 +67,11 @@ Additional environment variables can be configured there
 
 ### Fork-only settings
 
-These come from pull requests open on the [`alexbelgium/birdnet-go`](https://github.com/alexbelgium/birdnet-go) fork and are **not** in the standard add-on. They disappear from this build once the corresponding PR is merged upstream or closed.
+These are currently fork-only settings from the [`alexbelgium/birdnet-go`](https://github.com/alexbelgium/birdnet-go) fork and are **not** in the standard add-on. [`merge-prs.sh`](./merge-prs.sh) syncs the fork's `main` with upstream before applying open PRs, so once a PR merges upstream the setting stays in this build — it just arrives via that sync instead of the PR-merge step, and stops being fork-only. Only a PR that is **closed without merging** drops its setting from later builds.
 
 #### First daily detection consensus
 
-Requires a second model to confirm the **first** detection of each bird species each day. Every later detection of that species that day behaves exactly as it does today, on a single model.
+Requires a second model to confirm the **first** detection of each bird species each day. Until one is accepted, every attempt for that species is held to the same two-model bar; only once a detection clears it does every later detection that day behave exactly as it does today, on a single model.
 
 The first detection of a species in a day is the weakest evidence the pipeline produces, and it is the one that creates a "new species today" entry. Asking two models to agree on just that one detection removes most spurious new-species entries without slowing anything else down.
 
@@ -89,11 +89,11 @@ It deliberately does **nothing** in these cases, all of which keep today's singl
 
 - you run only one bird model (the default) — a second opinion does not exist, so the rule can never trigger
 - the species is not a bird — bats and the non-bird sound classes Perch reports (insects, amphibians, mammals, `power_tool`, and so on)
-- the species is not known to *every* active bird model — a species only one model can name could never reach two confirmations
+- the species is not known to *every* active bird model analyzing that audio source — a species only one of them can name could never reach two confirmations. With several sources running different model combinations, this is decided per source, not add-on-wide
 - a dynamic threshold has actually lowered the bar for that species, meaning you asked for a more permissive gate
 - the taxonomy or the database cannot be consulted — it fails open and accepts the detection
 
-In practice it only bites when you run two or more bird models (for example BirdNET plus Perch) on species both of them can identify. The trade is fewer false new-species entries, at the cost of occasionally delaying a genuine first sighting until a second model agrees.
+In practice it only bites when a single audio source has two or more bird models (for example BirdNET plus Perch) analyzing it, on species all of them can identify. The trade is fewer false new-species entries, at the cost of occasionally delaying a genuine first sighting until a second model agrees.
 
 Requires [alexbelgium/birdnet-go#63](https://github.com/alexbelgium/birdnet-go/pull/63).
 

--- a/birdnet-go-dev/README.md
+++ b/birdnet-go-dev/README.md
@@ -1,6 +1,6 @@
 # Home assistant add-on: Birdnet-Go (from source)
 
-> **⚠️ Test build.** This is a special variant of the [standard birdnet-go add-on](https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-go). Instead of pulling the prebuilt `ghcr.io/tphakala/birdnet-go` image, it **compiles BirdNET-Go from the [`alexbelgium/birdnet-go`](https://github.com/alexbelgium/birdnet-go) fork**. At build time it syncs the fork's `main` with the `tphakala/birdnet-go` upstream and **merges every open non-draft ("in review") pull request on the fly** (see [`merge-prs.sh`](./merge-prs.sh)), so the binary reflects upstream main plus all work currently under review. Everything below is identical to the standard add-on.
+> **⚠️ Test build.** This is a special variant of the [standard birdnet-go add-on](https://github.com/alexbelgium/hassio-addons/tree/master/birdnet-go). Instead of pulling the prebuilt `ghcr.io/tphakala/birdnet-go` image, it **compiles BirdNET-Go from the [`alexbelgium/birdnet-go`](https://github.com/alexbelgium/birdnet-go) fork**. At build time it syncs the fork's `main` with the `tphakala/birdnet-go` upstream and **merges every open non-draft ("in review") pull request on the fly** (see [`merge-prs.sh`](./merge-prs.sh)), so the binary reflects upstream main plus all work currently under review. Everything below is identical to the standard add-on, except the fork-only settings listed under [Fork-only settings](#fork-only-settings).
 
 
 
@@ -64,6 +64,38 @@ Additional variables can be configured using the config.yaml file found in /conf
 
 - Config_env.yaml
 Additional environment variables can be configured there
+
+### Fork-only settings
+
+These come from pull requests open on the [`alexbelgium/birdnet-go`](https://github.com/alexbelgium/birdnet-go) fork and are **not** in the standard add-on. They disappear from this build once the corresponding PR is merged upstream or closed.
+
+#### First daily detection consensus
+
+Requires a second model to confirm the **first** detection of each bird species each day. Every later detection of that species that day behaves exactly as it does today, on a single model.
+
+The first detection of a species in a day is the weakest evidence the pipeline produces, and it is the one that creates a "new species today" entry. Asking two models to agree on just that one detection removes most spurious new-species entries without slowing anything else down.
+
+**Off by default.** Turn it on in the web UI under *Settings → Filters → First Daily Detection Consensus*, or in `config.yaml`:
+
+```yaml
+realtime:
+  firstdailyconsensus:
+    enabled: true
+```
+
+The setting is re-read on each detection cycle, so it takes effect without restarting the add-on.
+
+It deliberately does **nothing** in these cases, all of which keep today's single-model behaviour:
+
+- you run only one bird model (the default) — a second opinion does not exist, so the rule can never trigger
+- the species is not a bird — bats and the non-bird sound classes Perch reports (insects, amphibians, mammals, `power_tool`, and so on)
+- the species is not known to *every* active bird model — a species only one model can name could never reach two confirmations
+- a dynamic threshold has actually lowered the bar for that species, meaning you asked for a more permissive gate
+- the taxonomy or the database cannot be consulted — it fails open and accepts the detection
+
+In practice it only bites when you run two or more bird models (for example BirdNET plus Perch) on species both of them can identify. The trade is fewer false new-species entries, at the cost of occasionally delaying a genuine first sighting until a second model agrees.
+
+Requires [alexbelgium/birdnet-go#63](https://github.com/alexbelgium/birdnet-go/pull/63).
 
 ### MQTT and MariaDB auto-configuration (opt-in)
 

--- a/birdnet-go-dev/config.yaml
+++ b/birdnet-go-dev/config.yaml
@@ -127,5 +127,5 @@ slug: birdnet-go-dev
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "20260909.5"
+version: "20260909.6"
 video: true

--- a/birdnet-go-dev/config.yaml
+++ b/birdnet-go-dev/config.yaml
@@ -127,5 +127,5 @@ slug: birdnet-go-dev
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "20260909.6"
+version: "20260909.7"
 video: true


### PR DESCRIPTION
## What changed

Documents the fork-only **first daily detection consensus** setting in the `birdnet-go-dev` README. This add-on compiles BirdNET-Go from the `alexbelgium/birdnet-go` fork and merges every open non-draft PR at build time, so the setting is already compiled into the image — it just wasn't documented anywhere.

Docs only. No add-on behaviour changes, no script, Dockerfile or option changes.

## Why it reads the way it does

The section leads with what the setting does **not** affect. "Requires a second model to confirm" reads as far more invasive than it is, and a user who reads only the headline would reasonably conclude the add-on is about to start dropping detections. It is inert:

- on a single-model install, which is the default — a second opinion does not exist
- on bats and the non-bird sound classes Perch reports
- on species not known to *every* active bird model
- when a dynamic threshold has already lowered the bar for that species
- when taxonomy or the database can't be consulted — it fails open

It only bites when two or more bird models run on species both can identify, and only on that species' first detection of the day.

Also qualifies the header's "everything below is identical to the standard add-on" claim, which the new section would otherwise contradict.

## Upstream

Requires [alexbelgium/birdnet-go#63](https://github.com/alexbelgium/birdnet-go/pull/63), which is open. If that PR is closed rather than merged, this section should be dropped — it is scoped under a "Fork-only settings" heading that says exactly that.

## Verified / not verified

- **Verified:** `validate.sh birdnet-go-dev --vs-master` passes; no new lint findings introduced by this diff.
- **Checked:** CHANGELOG updated and version bumped (`20260909.5` → `20260909.6`), both CI requirements.
- **Not verified:** the Docker build — no dockerd locally, CI is the only gate. Nothing in this diff reaches the build, so the risk is a markdown-lint regression at worst.

## Rollback

Single commit touching three files; revert it. The version bump is the only part with any user-visible effect (Supervisor offers a rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented the fork-only first daily detection consensus setting, including configuration, per-source scope, and fail-open behavior.
  * Clarified that merged settings remain available in builds, while settings from closed, unmerged changes are excluded.
  * Documented that all detection attempts are held until consensus acceptance.
  * Updated the changelog for version 20260909.7.

* **Chores**
  * Updated the add-on version to 20260909.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->