### PR TITLE
fix(transmission): let incomplete-dir stay off across restarts

### DIFF
--- a/transmission/CHANGELOG.md
+++ b/transmission/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.3.1 (2026-09-12)
+- Add `incomplete_dir_enabled` (default `true`): set to `false` to permanently disable the incomplete-downloads directory. Restarting the add-on always overwrote Transmission's own Web UI toggle for this back to enabled (#3059); this option is read on every restart instead, so it actually sticks
+- Fix a latent bug in the same code: an install where `incomplete_dir` was entirely absent from options (rather than emptied) would create and use a directory literally named `null`
  
 ## 4.1.3 (2026-07-04)
 - Update to latest version from linuxserver/docker-transmission (changelog : https://github.com/linuxserver/docker-transmission/releases)

--- a/transmission/README.md
+++ b/transmission/README.md
@@ -62,6 +62,7 @@ Configurations can be done through the app webUI, except for the following optio
 | `TZ` | str | | Timezone (e.g., `Europe/London`) |
 | `download_dir` | str | `/share/downloads` | Directory for completed downloads |
 | `incomplete_dir` | str | `/share/incomplete` | Directory for incomplete downloads |
+| `incomplete_dir_enabled` | bool | `true` | Set to `false` to permanently disable the incomplete-downloads directory. Transmission's own Web UI toggle for this is overwritten on every add-on restart, so use this option instead |
 | `watch_dir` | str | | Directory to watch for torrent files |
 | `customUI` | list | `flood-for-transmission` | Web UI (standard/transmission-web-control/kettu/flood-for-transmission) |
 | `user` | str | | Web UI username |

--- a/transmission/config.yaml
+++ b/transmission/config.yaml
@@ -87,6 +87,7 @@ options:
   customUI: flood-for-transmission
   download_dir: /share/downloads
   incomplete_dir: /share/incomplete
+  incomplete_dir_enabled: true
 panel_admin: false
 panel_icon: mdi:transmission-tower
 ports:
@@ -114,6 +115,7 @@ schema:
   customUI: list(standard|transmission-web-control|kettu|flood-for-transmission)
   download_dir: str
   incomplete_dir: str?
+  incomplete_dir_enabled: bool?
   localdisks: str?
   networkdisks: str?
   pass: str?
@@ -124,4 +126,4 @@ schema:
 slug: transmission_ls
 udev: true
 url: https://github.com/alexbelgium/hassio-addons
-version: "4.1.3"
+version: "4.1.3.1"

--- a/transmission/rootfs/etc/cont-init.d/01-config.sh
+++ b/transmission/rootfs/etc/cont-init.d/01-config.sh
@@ -57,6 +57,13 @@ bashio::log.warning "If UI was changed, you need to clear browser cache for it t
 echo "Creating config"
 download_dir=$(bashio::config 'download_dir')
 incomplete_dir=$(bashio::config 'incomplete_dir')
+# bashio::config prints the literal string "null" for an absent option (its
+# own default-value argument cannot be an empty string: bash's ${2:-null}
+# treats "" the same as unset). Without this, an option missing entirely
+# (upgrade from before this key existed) would count as a 4-character dir and
+# create one literally named "null"
+[ "$incomplete_dir" = "null" ] && incomplete_dir=""
+incomplete_dir_enabled=$(bashio::config 'incomplete_dir_enabled' true)
 CONFIG=$(< $CONFIGDIR/settings.json)
 
 # Permissions
@@ -64,8 +71,11 @@ echo "Updating permissions"
 mkdir -p "$download_dir"
 chown "$PUID:$PGID" "$download_dir"
 
-# if incomplete dir > 2, to allow both null and '', set it as existing
-if [ ${#incomplete_dir} -ge 2 ]; then
+# The addon's own toggle wins on every restart, which is the point: Transmission's
+# Web UI toggle is overwritten here regardless, so a permanent "off" has to come
+# from an option this script reads, not from the Web UI (issue #3059). A dir
+# shorter than 2 characters (empty, "/") is treated as unset either way.
+if bashio::var.true "$incomplete_dir_enabled" && [ ${#incomplete_dir} -ge 2 ]; then
     echo "Incomplete dir set: $incomplete_dir"
     CONFIG=$(bashio::jq "${CONFIG}" ".\"incomplete-dir-enabled\"=true")
     mkdir -p "$incomplete_dir"

--- a/transmission/rootfs/etc/cont-init.d/01-config.sh
+++ b/transmission/rootfs/etc/cont-init.d/01-config.sh
@@ -63,7 +63,9 @@ incomplete_dir=$(bashio::config 'incomplete_dir')
 # (upgrade from before this key existed) would count as a 4-character dir and
 # create one literally named "null"
 [ "$incomplete_dir" = "null" ] && incomplete_dir=""
-incomplete_dir_enabled=$(bashio::config 'incomplete_dir_enabled' true)
+# Enabled unless explicitly false: an absent key reads as "null" in bashio and
+# as "" in the standalone shim, which ignores bashio::config's default argument
+incomplete_dir_enabled=$(bashio::config 'incomplete_dir_enabled')
 CONFIG=$(< $CONFIGDIR/settings.json)
 
 # Permissions
@@ -75,7 +77,7 @@ chown "$PUID:$PGID" "$download_dir"
 # Web UI toggle is overwritten here regardless, so a permanent "off" has to come
 # from an option this script reads, not from the Web UI (issue #3059). A dir
 # shorter than 2 characters (empty, "/") is treated as unset either way.
-if bashio::var.true "$incomplete_dir_enabled" && [ ${#incomplete_dir} -ge 2 ]; then
+if [ "$incomplete_dir_enabled" != "false" ] && [ ${#incomplete_dir} -ge 2 ]; then
     echo "Incomplete dir set: $incomplete_dir"
     CONFIG=$(bashio::jq "${CONFIG}" ".\"incomplete-dir-enabled\"=true")
     mkdir -p "$incomplete_dir"


### PR DESCRIPTION
Fixes #3059.

## The problem

Transmission's `incomplete-dir-enabled` setting could not be turned off. `01-config.sh` rewrites
`settings.json` on every add-on restart, deriving the enabled flag purely from whether
`incomplete_dir` is a non-empty string:

```bash
if [ ${#incomplete_dir} -ge 2 ]; then
    CONFIG=$(bashio::jq "${CONFIG}" ".\"incomplete-dir-enabled\"=true")
    ...
else
    CONFIG=$(bashio::jq "${CONFIG}" ".\"incomplete-dir-enabled\"=false")
fi
```

`incomplete_dir` defaults to `/share/incomplete`, so this always took the `true` branch. Toggling
the setting off inside Transmission's own Web UI worked until the next restart, when this script
overwrote `settings.json` again and forced it back on — exactly the reported symptom.

## The fix

A new option, `incomplete_dir_enabled` (bool, default `true`). Setting it to `false` in the
add-on's own Configuration tab makes the script write the disabled state on every restart, instead
of always forcing it back to enabled. Every install that has never seen this key keeps today's
behavior unchanged — traced against the real `bashio::config` implementation, not assumed.

## A latent bug in the same line, fixed while there

`bashio::config`'s own default-value argument cannot be an empty string:
`local default_value=${2:-null}` in `/usr/lib/bashio/config.sh` treats bash's `${2:-null}` as
triggering on empty *or* unset, so `bashio::config 'incomplete_dir' ''` silently returns the
literal string `"null"`, not `""`. Confirmed directly against the real bashio installed on this
host, not assumed:

```
$ bashio::config "incomplete_dir" ""
null
```

So any install whose `incomplete_dir` key went missing entirely — rather than being emptied —
would have created and used a directory literally named `null`, with the feature force-enabled.
Fixed by reading with no default and normalizing the literal `"null"` explicitly:
`[ "$incomplete_dir" = "null" ] && incomplete_dir=""`.

## Verified

Behavioural test replaying the exact shipped script against the real bashio library on this host
(not a mock), 6/6:

```
ok   today's default (unchanged)                        -> true /share/incomplete
ok   new: explicit false disables, dir still set         -> false /share/incomplete
ok   new: explicit true, normal dir                      -> true /share/incomplete
ok   pre-existing: empty dir already disabled (unchanged) -> false
ok   upgrade: incomplete_dir key entirely absent          -> false   (previously: true, dir "null")
ok   explicit true wins even with a one-char dir          -> false /
```

`scripts/validate.sh transmission --vs-master`: shellcheck clean, hadolint clean, config.yaml
valid, no new lint findings versus master.

Independent Codex review (gpt-5.6-sol) of the plan and then the diff, both against the real
`/usr/lib/bashio` source rather than assumed semantics — no blocking finding on either pass.
Full transcript available on request; verdict was "ship it," one wording nit already applied.

## Not verified

No Docker build locally (no dockerd) — CI is the gate. Not verified inside an actual running
Supervisor instance: whether the Configuration-tab UI presents an unset `bool?` field in a way
that makes the true-by-default semantics obvious, versus looking unchecked/false at a glance.
Codex flagged this as a UX question, not a runtime one; noted in case a reviewer wants the option
given an explicit default in the `options:` block too (already done here, for exactly this reason:
`incomplete_dir_enabled: true` is set in `options:`, not left to the script-side default alone).

## Rollback

Revert the single commit. `incomplete_dir_enabled` is additive; nothing else changed shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an `incomplete_dir_enabled` configuration option, enabled by default.
  - Users can permanently disable the incomplete-downloads directory by setting this option to `false`; the setting is applied after restarts.

- **Bug Fixes**
  - Fixed an issue that could create a directory named `null` when no incomplete-downloads directory was configured.

- **Documentation**
  - Updated configuration documentation and the changelog to describe the new option and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->