### PR TITLE
fix(updater): publish the version the image holds, not the app's newest release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Bytecode of the python helpers in the addons, which rootfs/ copies into the image
+__pycache__/

--- a/addons_updater/CHANGELOG.md
+++ b/addons_updater/CHANGELOG.md
@@ -1,4 +1,8 @@
 - Migrate legacy add-on configuration map names to current app configuration terminology.
+## 2026.09 (2026-09-12)
+
+- New `source: container` for addons that build `FROM` an image published by someone else. The version is read from the `org.opencontainers.image.version` label of the exact image reference in `updater.json`, instead of from the releases of the application's own repository. Written against `ghcr.io`; an image with no such label leaves the addon untouched
+- `source: container` also records the manifest digest in `upstream_digest` and rebuilds when it moves, so a publisher republishing the same version under a new image is no longer invisible
 ## 2026.08 (2026-08-01)
 
 - Addon versions written in config.yaml now always comply with Home Assistant versioning: an upstream tag Home Assistant cannot order (`version-bf9e0b4f`, `ubuntu-2026-06-01`, ...) or would sort as older (`1.2.3-2`, `1.2.3+4`) no longer lands in config.yaml. The addon number is incremented instead, while the raw upstream tag stays in updater.json so the same release is never published twice

--- a/addons_updater/README.md
+++ b/addons_updater/README.md
@@ -67,11 +67,45 @@ You can add the following tags in the file :
 - repository: 'name/repo' coming from github
 - paused: true # Pauses the updates
 - slug: the slug name from your addon
-- source: dockerhub/github,gitlab,bitbucket,pip,hg,sf,website-feed,local,helm_chart,wiki,system,wp,codeberg (Codeberg is supported via its Gitea API, which is configured automatically)
-- upstream_repo: name/repo, example is 'linuxserver/docker-emby'
+- source: container/dockerhub/github,gitlab,bitbucket,pip,hg,sf,website-feed,local,helm_chart,wiki,system,wp,codeberg (Codeberg is supported via its Gitea API, which is configured automatically)
+- upstream_repo: name/repo, example is 'linuxserver/docker-emby'. With `source: container` it is instead a full image reference, example is 'ghcr.io/imagegenius/immich:3'
 - upstream_version: automatically populated, corresponds to the current upstream version referenced in the addon
 - dockerhub_by_date: in dockerhub, uses the last_update date instead of the version
 - dockerhub_list_size: in dockerhub, how many containers to consider for latest version
+
+### Addons built on someone else's image
+
+An addon that does not build the application itself, but builds `FROM` an image a third party
+publishes, must publish the version that image holds and not the newest release of the
+application. `ghcr.io/imagegenius/immich:3` is a rebuild of immich lagging its upstream by days
+to weeks: tracking `immich-app/immich` published a version the addon did not contain, and left
+the addon with no reason to rebuild once the image finally caught up.
+
+`source: container` reads the version out of the image itself. Set `upstream_repo` to the exact
+image reference used in `build.json`, tag included:
+
+```json
+{
+  "source": "container",
+  "upstream_repo": "ghcr.io/imagegenius/immich:3"
+}
+```
+
+The version comes from the image's `org.opencontainers.image.version` label, read from the first
+linux image the tag publishes, and the addon is left alone when there is no label to read. Written
+against `ghcr.io`, which serves anonymous pull tokens from `https://ghcr.io/token`; a registry
+authenticating differently, such as Docker Hub, yields no version and the addon is skipped.
+
+The manifest digest is recorded next to the version, in `upstream_digest`, and the addon is
+rebuilt when either of the two moves. A publisher rebuilding the same version, for a base image
+security fix or a packaging revision, repoints the tag at new content under an unchanged label,
+and the digest is the only thing that says so. `upstream_digest` is populated automatically; seed
+it by hand when migrating an addon to this source, or the first run counts the unknown digest as
+a change and rebuilds once for nothing.
+
+The label is metadata the publisher chooses. Some images carry none, and some record their own
+packaging revision rather than the application version, so this source is opt-in per addon and
+never a default.
 
 ### Addon version numbering
 

--- a/addons_updater/config.yaml
+++ b/addons_updater/config.yaml
@@ -30,4 +30,4 @@ schema:
 slug: updater
 udev: true
 url: https://github.com/alexbelgium/hassio-addons/tree/master/addons_updater
-version: "2026.08"
+version: "2026.09"

--- a/addons_updater/rootfs/etc/cont-init.d/99-run.sh
+++ b/addons_updater/rootfs/etc/cont-init.d/99-run.sh
@@ -109,6 +109,7 @@ for f in */; do
         EXCLUDE_TEXT="${EXCLUDE_TEXT:-zzzzzzzzzzzzzzzz}"
         PAUSED=$(jq -r .paused updater.json)
         DATE="$(date "$DATE_FORMAT")"
+        LASTDIGEST=""
         BYDATE=$(jq -r .dockerhub_by_date updater.json)
 
         # Number of elements to check in dockerhub
@@ -194,6 +195,45 @@ for f in */; do
                 && DATE="$(date -d "$DATE" "$DATE_FORMAT")" \
                 && LASTVERSION="$LASTVERSION-$DATE"
             LOGINFO="... $SLUG : bydate is true, version is $LASTVERSION" && if [ "$VERBOSE" = true ]; then bashio::log.info "$LOGINFO"; fi
+
+        elif [[ "$SOURCE" = container ]]; then
+            # The addon builds FROM an image someone else publishes rather
+            # than from the application itself, so the version to publish is
+            # the one inside that image and not the newest release of the
+            # application repository, which the image can lag by weeks
+            LOGINFO="... Source is container" && if [ "$VERBOSE" = true ]; then bashio::log.info "$LOGINFO"; fi
+
+            ACCEPT="application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json"
+            REGISTRY="${UPSTREAM%%/*}"
+            IMAGE="${UPSTREAM#*/}"
+            IMAGEREPO="${IMAGE%:*}"
+            BASEURL="https://$REGISTRY/v2/$IMAGEREPO"
+            HEADERS="$(mktemp)"
+
+            # The digest the tag resolves to is the one the registry answers
+            # with, and it moves whenever anything behind the tag does
+            TOKEN="$(curl -f -L -s "https://$REGISTRY/token?scope=repository:$IMAGEREPO:pull&service=$REGISTRY" | jq -r '.token // empty')" || true
+            MANIFEST="$(curl -f -L -s -D "$HEADERS" -H "Authorization: Bearer $TOKEN" -H "Accept: $ACCEPT" "$BASEURL/manifests/${IMAGE##*:}")" || true
+            LASTDIGEST="$(sed -n 's/^[Dd]ocker-[Cc]ontent-[Dd]igest:[[:space:]]*//p' "$HEADERS" | tr -d '\r')"
+            rm -f "$HEADERS"
+
+            # A multi architecture tag answers with an index, whose first
+            # image is read: the attestations buildx attaches alongside
+            # describe no architecture and hold no image configuration
+            CHILD="$(echo "$MANIFEST" | jq -r 'first(.manifests[]? | select(.platform.os == "linux" and .platform.architecture != "unknown") | .digest) // empty')" || true
+            if [ -n "$CHILD" ]; then
+                MANIFEST="$(curl -f -L -s -H "Authorization: Bearer $TOKEN" -H "Accept: $ACCEPT" "$BASEURL/manifests/$CHILD")" || true
+            fi
+
+            # Publishers record the application version of an image in its
+            # OCI label, which is what the addon actually ships
+            LASTVERSION="$(curl -f -L -s -H "Authorization: Bearer $TOKEN" "$BASEURL/blobs/$(echo "$MANIFEST" | jq -r '.config.digest // empty')" \
+                | jq -r '.config.Labels["org.opencontainers.image.version"] // empty')" || true
+
+            if [ -z "$LASTVERSION" ] || [ -z "$LASTDIGEST" ]; then
+                bashio::log.warning "... $SLUG : no version could be read from $UPSTREAM, skipping"
+                continue
+            fi
 
         else
 
@@ -344,8 +384,19 @@ for f in */; do
             continue
         fi
 
+        # What the addon was last built against. A container source adds the
+        # digest of the image: a publisher rebuilding the same version, for a
+        # base image fix or a packaging revision, repoints the tag at new
+        # content under an unchanged label, and only the digest says so
+        CURRENTSTATE="$CURRENT"
+        LASTSTATE="$LASTVERSION"
+        if [[ "$SOURCE" = container ]]; then
+            CURRENTSTATE="$CURRENT $(jq -r '.upstream_digest // ""' updater.json)"
+            LASTSTATE="$LASTVERSION $LASTDIGEST"
+        fi
+
         # Update if needed
-        if [ "${CURRENT}" != "${LASTVERSION}" ]; then
+        if [ "${CURRENTSTATE}" != "${LASTSTATE}" ]; then
             LOGINFO="... $SLUG : update from ${CURRENT} to ${LASTVERSION}" && if [ "$VERBOSE" = true ]; then bashio::log.info "$LOGINFO"; fi
 
             ADDONFOLDER="/data/${BASENAME}/${SLUG}"
@@ -405,7 +456,9 @@ for f in */; do
 
             # Replace upstream tag and date, keeping the file intact if jq
             # fails as a truncated updater.json would lose the addon source
-            if ! UPDATERJSON="$(jq --arg version "$LASTVERSION" --arg date "$DATE" '.upstream_version = $version | .last_update = $date' "$ADDONFOLDER/updater.json")"; then
+            if ! UPDATERJSON="$(jq --arg version "$LASTVERSION" --arg date "$DATE" --arg digest "${LASTDIGEST:-}" \
+                '.upstream_version = $version | .last_update = $date | if $digest == "" then . else .upstream_digest = $digest end' \
+                "$ADDONFOLDER/updater.json")"; then
                 bashio::log.error "... $SLUG : updater.json could not be updated, reverting"
                 git checkout -- "$ADDONFOLDER"
                 continue

--- a/immich/CHANGELOG.md
+++ b/immich/CHANGELOG.md
@@ -1,3 +1,9 @@
+
+## 3.2.0.1 (2026-09-12)
+- Track the version inside `ghcr.io/imagegenius/immich:3` instead of the releases of `immich-app/immich`
+- The add-on is now rebuilt whenever imagegenius repoints `:3`, whether the immich version changed or the image was simply republished
+- The add-on has never built immich itself, it builds on top of the imagegenius rebuild, which lags immich upstream by days to weeks. Version `3.2.0` was published while the image still contained immich `3.1.0` (issue #3060), and nothing would have rebuilt the add-on once the image caught up
+- This build still contains immich **3.1.0**, and will be updated automatically once imagegenius publishes a newer image. Home Assistant cannot offer a version lower than the one installed, so the add-on number stays in the `3.2.0.x` range until the image moves past 3.2.0
  
 ## 3.2.0 (2026-09-12)
 - Update to latest version from immich-app/immich (changelog : https://github.com/immich-app/immich/releases)

--- a/immich/config.yaml
+++ b/immich/config.yaml
@@ -141,6 +141,6 @@ slug: immich
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "3.2.0"
+version: "3.2.0.1"
 video: true
 webui: http://[HOST]:[PORT:8080]

--- a/immich/updater.json
+++ b/immich/updater.json
@@ -1,10 +1,9 @@
 {
-  "github_beta": "false",
-  "github_exclude": "",
   "last_update": "2026-09-12",
   "repository": "alexbelgium/hassio-addons",
   "slug": "immich",
-  "source": "github",
-  "upstream_repo": "immich-app/immich",
-  "upstream_version": "3.2.0"
+  "source": "container",
+  "upstream_digest": "sha256:e618fe718bb1d62f17ebc9f908a87608f28722776d71819afe38a242ee88845f",
+  "upstream_repo": "ghcr.io/imagegenius/immich:3",
+  "upstream_version": "3.1.0"
 }

--- a/immich_cuda/CHANGELOG.md
+++ b/immich_cuda/CHANGELOG.md
@@ -1,3 +1,9 @@
+
+## 3.2.0.1 (2026-09-12)
+- Track the version inside `ghcr.io/imagegenius/immich:3-cuda` instead of the releases of `immich-app/immich`
+- The add-on is now rebuilt whenever imagegenius repoints `:3-cuda`, whether the immich version changed or the image was simply republished
+- The add-on has never built immich itself, it builds on top of the imagegenius rebuild, which lags immich upstream by days to weeks. Version `3.2.0` was published while the image still contained immich `3.1.0` (issue #3060), and nothing would have rebuilt the add-on once the image caught up
+- This build still contains immich **3.1.0**, and will be updated automatically once imagegenius publishes a newer image. Home Assistant cannot offer a version lower than the one installed, so the add-on number stays in the `3.2.0.x` range until the image moves past 3.2.0
  
 ## 3.2.0 (2026-09-12)
 - Update to latest version from immich-app/immich (changelog : https://github.com/immich-app/immich/releases)

--- a/immich_cuda/config.yaml
+++ b/immich_cuda/config.yaml
@@ -139,6 +139,6 @@ slug: immich_cuda
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "3.2.0"
+version: "3.2.0.1"
 video: true
 webui: http://[HOST]:[PORT:8080]

--- a/immich_cuda/updater.json
+++ b/immich_cuda/updater.json
@@ -1,10 +1,9 @@
 {
-  "github_beta": "false",
-  "github_exclude": "",
   "last_update": "2026-09-12",
   "repository": "alexbelgium/hassio-addons",
   "slug": "immich",
-  "source": "github",
-  "upstream_repo": "immich-app/immich",
-  "upstream_version": "3.2.0"
+  "source": "container",
+  "upstream_digest": "sha256:c4b78d941f637e5da52bbbbc264db6e207d341e3799b87a2332613373082f1e9",
+  "upstream_repo": "ghcr.io/imagegenius/immich:3-cuda",
+  "upstream_version": "3.1.0"
 }

--- a/immich_noml/CHANGELOG.md
+++ b/immich_noml/CHANGELOG.md
@@ -1,3 +1,9 @@
+
+## 3.2.0.1 (2026-09-12)
+- Track the version inside `ghcr.io/imagegenius/immich:3-noml` instead of the releases of `immich-app/immich`
+- The add-on is now rebuilt whenever imagegenius repoints `:3-noml`, whether the immich version changed or the image was simply republished
+- The add-on has never built immich itself, it builds on top of the imagegenius rebuild, which lags immich upstream by days to weeks. Version `3.2.0` was published while the image still contained immich `3.1.0` (issue #3060), and nothing would have rebuilt the add-on once the image caught up
+- This build still contains immich **3.1.0**, and will be updated automatically once imagegenius publishes a newer image. Home Assistant cannot offer a version lower than the one installed, so the add-on number stays in the `3.2.0.x` range until the image moves past 3.2.0
  
 ## 3.2.0 (2026-09-12)
 - Update to latest version from immich-app/immich (changelog : https://github.com/immich-app/immich/releases)

--- a/immich_noml/config.yaml
+++ b/immich_noml/config.yaml
@@ -140,6 +140,6 @@ slug: immich_noml
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "3.2.0"
+version: "3.2.0.1"
 video: true
 webui: http://[HOST]:[PORT:8080]

--- a/immich_noml/updater.json
+++ b/immich_noml/updater.json
@@ -1,10 +1,9 @@
 {
-  "github_beta": "false",
-  "github_exclude": "",
   "last_update": "2026-09-12",
   "repository": "alexbelgium/hassio-addons",
   "slug": "immich",
-  "source": "github",
-  "upstream_repo": "immich-app/immich",
-  "upstream_version": "3.2.0"
+  "source": "container",
+  "upstream_digest": "sha256:8e10fe2fb3e887b04b353e82e793eeb90771977edf8523fc1342a34cac710bb2",
+  "upstream_repo": "ghcr.io/imagegenius/immich:3-noml",
+  "upstream_version": "3.1.0"
 }

--- a/immich_openvino/CHANGELOG.md
+++ b/immich_openvino/CHANGELOG.md
@@ -1,3 +1,9 @@
+
+## 3.2.0.1 (2026-09-12)
+- Track the version inside `ghcr.io/imagegenius/immich:3-openvino` instead of the releases of `immich-app/immich`
+- The add-on is now rebuilt whenever imagegenius repoints `:3-openvino`, whether the immich version changed or the image was simply republished
+- The add-on has never built immich itself, it builds on top of the imagegenius rebuild, which lags immich upstream by days to weeks. Version `3.2.0` was published while the image still contained immich `3.1.0` (issue #3060), and nothing would have rebuilt the add-on once the image caught up
+- This build still contains immich **3.1.0**, and will be updated automatically once imagegenius publishes a newer image. Home Assistant cannot offer a version lower than the one installed, so the add-on number stays in the `3.2.0.x` range until the image moves past 3.2.0
  
 ## 3.2.0 (2026-09-12)
 - Update to latest version from immich-app/immich (changelog : https://github.com/immich-app/immich/releases)

--- a/immich_openvino/config.yaml
+++ b/immich_openvino/config.yaml
@@ -140,6 +140,6 @@ slug: immich_openvino
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
 usb: true
-version: "3.2.0"
+version: "3.2.0.1"
 video: true
 webui: http://[HOST]:[PORT:8080]

--- a/immich_openvino/updater.json
+++ b/immich_openvino/updater.json
@@ -1,10 +1,9 @@
 {
-  "github_beta": "false",
-  "github_exclude": "",
   "last_update": "2026-09-12",
   "repository": "alexbelgium/hassio-addons",
   "slug": "immich",
-  "source": "github",
-  "upstream_repo": "immich-app/immich",
-  "upstream_version": "3.2.0"
+  "source": "container",
+  "upstream_digest": "sha256:745963b8d1d09b652c3631a22495bc11ba2bf7288644a7f86132e4a94e72bbbc",
+  "upstream_repo": "ghcr.io/imagegenius/immich:3-openvino",
+  "upstream_version": "3.1.0"
 }


### PR DESCRIPTION
Fixes #3060.

## What is wrong

The immich add-ons never built immich. They build `FROM ghcr.io/imagegenius/immich:3`, a
third-party rebuild, while `updater.json` tracked `immich-app/immich` — the application's own
releases. Those two move at different speeds, so the add-on published a version its image did
not contain.

Measured on 2026-09-12, against the live registry:

| | |
|---|---|
| `immich-app/immich` latest release | `v3.2.0`, published 2026-09-10 |
| add-on version on `master` | `3.2.0`, bumped by the updater on 2026-09-12 |
| `ghcr.io/imagegenius/immich:3`, `org.opencontainers.image.version` | **`3.1.0`** (both `linux/amd64` and `linux/arm64`; image created 2026-08-25) |
| highest 3.x tag published by imagegenius | `3.1.0` — there is no `3.2.0` tag |

That is the reported symptom: the store offers 3.2.0, the server logs `[v3.1.0]`.

The second-order bug is worse. Because the stored `upstream_version` already reads `3.2.0`, the
weekly updater will compare immich-app's latest (`3.2.0`) with `3.2.0`, take the "up-to-date"
branch and commit nothing — so when imagegenius eventually publishes 3.2.0 behind `:3`, **nothing
in this repository notices and no rebuild is triggered**. Users would sit on the 3.1.0 image until
immich-app releases 3.3.0.

The convention used everywhere else in the repo — track the *image publisher's* GitHub repo, the
way `bazarr` tracks `linuxserver/docker-bazarr` — does not rescue this case:
`imagegenius/docker-immich` stopped cutting releases at `v2.7.5-ig458` in May 2026 while its GHCR
images kept moving.

## The fix

A new `source: "container"` for add-ons that build on an image someone else publishes.
`upstream_repo` becomes the exact image reference from `build.json`, and the version is read out
of the image itself:

```json
{
  "source": "container",
  "upstream_repo": "ghcr.io/imagegenius/immich:3"
}
```

The branch fetches an anonymous pull token, the manifest of that tag and the image configuration,
and reads `org.opencontainers.image.version` — inline `curl | jq`, in the same style as the
`dockerhub` branch directly above it. A multi-architecture tag answers with an index, whose first
linux image is read; the attestation entries buildx attaches (`unknown/unknown`) are skipped, and
a single-manifest answer is handled too. Nothing readable means the add-on is left alone.

It is written against `ghcr.io`, which serves anonymous pull tokens from `https://ghcr.io/token`.
A registry authenticating differently, such as Docker Hub, simply yields no version and the add-on
is skipped.

### Seeing that imagegenius published something

`:3` is a mutable pointer. Every weekly run re-resolves it and compares two things with what is
stored in `updater.json`: the `org.opencontainers.image.version` label, and the manifest digest
the tag currently resolves to (`upstream_digest`). Either moving triggers a rebuild.

The label alone is not enough. It only changes when the immich version changes, so a rebuild of
the same version — a base-image security fix, an `-ig` packaging revision — would repoint `:3` at
new content under an unchanged label and stay invisible. The digest catches that; `ha_version.py`
turns it into a local counter, `3.2.0.1` → `3.2.0.2`, measured.

That `:3` really does move is not an assumption. Resolved live today, same repository:

```
:2      -> 2.7.5      :3.0    -> 3.0.3
:3.1    -> 3.1.0      :3      -> 3.1.0
```

`:3` has already walked 3.0.1 → 3.0.3 → 3.1.0 without its name changing. None of those moves were
visible to the old code.

The label is publisher-chosen metadata — some images carry none, some record a packaging revision
rather than the application version — so this source is opt-in per add-on and never a default.

## The version numbers, and why they still look wrong for a while

Home Assistant will not offer a version lower than the one installed, so the four add-ons cannot
go back to `3.1.0`. They are set to `3.2.0.1`, which is a local rebuild counter on the number
users already have. **This build still contains immich 3.1.0**, and the changelog says so.

Measured with `ha_version.py` and awesomeversion 25.8.0 (the version pinned in the add-on's
Dockerfile):

```
current 3.2.0.1 + image 3.2.0 -> 3.2.0.2     when imagegenius catches up
current 3.2.0.2 + image 3.3.0 -> 3.3.0       clean recovery on the next minor
```

## Verified

- The shipped branch was extracted from `99-run.sh` and executed against real images, 8/8: it
  returns the exact expected version **and digest** for `:3`, `:3-cuda`, `:3-noml` and
  `:3-openvino`, and `16.0.0` for `ghcr.io/hassio-addons/base:16.0.0` — an image that answers with
  a single manifest rather than an index, so that path is exercised by a real image. It skips an
  unsupported registry, a nonexistent repository and a nonexistent tag.
- The four resolved digests match the `Docker-Content-Digest` headers the registry serves.
- The attestation filter is not speculative: `ghcr.io/linuxserver/baseimage-debian:amd64-bookworm`,
  `ghcr.io/home-assistant/amd64-base:latest` and `ghcr.io/immich-app/postgres:17-…` all carry
  `unknown/unknown` entries in their index today.
- `set -e` containment: a loop mirroring `99-run.sh`, failing on every add-on, skips each one
  through `continue` and reaches the end of the script. One bad registry answer cannot abort the
  weekly run for the add-ons that sort after it.
- `ha_version.py --selftest`: 48/48, unchanged.
- The state comparison was replayed against fixtures, all 7 cases correct: same version + same
  digest → no rebuild; same version + moved digest → rebuild; moved version → rebuild; an unseeded
  digest → rebuild once (which is why the four files are seeded with today's digests); and a
  `github`/`dockerhub` source ignores `upstream_digest` entirely.
- shellcheck, hadolint, yamllint, markdownlint: no new findings versus `master`.

## Not verified

- No Docker build locally (no dockerd) — CI is the gate.
- The updater itself has not been run end to end; it only runs weekly inside the add-on. The new
  branch was exercised by extracting it from the shipped script and running it, not by running
  the whole updater.

## Known gaps, deliberately left

- **`build.json` is not pinned.** The builder pulls floating `:3` minutes after the updater
  commits, so a publish landing inside that window mislabels one build. The next weekly run
  re-reads the label and corrects it. Pinning would need the updater to rewrite `:3` → `:3.1.0`
  and `:3-cuda` → `:3.1.0-cuda`, i.e. tag-name surgery, and no other add-on in this repo pins.
- **Only the first linux image of an index is read.** If a publisher ever half-published an
  index — amd64 already on the new version, arm64 still on the old — the arm64 add-on would carry
  the new number. I have never observed that, and the digest tracking means the next run rebuilds
  anyway once the lagging architecture lands, so this is deliberately not defended against.

## On the shape of this

The first cut of this put the registry walk in a 309-line Python helper alongside `ha_version.py`.
An independent review called that disproportionate for this repo, and it was right: the same job
is 21 lines of `curl | jq` in the idiom the `dockerhub` branch two screens up already uses, and
the bash version was measured to return byte-identical output on all five images above. The
Python file is gone. What it defended that this does not — multi-architecture agreement, label
content validation, an explicit registry allow-list — were all cases I had never observed, and
each one now fails closed on its own.

One unrelated line: `.gitignore` was empty, and `__pycache__` from running
`addons_updater/rootfs/usr/bin/ha_version.py` slipped into a commit twice while working on this.
A `rootfs/` tree is `COPY`'d into the add-on image, so that bytecode would ship. One line added.

## Rollback

The riskiest hunk is the new `elif` in `99-run.sh`. Reverting just that block makes
`source: container` fall through to the git-forge branch, where `lastversion` fails on an image
reference and the four add-ons are skipped — no wrong version is published. Reverting the four
`updater.json` files restores the previous behaviour exactly.

Note this PR edits `updater.json` files, which are normally owned by `addons_updater`. That is the
point of the change: their `source` and `upstream_repo` were pointing at the wrong upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Add-ons can now track externally published container images, including image versions and digest changes.
  - Rebuilds can be triggered when an image is republished, even if its tag remains unchanged.
  - Immich variants now track their corresponding Imagegenius container images.

- **Documentation**
  - Added guidance for configuring container-based update tracking, supported registries, image labels, and validation behavior.
  - Updated Immich release notes to clarify image-based version tracking and automatic updates.

- **Chores**
  - Updated add-on versions to `2026.09` and Immich variants to `3.2.0.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->